### PR TITLE
fix(web-components): switching out svg for rounded circular determinate indicator

### DIFF
--- a/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.css
+++ b/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.css
@@ -15,6 +15,12 @@
   --linear-line-height: var(--ic-space-xs);
 }
 
+:host(.light) {
+  --inner-color: var(--ic-architectural-white);
+  --outer-color: var(--ic-architectural-800);
+  --label-color: var(--ic-architectural-white);
+}
+
 .ic-loading-container {
   display: flex;
   flex-direction: column;
@@ -32,7 +38,7 @@
 }
 
 :host([size="large"]) {
-  --circular-diameter: 160px;
+  --circular-diameter: 120px;
 }
 
 :host([size="icon"]) {
@@ -53,108 +59,14 @@
 }
 
 .ic-loading-circular-outer {
-  box-shadow: inset 0 0 0 var(--circular-line-width) var(--outer-color);
   height: var(--circular-diameter);
   width: var(--circular-diameter);
-  border-radius: 50%;
-  position: relative;
+
 }
 
 .ic-loading-circular-outer.indeterminate {
   animation: circular-animation 1s linear;
   animation-iteration-count: infinite;
-}
-
-.ic-loading-circular-inner {
-  height: var(--circular-diameter);
-  width: var(--circular-diameter);
-  border-radius: 50%;
-  position: relative;
-}
-
-.indeterminate > .ic-loading-circular-inner {
-  box-shadow: inset 0 0 0 var(--circular-line-width) var(--inner-color);
-  clip-path: inset(0 50% 50% 0);
-}
-
-.determinate > .ic-loading-circular-inner {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-}
-
-.determinate > .ic-loading-circular-inner.clip {
-  clip: rect(
-    0,
-    var(--circular-diameter),
-    var(--circular-diameter),
-    calc(var(--circular-diameter) / 2)
-  );
-}
-
-.ic-loading-circular-inner .left,
-.ic-loading-circular-inner .right {
-  height: 100%;
-  width: 100%;
-  border: var(--circular-line-width) solid var(--inner-color);
-  border-radius: 50%;
-  box-sizing: border-box;
-  clip: rect(
-    0,
-    calc(var(--circular-diameter) / 2),
-    var(--circular-diameter),
-    0
-  );
-  position: absolute;
-  left: 0;
-  top: 0;
-}
-
-.indeterminate > .ic-loading-circular-inner .left,
-.indeterminate > .ic-loading-circular-inner .right {
-  display: none;
-}
-
-.determinate > .ic-loading-circular-inner .left {
-  transform: rotate(var(--circular-rotation));
-}
-
-.determinate > .ic-loading-circular-inner .right {
-  transform: rotate(180deg);
-}
-
-.determinate > .ic-loading-circular-inner.clip .right {
-  display: none;
-}
-
-.ic-loading-circular-outer::before {
-  content: "";
-  height: var(--circular-line-width);
-  width: var(--circular-line-width);
-  border-radius: 50%;
-  background-color: var(--inner-color);
-  position: absolute;
-  display: block;
-  top: calc(50% - var(--circular-line-width) / 2);
-}
-
-.ic-loading-circular-outer::after {
-  content: "";
-  height: var(--circular-line-width);
-  width: var(--circular-line-width);
-  border-radius: 50%;
-  background-color: var(--inner-color);
-  position: absolute;
-  display: block;
-  top: 0;
-  left: calc(50% - var(--circular-line-width) / 2);
-}
-
-.ic-loading-circular-outer.determinate::before,
-.ic-loading-circular-outer.determinate::after {
-  display: none;
 }
 
 @keyframes circular-animation {
@@ -223,29 +135,52 @@
   }
 }
 
-:host(.light) {
-  --inner-color: var(--ic-architectural-white);
-  --outer-color: var(--ic-architectural-800);
-  --label-color: var(--ic-architectural-white);
+.ic-loading-circular-svg {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.ic-loading-circular-svg circle {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: var(--outer-color);
+  stroke-width: var(--circular-line-width);
+  stroke-linecap: round;
+}
+
+/* --stroke-dash-array calculated via dashArray method */
+.ic-loading-circular-svg circle:nth-child(2) {
+  --circular-indeterminate: calc(
+    (0.25 * var(--stroke-dasharray)) - var(--stroke-dasharray)
+  );
+
+  stroke-dasharray: var(--stroke-dasharray), var(--stroke-dasharray);
+  stroke-dashoffset: var(--stroke-dashoffset, var(--circular-indeterminate));
+  stroke: var(--inner-color);
 }
 
 /** High Contrast **/
 @media (forced-colors: active) {
   .indeterminate > .ic-loading-circular-inner {
     forced-color-adjust: none;
-    box-shadow: inset 0 0 0 var(--circular-line-width) canvastext;
   }
 
   .ic-loading-linear-outer {
     border: var(--ic-hc-border);
   }
-  
-  .ic-loading-circular-outer::after,
-  .ic-loading-circular-outer::before {
-    background-color: canvastext;
-  }
 
   .ic-loading-linear-inner {
     background-color: canvastext;
+  }
+
+  .ic-loading-circular-svg circle {
+    stroke: Background;
+  }
+
+  .ic-loading-circular-svg circle:nth-child(2) {
+    stroke: canvastext;
   }
 }

--- a/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.spec.ts
+++ b/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.spec.ts
@@ -15,7 +15,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-labelledby="ic-loading-label" aria-valuemax="100" aria-valuemin="0" class="ic-loading-circular-outer indeterminate" role="progressbar">
-          <div class="ic-loading-circular-inner"></div>
+          <div class="ic-loading-circular-inner">
+            <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+              <circle cx="0" cy="0" r="0"></circle>
+              <circle cx="0" cy="0" r="0"></circle>
+            </svg>
+          </div>
         </div>
         <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
           <mock:shadow-root>
@@ -41,9 +46,11 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-labelledby="ic-loading-label" aria-valuemax="100" aria-valuemin="0" aria-valuenow="30" class="ic-loading-circular-outer determinate" role="progressbar">
-          <div class="clip ic-loading-circular-inner" style="--circular-rotation: 108deg; --linear-width: 30%;">
-            <div class="left"></div>
-            <div class="right"></div>
+          <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0" style='--progress-value: 30;'></circle>
+          </svg>
           </div>
         </div>
         <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
@@ -70,7 +77,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-valuemax="100" aria-valuemin="0" class="ic-loading-circular-outer indeterminate" role="progressbar">
-          <div class="ic-loading-circular-inner"></div>
+        <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0"></circle>
+          </svg>
+        </div>
         </div>
       </div>
     </mock:shadow-root>
@@ -88,7 +100,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-labelledby="ic-loading-label" aria-valuemax="100" aria-valuemin="0" class="ic-loading-circular-outer indeterminate" role="progressbar">
-          <div class="ic-loading-circular-inner"></div>
+        <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0"></circle>
+          </svg>
+        </div>
         </div>
         <ic-typography class="ic-loading-label ic-typography-label" id="ic-loading-label" role="status">
           <mock:shadow-root>
@@ -114,7 +131,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-labelledby="ic-loading-label" aria-valuemax="100" aria-valuemin="0" class="ic-loading-circular-outer indeterminate" role="progressbar">
-          <div class="ic-loading-circular-inner"></div>
+        <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0"></circle>
+          </svg>
+        </div>
         </div>
         <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
           <mock:shadow-root>
@@ -140,7 +162,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-labelledby="ic-loading-label" aria-valuemax="100" aria-valuemin="0" class="ic-loading-circular-outer indeterminate" role="progressbar">
-          <div class="ic-loading-circular-inner"></div>
+        <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0"></circle>
+          </svg>
+        </div>
         </div>
         <ic-typography class="ic-loading-label ic-typography-h2" id="ic-loading-label" role="status">
           <mock:shadow-root>
@@ -166,7 +193,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="IC Loading Indicator Test" aria-valuemax="100" aria-valuemin="0" class="ic-loading-circular-outer indeterminate" role="progressbar">
-          <div class="ic-loading-circular-inner"></div>
+        <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0"></circle>
+          </svg>
+        </div>
         </div>
       </div>
     </mock:shadow-root>
@@ -202,10 +234,12 @@ describe("ic-loading-indicator component", () => {
     <mock:shadow-root>
       <div class="ic-loading-container">
         <div aria-label="Loading" aria-valuemax="50" aria-valuemin="10" aria-valuenow="30" class="ic-loading-circular-outer determinate" role="progressbar">
-          <div class="clip ic-loading-circular-inner" style="--circular-rotation: 180deg; --linear-width: 50%;">
-            <div class="left"></div>
-            <div class="right"></div>
-          </div>
+        <div class="ic-loading-circular-inner">
+          <svg class="ic-loading-circular-svg" viewBox="0 0 0 0">
+            <circle cx="0" cy="0" r="0"></circle>
+            <circle cx="0" cy="0" r="0" style='--progress-value: 30;'></circle>
+          </svg>
+        </div>
         </div>
       </div>
     </mock:shadow-root>
@@ -224,5 +258,42 @@ describe("ic-loading-indicator component", () => {
     await page.waitForChanges();
 
     expect(page.rootInstance.indicatorLabel).toEqual("still waiting");
+  });
+
+  it("should render linear determinate progress bar", async () => {
+    const page = await newSpecPage({
+      components: [LoadingIndicator, Typography],
+      html: `<ic-loading-indicator progress="30" min="10" max="50" type='linear'></ic-loading-indicator>`,
+    });
+
+    expect(page.root)
+      .toEqualHtml(`<ic-loading-indicator max="50" min="10" progress="30" size="default" type="linear">
+          <mock:shadow-root>
+            <div class="ic-loading-container">
+              <div aria-label="Loading" aria-valuemax="50" aria-valuemin="10" aria-valuenow="30" class="determinate ic-loading-linear-outer" role="progressbar">
+                <div class="clip ic-loading-linear-inner" style="--linear-width: 50%;"></div>
+              </div>
+            </div>
+          </mock:shadow-root>
+        </ic-loading-indicator>
+    `);
+  });
+
+  it("should render linear indeterminate progress bar", async () => {
+    const page = await newSpecPage({
+      components: [LoadingIndicator, Typography],
+      html: `<ic-loading-indicator type='linear'></ic-loading-indicator>`,
+    });
+
+    expect(page.root)
+      .toEqualHtml(`<ic-loading-indicator size="default" type="linear">
+    <mock:shadow-root>
+      <div class="ic-loading-container">
+        <div aria-label="Loading" aria-valuemax="100" aria-valuemin="0" class="ic-loading-linear-outer indeterminate" role="progressbar">
+          <div class="ic-loading-linear-inner"></div>
+        </div>
+      </div>
+    </mock:shadow-root>
+  </ic-loading-indicator>`);
   });
 });

--- a/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.types.tsx
+++ b/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.types.tsx
@@ -1,3 +1,9 @@
 export type IcLoadingSizes = "default" | "small" | "large" | "icon";
 
 export type IcLoadingTypes = "circular" | "linear";
+
+export interface IcLoadingCircleXYR {
+  x: number;
+  y: number;
+  r: number;
+}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Using SVG to add rounded corners to loading indicator. Psuedo elements are no longer required as stroke-linecap on SVG works. Also updated code to only display necessary linear or circular inline styling

## Related issue
#118

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 