### PR TITLE
fix(web-components): fix light footer link turning blue

### DIFF
--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -106,7 +106,7 @@ a:link:visited > ::slotted(svg) {
 :host(.footer-link) a ::slotted(a:link:active),
 :host(.footer-link) a ::slotted(a:link:focus:active),
 :host(.footer-link) a ::slotted(a:link:visited:active) {
-  color: var(--ic-action-default);
+  color: inherit;
   text-decoration: none;
 }
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Make footer link have white text when light and active

## Related issue
#84

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 