### PR TITLE
fix(web-components): remove clashing button styles from dismissable alert

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -142,12 +142,7 @@
 }
 
 .dismiss-icon:hover {
-  background-color: var(--ic-architectural-200);
   cursor: pointer;
-}
-
-.dismiss-icon:active {
-  background-color: var(--ic-architectural-300);
 }
 
 @media (max-width: 628px) {


### PR DESCRIPTION
Removed circle styles that clashed with icon button shadow styles

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have ensured any changes match the Figma component library. 