### PR TITLE
feat(web-components): renames entry point for unpkg

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -9,7 +9,7 @@
   "types": "dist/types/interface.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/icds/icds.esm.js",
+  "unpkg": "dist/core/core.esm.js",
   "files": [
     "dist/",
     "loader/",


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Changes name of entry point for published components when accessed via unpkg. Was previously pointing at file that does not exist.
