### PR TITLE
fix(web-components): add transparent borders in HCM

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -167,3 +167,9 @@
     margin-bottom: 14px;
   }
 }
+
+@media (forced-colors: active) {
+  .container {
+    border: var(--ic-hc-border);
+  }
+}

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
@@ -51,3 +51,9 @@
   color: #000;
   text-transform: none;
 }
+
+@media (forced-colors: active) {
+  .classification-banner {
+    border: var(--ic-hc-border);
+  }
+}

--- a/packages/web-components/src/components/ic-footer/ic-footer.css
+++ b/packages/web-components/src/components/ic-footer/ic-footer.css
@@ -94,3 +94,9 @@ footer {
 .classification-spacing {
   margin-bottom: var(--ic-space-lg);
 }
+
+@media (forced-colors: active) {
+  footer {
+    border-top: var(--ic-hc-border);
+  }
+}

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -605,3 +605,10 @@
     box-shadow: none;
   }
 }
+
+@media (forced-colors: active) {
+  .side-navigation,
+  .top-bar {
+    border-right: var(--ic-hc-border);
+  }
+}

--- a/packages/web-components/src/components/ic-status-tag/ic-status-tag.css
+++ b/packages/web-components/src/components/ic-status-tag/ic-status-tag.css
@@ -56,3 +56,9 @@
   color: var(--ic-status-error);
   border: 1px solid var(--ic-status-error);
 }
+
+@media (forced-colors: active) {
+  .tag {
+    border: var(--ic-hc-border);
+  }
+}

--- a/packages/web-components/src/components/ic-switch/ic-switch.css
+++ b/packages/web-components/src/components/ic-switch/ic-switch.css
@@ -181,3 +181,14 @@ input {
 ::slotted(*) {
   margin-left: var(--ic-space-sm);
 }
+
+@media (forced-colors: active) {
+  .ic-switch-toggle::before,
+  .ic-switch-input:checked + .ic-switch-toggle {
+    border: var(--ic-hc-border);
+  }
+
+  .ic-switch-input:checked + .ic-switch-toggle::before {
+    transform: translate(calc(var(--ic-space-xl) - 2px), -50%);
+  }
+}

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
@@ -102,3 +102,9 @@
 :host([target="ic-button-with-tooltip-clear-button"]) .ic-tooltip-container {
   z-index: calc(var(--ic-z-index-popup-menu) + 1);
 }
+
+@media (forced-colors: active) {
+  :host(.ic-tooltip) .ic-tooltip-container {
+    border: var(--ic-hc-border);
+  }
+}

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -19,6 +19,7 @@
   --ic-transition-duration-fast: 100ms;
   --ic-transition-duration-slow: 300ms;
   --ic-border-disabled: 1px dashed var(--ic-architectural-200);
+  --ic-hc-border: 1px solid transparent;
 
   /* fonts */
   --ic-font-body-family: "Open Sans", "Helvetica Neue", "Arial", "sans-serif";


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add transparent borders in HCM to alert, classification banner, footer, side nav, status tags, switch, and tooltips.

## Related issue
91 on design system

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 