### PR TITLE
fix(web-components): updated foreground colour calculations, added colour contrast check

### DIFF
--- a/packages/web-components/src/components/ic-theme/ic-theme.tsx
+++ b/packages/web-components/src/components/ic-theme/ic-theme.tsx
@@ -14,6 +14,11 @@ import {
   hexToRgba,
   rgbaStrToObj,
 } from "../../utils/helpers";
+import { getThemeColorBrightness } from "../../utils/helpers";
+import {
+  BLACK_MIN_COLOR_BRIGHTNESS,
+  WHITE_MAX_COLOR_BRIGHTNESS,
+} from "../../utils/constants";
 
 @Component({
   tag: "ic-theme",
@@ -35,6 +40,17 @@ export class Theme {
    */
   @Event() icThemeChange: EventEmitter<IcTheme>;
 
+  private checkThemeColorContrast = (): void => {
+    if (
+      getThemeColorBrightness() < BLACK_MIN_COLOR_BRIGHTNESS &&
+      getThemeColorBrightness() > WHITE_MAX_COLOR_BRIGHTNESS
+    ) {
+      console.warn(
+        `The theme colour does not provide enough contrast with either of the ICDS black or white foreground colours. Consider choosing a colour with a different brightness to achieve sufficient colour contrast for good visibility. See https://www.w3.org/TR/AERT/#color-contrast for more information about colour contrast.`
+      );
+    }
+  };
+
   private setThemeColor = () => {
     if (this.color !== null) {
       let colorRGBA = null;
@@ -55,6 +71,9 @@ export class Theme {
       root.style.setProperty("--ic-theme-primary-g", colorRGBA.g.toString());
       root.style.setProperty("--ic-theme-primary-b", colorRGBA.b.toString());
       root.style.setProperty("--ic-theme-primary-a", colorRGBA.a.toString());
+
+      this.checkThemeColorContrast();
+
       const foregroundColor = getThemeForegroundColor();
       this.icThemeChange.emit({ mode: foregroundColor, color: colorRGBA });
     }

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -176,41 +176,42 @@
   --ic-theme-primary-b: var(--ic-theme-blue-primary-b);
   --ic-theme-primary-a: var(--ic-theme-blue-primary-a);
   --ic-theme-primary: rgb(
-    var(--ic-theme-primary-r)
-    var(--ic-theme-primary-g)
-    var(--ic-theme-primary-b) /
-    var(--ic-theme-primary-a)
+    var(--ic-theme-primary-r) var(--ic-theme-primary-g)
+      var(--ic-theme-primary-b) / var(--ic-theme-primary-a)
   );
   --ic-theme-secondary: rgb(
-    calc(var(--ic-theme-primary-r) * 0.8)
-    calc(var(--ic-theme-primary-g) * 0.8)
-    calc(var(--ic-theme-primary-b) * 0.8) /
-    var(--ic-theme-primary-a)
+    calc(var(--ic-theme-primary-r) * 0.8) calc(var(--ic-theme-primary-g) * 0.8)
+      calc(var(--ic-theme-primary-b) * 0.8) / var(--ic-theme-primary-a)
   );
   --ic-theme-tertiary: rgb(
-    calc(var(--ic-theme-primary-r) * 0.6)
-    calc(var(--ic-theme-primary-g) * 0.6)
-    calc(var(--ic-theme-primary-b) * 0.6) /
-    var(--ic-theme-primary-a)
+    calc(var(--ic-theme-primary-r) * 0.6) calc(var(--ic-theme-primary-g) * 0.6)
+      calc(var(--ic-theme-primary-b) * 0.6) / var(--ic-theme-primary-a)
   );
   --ic-theme-secondary-light: rgb(
     calc(var(--ic-theme-primary-r) + ((255 - var(--ic-theme-primary-r)) * 0.2))
-    calc(var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.2))
-    calc(var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.2)) /
-    var(--ic-theme-primary-a)
+      calc(
+        var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.2)
+      )
+      calc(
+        var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.2)
+      ) / var(--ic-theme-primary-a)
   );
   --ic-theme-tertiary-light: rgb(
     calc(var(--ic-theme-primary-r) + ((255 - var(--ic-theme-primary-r)) * 0.4))
-    calc(var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.4))
-    calc(var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.4)) /
-    var(--ic-theme-primary-a)
+      calc(
+        var(--ic-theme-primary-g) + ((255 - var(--ic-theme-primary-g)) * 0.4)
+      )
+      calc(
+        var(--ic-theme-primary-b) + ((255 - var(--ic-theme-primary-b)) * 0.4)
+      ) / var(--ic-theme-primary-a)
   );
 
   /* ic-theme-calc and ic-theme-text returns if black or white font colors should be used for color contrast reasons by:
     - Multiplying each RGB value by a set number: https://www.w3.org/TR/AERT/#color-contrast
     - Adding them together and dividing by 1000
+    - Calculating this for the black and white text RGB values, adding them together and dividing by 2 gives the threshold for determining the font color
     - Due to no if statement in CSS, high RGB values are capped at 255 and low RGB capped at 0
-    - Subtracting 128 from the calculation and dividing by 1000 returns a large positive or negative number
+    - Subtracting the dark mode threshold from the calculation and multiplying by -10000 returns a large positive or negative number
     - The RGB function caps negative numbers to RGB(0, 0, 0) or positive numbers to RGB(255, 255, 255)
     - The ICDS does not use pure black RGB(0, 0, 0) as it's font, it uses #0b0c0c/RGB(11, 12, 12)
     - The max() CSS function therefore ensures any negative numbers can be no less than 0
@@ -218,6 +219,7 @@
     - The result then returns the RGB values for the ICDS white or black font color, dependent on which is the most color contrast compliant
     This is a similar calculation to it's JS counterpart: "getThemeFontColor"
   */
+  --ic-theme-dark-mode-threshold: 133.3505;
   --ic-theme-primary-r-calc: calc(var(--ic-theme-primary-r) * 299);
   --ic-theme-primary-g-calc: calc(var(--ic-theme-primary-g) * 587);
   --ic-theme-primary-b-calc: calc(var(--ic-theme-primary-b) * 114);
@@ -227,27 +229,21 @@
   );
   --ic-theme-primary-divide-calc: calc(var(--ic-theme-primary-sum-calc) / 1000);
   --ic-theme-primary-subtract-calc: calc(
-    var(--ic-theme-primary-divide-calc) - 128
+    var(--ic-theme-primary-divide-calc) - var(--ic-theme-dark-mode-threshold)
   );
-  --ic-theme-primary-calc: calc(var(--ic-theme-primary-subtract-calc) * -1000);
+  --ic-theme-primary-calc: calc(var(--ic-theme-primary-subtract-calc) * -10000);
   --ic-theme-calc: max(0, var(--ic-theme-primary-calc));
   --ic-theme-text: rgb(
-    calc(var(--ic-theme-calc) + 11)
-    calc(var(--ic-theme-calc) + 12)
-    calc(var(--ic-theme-calc) + 12) /
-    var(--ic-theme-primary-a)
+    calc(var(--ic-theme-calc) + 11) calc(var(--ic-theme-calc) + 12)
+      calc(var(--ic-theme-calc) + 12) / var(--ic-theme-primary-a)
   );
   --ic-theme-hover: rgb(
-    calc(var(--ic-theme-calc) + 65)
-    calc(var(--ic-theme-calc) + 70)
-    calc(var(--ic-theme-calc) + 77) /
-    10%
+    calc(var(--ic-theme-calc) + 65) calc(var(--ic-theme-calc) + 70)
+      calc(var(--ic-theme-calc) + 77) / 10%
   );
   --ic-theme-active: rgb(
-    calc(var(--ic-theme-calc) + 65)
-    calc(var(--ic-theme-calc) + 70)
-    calc(var(--ic-theme-calc) + 77) /
-    20%
+    calc(var(--ic-theme-calc) + 65) calc(var(--ic-theme-calc) + 70)
+      calc(var(--ic-theme-calc) + 77) / 20%
   );
 
   /* hyperlinks */

--- a/packages/web-components/src/utils/constants.ts
+++ b/packages/web-components/src/utils/constants.ts
@@ -49,3 +49,13 @@ export interface IcColorExceptions {
 export const IC_BLOCK_COLOR_EXCEPTIONS: IcColorExceptions = {
   "ic-alert": ["ic-link"],
 };
+
+/* Range within which the chosen theme colour would not have a sufficient brightness difference with either of the black or white foreground colours
+ * The brightness difference must be greater than 125 to provide good colour visibility
+ * Calculated by:
+ * - Using the brightness formula for both colours: https://www.w3.org/TR/AERT/#color-contrast
+ * - Adding 125 to the brightness of the black foreground colour - RGB(11, 12, 12)
+ * - Subtracting 125 from the brightness of the white foreground colour - RGB(255, 255, 255)
+ */
+export const BLACK_MIN_COLOR_BRIGHTNESS = 136.701;
+export const WHITE_MAX_COLOR_BRIGHTNESS = 130;

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -19,7 +19,7 @@ import {
   IC_FIXED_COLOR_COMPONENTS,
 } from "./constants";
 
-const DARK_MODE_THRESHOLD = 128;
+const DARK_MODE_THRESHOLD = 133.3505;
 
 /**
  * Used to inherit global attributes set on the host. Called in componentWillLoad and assigned
@@ -314,25 +314,31 @@ export const getCssProperty = (cssVar: string): string => {
   return getComputedStyle(document.documentElement).getPropertyValue(cssVar);
 };
 
-export const getThemeForegroundColor = (): IcThemeForeground => {
-  /*
-    Returns if dark or light font colors should be used for color contrast reasons, calculated by using the theme RGB CSS values by:
-    - Multiplying each RGB value by a set number: https://www.w3.org/TR/AERT/#color-contrast
-    - Adding them together and dividing by 1000
-    - If the result is greater than 128 return "dark" color, else return "light" color
-    This is a similar calculation to it's CSS counterpart: "--ic-theme-text"
-  */
+/**
+ * Returns the brightness of the theme colour, calculated by using the theme RGB CSS values by:
+ * - Multiplying each RGB value by a set number: https://www.w3.org/TR/AERT/#color-contrast
+ * - Adding them together and dividing by 1000
+ * This is a similar calculation to its CSS counterpart: "--ic-theme-text"
+ * @returns number representing the brightness of the theme colour
+ */
+export const getThemeColorBrightness = () => {
   const themeRed = getCssProperty("--ic-theme-primary-r");
   const themeGreen = getCssProperty("--ic-theme-primary-g");
   const themeBlue = getCssProperty("--ic-theme-primary-b");
-  const fontColor = Math.round(
+  const themeColorBrightness =
     (parseInt(themeRed) * 299 +
       parseInt(themeGreen) * 587 +
       parseInt(themeBlue) * 114) /
-      1000
-  );
+    1000;
+  return themeColorBrightness;
+};
 
-  return fontColor > DARK_MODE_THRESHOLD
+/**
+ * Returns if dark or light foreground colors should be used for color contrast reasons
+ * @returns "dark" or "light"
+ */
+export const getThemeForegroundColor = (): IcThemeForeground => {
+  return getThemeColorBrightness() > DARK_MODE_THRESHOLD
     ? IcThemeForegroundEnum.Dark
     : IcThemeForegroundEnum.Light;
 };


### PR DESCRIPTION
## Summary of the changes
Updated foreground colour calculations - updated dark mode threshold and changed -1000 to -10000 as foreground colour was sometimes showing as grey because this number wasn't large enough to bring it over 255, ran prettier:fix, added colour contrast check to ic-theme component which creates a console warning if the chosen colour has a colour brightness which is too close to being halfway between that of the black and white foregound colours - and therefore not a high enough contrast.

## Related issue
#3 