### PR TITLE
feat(web-components): add "no results" state to search bar variant with disabled filter

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.spec.ts
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.spec.ts
@@ -497,4 +497,25 @@ describe("ic-search-bar search", () => {
     await page.rootInstance.highlightFirstOptionAfterNoResults();
     expect(page.rootInstance.prevNoOption).toBe(false);
   });
+
+  it("should test no results state when no options passed and filtering disabled", async () => {
+    const page = await newSpecPage({
+      components: [SearchBar, Button, TextField, Menu],
+      html: '<ic-search-bar label="Test label" disable-filter="true"></ic-search-bar>',
+    });
+
+    const textfield = page.root.shadowRoot.querySelector("ic-text-field");
+    const event = new Event("input", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    page.rootInstance.value = "aa";
+    textfield.dispatchEvent(event);
+    await page.waitForChanges();
+    //delay to wait for aria live update
+    await waitForTimeout(700);
+    expect(page.rootInstance.filteredOptions).toHaveLength(1);
+    expect(page.rootInstance.filteredOptions[0].label).toEqual("No results found");
+  });
 });

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -14,7 +14,7 @@ export class Tooltip {
   /**
    * The ID of the element the tooltip is describing - for when aria-labelledby or aria-describedby is used.
    */
-  @Prop() target?: string;
+  @Prop({ reflect: true }) target?: string;
 
   /**
    * The position of the tool-tip in relation to the parent element.


### PR DESCRIPTION
## Summary of the changes
Added "no results" state to search bar variant with disabled filter, fixed z-index of tooltips on clear and search buttons, stopped icSubmitSearch being emitted when enter pressed while search button showing as disabled, set text of ARIA live region to emptyOptionListText when no results are found (was previously being set to "1 result available"), stopped live region updating when menu not displayed due to charactersUntilSuggestions prop.

I have checked this by importing it into the guidance site locally. Another way this can be tested is to not pass any options to it and it should display "No results found"

## Related issue
#111

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 