### PR TITLE
feat(web-components): adds focus borders for high contrast mode

### DIFF
--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
@@ -67,7 +67,7 @@ ic-link {
 
 :host(.collapsed-breadcrumb-wrapper) ::slotted(.collapsed-breadcrumb:hover),
 :host(.collapsed-breadcrumb-wrapper) ::slotted(.collapsed-breadcrumb:focus) {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   text-decoration-line: underline;
   text-decoration-thickness: 25%;
   text-underline-offset: 25%;

--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -46,7 +46,7 @@
 }
 
 .button:focus-visible {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.dark) .button {

--- a/packages/web-components/src/components/ic-card/ic-card.css
+++ b/packages/web-components/src/components/ic-card/ic-card.css
@@ -12,7 +12,7 @@ a {
 button {
   border: none;
   background-color: transparent;
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 .card,
@@ -35,7 +35,7 @@ button {
 .card.clickable.focussed {
   background-color: var(--ic-action-default-bg-hover);
   box-shadow: var(--ic-border-focus);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 .card.clickable:active {

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
@@ -28,7 +28,7 @@
   background-color: transparent;
   border: 1px solid var(--ic-architectural-300);
   border-radius: var(--ic-border-radius);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   cursor: pointer;
   transition: var(--ic-easing-transition-fast);
 }

--- a/packages/web-components/src/components/ic-footer-link-group/ic-footer-link-group.css
+++ b/packages/web-components/src/components/ic-footer-link-group/ic-footer-link-group.css
@@ -41,14 +41,14 @@
 :host(.footer-link-group-sparse:focus) {
   box-shadow: var(--ic-border-focus-inset);
   border-radius: var(--ic-border-radius-inset);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   z-index: 1;
 }
 
 :host(.footer-link-group-small:focus) {
   box-shadow: var(--ic-border-focus-inset);
   border-radius: var(--ic-border-radius-inset);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   z-index: 1;
 }
 

--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -79,10 +79,19 @@ a:link:visited > ::slotted(svg) {
 :host(.footer-link) a:link:focus,
 :host(.footer-link) a ::slotted(a:link:hover),
 :host(.footer-link) a ::slotted(a:link:focus) {
-  outline: none;
   text-decoration-line: underline;
   text-decoration-thickness: 25%;
   text-underline-offset: 25%;
+}
+
+:host(.footer-link) a:link:hover,
+:host(.footer-link) a ::slotted(a:link:hover) {
+  outline: none;
+}
+
+:host(.footer-link) a:link:focus,
+:host(.footer-link) a ::slotted(a:link:focus) {
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.footer-link) a:link:focus > ::slotted(svg),
@@ -96,7 +105,7 @@ a:link:visited > ::slotted(svg) {
 :host(.footer-link) a:focus,
 :host(.footer-link) a ::slotted(a:focus) {
   border-radius: var(--ic-border-radius);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   transition: var(--ic-transition-duration-fast);
 }
 

--- a/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
+++ b/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
@@ -113,3 +113,8 @@ ic-input-component-container:hover {
 .focus-indicator.dark:focus-within {
   box-shadow: var(--ic-border-focus);
 }
+
+.focus-indicator:focus-within input,
+.focus-indicator:focus-within textarea {
+  outline: var(--ic-hc-focus-outline);
+}

--- a/packages/web-components/src/components/ic-link/ic-link.css
+++ b/packages/web-components/src/components/ic-link/ic-link.css
@@ -27,10 +27,19 @@
 :host(.link) .ic-link:focus,
 :host(.link) ::slotted(a:hover),
 :host(.link) ::slotted(a:focus) {
-  outline: none;
   text-decoration-line: underline;
   text-decoration-thickness: 25%;
   text-underline-offset: 25%;
+}
+
+:host(.link) .ic-link:hover,
+:host(.link) ::slotted(a:hover) {
+  outline: none;
+}
+
+:host(.link) .ic-link:focus,
+:host(.link) ::slotted(a:focus) {
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.link) .ic-link:active,
@@ -95,7 +104,7 @@
 
 :host(.breadcrumb-link.current-page) .ic-link,
 :host(.breadcrumb-link.current-page) ::slotted(a:focus) {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   text-decoration: none;
 }
 

--- a/packages/web-components/src/components/ic-menu/ic-menu.css
+++ b/packages/web-components/src/components/ic-menu/ic-menu.css
@@ -84,7 +84,7 @@
 }
 
 .option:focus-visible {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 .option:not(.disabled-option) .option-description {

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
@@ -82,7 +82,7 @@
 :host(:not(.in-side-menu)) .navigation-group:focus {
   box-shadow: var(--ic-border-focus);
   border-radius: var(--ic-border-radius);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   z-index: 1;
   transition: box-shadow var(--ic-easing-transition-fast);
 }
@@ -95,6 +95,10 @@
   cursor: auto;
   box-shadow: none;
   outline: none;
+}
+
+:host(.in-side-menu) .navigation-group-side-menu:focus {
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.in-side-menu) .navigation-group-side-menu-expanded:hover:not(:focus),
@@ -115,7 +119,7 @@
   color: var(--ic-action-default);
   box-shadow: var(--ic-border-focus-inset);
   border-radius: var(--ic-border-radius-inset);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host .navigation-group-dropdown {

--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -89,21 +89,21 @@ ic-typography {
 :host(.navigation-item) ::slotted(a:focus) {
   box-shadow: var(--ic-border-focus);
   border-radius: var(--ic-border-radius);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.navigation-item-selected) .link:focus,
 :host(.navigation-item) ::slotted(a.active:focus) {
   box-shadow: var(--ic-border-focus);
   border-radius: var(--ic-border-radius);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.navigation-item-selected.dark) .link:focus,
 :host(.navigation-item.dark) ::slotted(a.active:focus) {
   box-shadow: var(--ic-border-focus);
   border-radius: var(--ic-border-radius);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(.navigation-item) .link:active:not(:focus),
@@ -195,7 +195,7 @@ ic-typography {
 :host(.navigation-item-top-nav-child) .link:focus,
 :host(.navigation-item-top-nav-child) ::slotted(a:focus) {
   z-index: 1;
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   border-radius: var(--ic-border-radius-inset);
   box-shadow: var(--ic-border-focus-inset);
   transition: border-radius 0s, box-shadow var(--ic-transition-duration-fast);
@@ -212,7 +212,7 @@ ic-typography {
 
 :host(.navigation-item-top-nav-child) .link:active:not(:focus),
 :host(.navigation-item-top-nav-child) ::slotted(a:active):not(:focus) {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   background-color: var(--ic-action-dark-bg-active);
 }
 

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
@@ -25,11 +25,11 @@
 .container input:focus + span.checkmark,
 :host(:focus) .container input:checked + span.checkmark {
   box-shadow: var(--ic-border-focus);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 .container input:focus-visible {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 /* The container */

--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -89,7 +89,7 @@ select:not([disabled]) {
 }
 
 .select-input:focus {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(:not([disabled])) ic-input-component-container:hover .select-input {

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -174,7 +174,7 @@
 :host .title-link:focus {
   border-radius: var(--ic-border-radius);
   box-shadow: var(--ic-border-focus);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
   background-color: transparent;
 }
 
@@ -481,7 +481,7 @@
     width: 100%;
     color: var(--ic-theme-text);
     background-color: transparent;
-    outline: none;
+    outline: var(--ic-hc-focus-outline);
     border: none;
     cursor: pointer;
     display: flex;

--- a/packages/web-components/src/components/ic-tab-group/ic-tab-group.css
+++ b/packages/web-components/src/components/ic-tab-group/ic-tab-group.css
@@ -76,7 +76,7 @@
 }
 
 .scroll-arrow:focus {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 .scroll-arrow:hover {

--- a/packages/web-components/src/components/ic-tab/ic-tab.css
+++ b/packages/web-components/src/components/ic-tab/ic-tab.css
@@ -27,7 +27,7 @@
 }
 
 :host(:focus-visible) {
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host(:hover) {

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -46,7 +46,7 @@
 :host .title-link:focus {
   border-radius: var(--ic-border-radius);
   box-shadow: var(--ic-border-focus);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 :host .title-link ic-typography {

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -252,6 +252,7 @@
   /* focus */
   --ic-focus-blue: #0044d7;
   --ic-focus-glow: #80a1e8;
+  --ic-hc-focus-outline: 3px solid transparent;
 
   /* breakpoints */
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Adds outline token to be used for windows high contrast mode

## Related issue

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 