### PR TITLE
fix(web-components): fix light footer link turning blue

### DIFF
--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -71,6 +71,11 @@ a:link:visited > ::slotted(svg) {
   fill: var(--ic-architectural-white);
 }
 
+:host(.footer-link-light) a:link:active,
+:host(.footer-link-light) ::slotted(a:link:active) {
+  color: var(--ic-color-white-text);
+}
+
 :host(.footer-link-dark) ::slotted(svg) {
   fill: var(--ic-architectural-black);
 }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Make footer link have white text when light and active

## Related issue
#84

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 