### PR TITLE
Set outer colour of loading indicator to transparent when part of loading buttons

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -281,6 +281,10 @@ div.loading-container {
   align-items: center;
 }
 
+ic-loading-indicator {
+  --outer-color: transparent;
+}
+
 @keyframes loading-animation {
   0% {
     width: 0%;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Set outer colour of loading indicator to transparent when part of loading buttons

## Related issue
#5

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 