### PR TITLE
fix(web-components): fixes alert styling when javascript disabled

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -75,19 +75,19 @@
   fill: var(--ic-architectural-500);
 }
 
-.icon-info > svg {
+:host([variant="info"]) .alert-icon svg {
   fill: var(--ic-status-info);
 }
 
-.icon-warning > svg {
+:host([variant="warning"]) .alert-icon svg {
   fill: var(--ic-status-warning-mid);
 }
 
-.icon-error > svg {
+:host([variant="error"]) .alert-icon svg {
   fill: var(--ic-status-error);
 }
 
-.icon-success > svg {
+:host([variant="success"]) .alert-icon svg {
   fill: var(--ic-status-success);
 }
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Now applies correct colour to icon when JavaScript disabled.

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 