### PR TITLE
fix(web-components): add rgba themes

### DIFF
--- a/packages/web-components/src/components/ic-theme/ic-theme.spec.tsx
+++ b/packages/web-components/src/components/ic-theme/ic-theme.spec.tsx
@@ -49,4 +49,16 @@ describe("ic-theme", () => {
       </ic-theme>
     `);
   });
+
+  it("sets theme colour with rgba", async () => {
+    const page = await newSpecPage({
+      components: [Theme],
+      html: `<ic-theme color="rgba(159, 43, 104, 1)"></ic-theme>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <ic-theme color="rgba(159, 43, 104, 1)">
+        <mock:shadow-root></mock:shadow-root>
+      </ic-theme>
+    `);
+  });
 });

--- a/packages/web-components/src/components/ic-theme/ic-theme.stories.mdx
+++ b/packages/web-components/src/components/ic-theme/ic-theme.stories.mdx
@@ -19,7 +19,7 @@ import readme from "./readme.md";
     name="Switch theme"
     parameters={{ loki: { skip: true }, layout: "fullscreen" }}
   >
-    {html` <ic-theme color="rgb(27, 60, 121)"></ic-theme>
+    {html` <ic-theme color="rgba(27, 60, 121, 1)"></ic-theme>
       <ic-button
         variant="primary"
         id="default-btn"
@@ -30,7 +30,7 @@ import readme from "./readme.md";
       <ic-button
         variant="primary"
         id="custom-btn"
-        onClick="document.querySelector('ic-theme').color='rgb(255, 201, 60)'"
+        onClick="document.querySelector('ic-theme').color='rgba(255, 201, 60, 1)'"
       >
         Sunrise theme
       </ic-button>

--- a/packages/web-components/src/components/ic-theme/ic-theme.tsx
+++ b/packages/web-components/src/components/ic-theme/ic-theme.tsx
@@ -8,11 +8,11 @@ import {
   Prop,
 } from "@stencil/core";
 
-import { IcColorRGB, IcTheme } from "../../utils/types";
+import { IcColorRGBA, IcTheme } from "../../utils/types";
 import {
   getThemeForegroundColor,
-  hexToRgb,
-  rgbStrToObj,
+  hexToRgba,
+  rgbaStrToObj,
 } from "../../utils/helpers";
 
 @Component({
@@ -37,25 +37,26 @@ export class Theme {
 
   private setThemeColor = () => {
     if (this.color !== null) {
-      let colorRGB = null;
+      let colorRGBA = null;
       const firstChar = this.color.slice(0, 1);
       if (firstChar === "#") {
-        colorRGB = hexToRgb(this.color);
+        colorRGBA = hexToRgba(this.color);
       } else if (firstChar.toLowerCase() === "r") {
-        colorRGB = rgbStrToObj(this.color);
+        colorRGBA = rgbaStrToObj(this.color);
       }
-      this.setThemeRGB(colorRGB);
+      this.setThemeRGBA(colorRGBA);
     }
   };
 
-  private setThemeRGB = (colorRGB: IcColorRGB) => {
-    if (colorRGB !== null) {
+  private setThemeRGBA = (colorRGBA: IcColorRGBA) => {
+    if (colorRGBA !== null) {
       const root = document.documentElement;
-      root.style.setProperty("--ic-theme-primary-r", colorRGB.r.toString());
-      root.style.setProperty("--ic-theme-primary-g", colorRGB.g.toString());
-      root.style.setProperty("--ic-theme-primary-b", colorRGB.b.toString());
+      root.style.setProperty("--ic-theme-primary-r", colorRGBA.r.toString());
+      root.style.setProperty("--ic-theme-primary-g", colorRGBA.g.toString());
+      root.style.setProperty("--ic-theme-primary-b", colorRGBA.b.toString());
+      root.style.setProperty("--ic-theme-primary-a", colorRGBA.a.toString());
       const foregroundColor = getThemeForegroundColor();
-      this.icThemeChange.emit({ mode: foregroundColor, color: colorRGB });
+      this.icThemeChange.emit({ mode: foregroundColor, color: colorRGBA });
     }
   };
 

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -170,38 +170,40 @@
   --ic-theme-blue-primary-r: 27;
   --ic-theme-blue-primary-g: 60;
   --ic-theme-blue-primary-b: 121;
+  --ic-theme-blue-primary-a: 1;
   --ic-theme-primary-r: var(--ic-theme-blue-primary-r);
   --ic-theme-primary-g: var(--ic-theme-blue-primary-g);
   --ic-theme-primary-b: var(--ic-theme-blue-primary-b);
+  --ic-theme-primary-a: var(--ic-theme-blue-primary-a);
   --ic-theme-primary: rgb(
-    var(--ic-theme-primary-r) var(--ic-theme-primary-g)
-      var(--ic-theme-primary-b)
+    var(--ic-theme-primary-r)
+    var(--ic-theme-primary-g)
+    var(--ic-theme-primary-b) /
+    var(--ic-theme-primary-a)
   );
   --ic-theme-secondary: rgb(
-    calc(var(--ic-theme-primary-r) * 0.8) calc(var(--ic-theme-primary-g) * 0.8)
-      calc(var(--ic-theme-primary-b) * 0.8)
+    calc(var(--ic-theme-primary-r) * 0.8)
+    calc(var(--ic-theme-primary-g) * 0.8)
+    calc(var(--ic-theme-primary-b) * 0.8) /
+    var(--ic-theme-primary-a)
   );
   --ic-theme-tertiary: rgb(
-    calc(var(--ic-theme-primary-r) * 0.6) calc(var(--ic-theme-primary-g) * 0.6)
-      calc(var(--ic-theme-primary-b) * 0.6)
+    calc(var(--ic-theme-primary-r) * 0.6)
+    calc(var(--ic-theme-primary-g) * 0.6)
+    calc(var(--ic-theme-primary-b) * 0.6) /
+    var(--ic-theme-primary-a)
   );
   --ic-theme-secondary-light: rgb(
     calc(var(--ic-theme-primary-r) + ((255 - var(--ic-theme-primary-r)) * 0.2))
-      calc(
-        var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.2)
-      )
-      calc(
-        var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.2)
-      )
+    calc(var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.2))
+    calc(var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.2)) /
+    var(--ic-theme-primary-a)
   );
   --ic-theme-tertiary-light: rgb(
     calc(var(--ic-theme-primary-r) + ((255 - var(--ic-theme-primary-r)) * 0.4))
-      calc(
-        var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.4)
-      )
-      calc(
-        var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.4)
-      )
+    calc(var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.4))
+    calc(var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.4)) /
+    var(--ic-theme-primary-a)
   );
 
   /* ic-theme-calc and ic-theme-text returns if black or white font colors should be used for color contrast reasons by:
@@ -230,16 +232,22 @@
   --ic-theme-primary-calc: calc(var(--ic-theme-primary-subtract-calc) * -1000);
   --ic-theme-calc: max(0, var(--ic-theme-primary-calc));
   --ic-theme-text: rgb(
-    calc(var(--ic-theme-calc) + 11) calc(var(--ic-theme-calc) + 12)
-      calc(var(--ic-theme-calc) + 12)
+    calc(var(--ic-theme-calc) + 11)
+    calc(var(--ic-theme-calc) + 12)
+    calc(var(--ic-theme-calc) + 12) /
+    var(--ic-theme-primary-a)
   );
   --ic-theme-hover: rgb(
-    calc(var(--ic-theme-calc) + 65) calc(var(--ic-theme-calc) + 70)
-      calc(var(--ic-theme-calc) + 77) / 10%
+    calc(var(--ic-theme-calc) + 65)
+    calc(var(--ic-theme-calc) + 70)
+    calc(var(--ic-theme-calc) + 77) /
+    10%
   );
   --ic-theme-active: rgb(
-    calc(var(--ic-theme-calc) + 65) calc(var(--ic-theme-calc) + 70)
-      calc(var(--ic-theme-calc) + 77) / 20%
+    calc(var(--ic-theme-calc) + 65)
+    calc(var(--ic-theme-calc) + 70)
+    calc(var(--ic-theme-calc) + 77) /
+    20%
   );
 
   /* hyperlinks */

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -4,8 +4,8 @@ import {
   IcInformationStatusOrEmpty,
   IcNavParentDetails,
   IcPropObject,
-  IcColorRGB,
   IcSearchMatchPositions,
+  IcColorRGBA,
 } from "./types";
 
 import {
@@ -464,7 +464,7 @@ const hex2dec = function (v: string) {
   return parseInt(v, 16);
 };
 
-export const hexToRgb = (hex: string): IcColorRGB => {
+export const hexToRgba = (hex: string): IcColorRGBA => {
   let c;
   if (hex.length === 4) {
     c = hex.replace("#", "").split("");
@@ -472,27 +472,43 @@ export const hexToRgb = (hex: string): IcColorRGB => {
       r: hex2dec(c[0] + c[0]),
       g: hex2dec(c[1] + c[1]),
       b: hex2dec(c[2] + c[2]),
+      a: 1,
     };
   } else {
     return {
       r: hex2dec(hex.slice(1, 3)),
       g: hex2dec(hex.slice(3, 5)),
       b: hex2dec(hex.slice(5)),
+      a: 1,
     };
   }
 };
 
-export const rgbStrToObj = (rgbStr: string): IcColorRGB => {
-  const colorRGB: IcColorRGB = { r: null, g: null, b: null };
-  const rgb = rgbStr
-    .substring(4, rgbStr.length - 1)
-    .replace(/ /g, "")
-    .split(",");
-  colorRGB.r = Number(rgb[0]);
-  colorRGB.g = Number(rgb[1]);
-  colorRGB.b = Number(rgb[2]);
+export const rgbaStrToObj = (rgbaStr: string): IcColorRGBA => {
+  const fourthChar = rgbaStr.slice(3, 4);
+  let colorRGBA: IcColorRGBA;
+  if (fourthChar.toLowerCase() === "a") {
+    colorRGBA = { r: null, g: null, b: null, a: null };
+    const rgba = rgbaStr
+      .substring(5, rgbaStr.length - 1)
+      .replace(/ /g, "")
+      .split(",");
+    colorRGBA.r = Number(rgba[0]);
+    colorRGBA.g = Number(rgba[1]);
+    colorRGBA.b = Number(rgba[2]);
+    colorRGBA.a = Number(rgba[3]);
+  } else {
+    colorRGBA = { r: null, g: null, b: null, a: 1 };
+    const rgb = rgbaStr
+      .substring(4, rgbaStr.length - 1)
+      .replace(/ /g, "")
+      .split(",");
+    colorRGBA.r = Number(rgb[0]);
+    colorRGBA.g = Number(rgb[1]);
+    colorRGBA.b = Number(rgb[2]);
+  }
 
-  return colorRGB;
+  return colorRGBA;
 };
 
 export const elementOverflowsX = (element: HTMLElement): boolean => {

--- a/packages/web-components/src/utils/types.ts
+++ b/packages/web-components/src/utils/types.ts
@@ -91,6 +91,10 @@ export type IcColorRGB = {
   b: number;
 };
 
+export type IcColorRGBA = IcColorRGB & {
+  a: number;
+};
+
 export type IcActivationTypes = "automatic" | "manual";
 
 export type IcAutocorrectStates = "on" | "off";


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update theme to use rgba that can either be set by user, or sets to 1 for hex and rgb inputs.

## Related issue
#4

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 