### PR TITLE
fix(web-components): removed hyphenated title on Safari

### DIFF
--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -251,7 +251,7 @@ slot[name="toggle-icon"] svg {
     :host .title-link {
       margin-right: var(--ic-space-xxxs);
       word-break: break-word;
-      hyphens: auto;
+      hyphens: none;
     }
 
     .top-panel-container {


### PR DESCRIPTION
Added -webkit-hyphens property to define behaviour on safari

## Related issue
[138](https://github.com/mi6/ic-ui-kit/issues/138)

## Checklist
- [x] I have ensured any changes match the Figma component library. 