### PR TITLE
feat(web-components): removes required flag for internal props

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1072,8 +1072,8 @@ export namespace Components {
         "status"?: IcStatusTagStatuses;
     }
     interface IcStep {
-        "lastStep": boolean;
-        "stepNum": number;
+        "lastStep"?: boolean;
+        "stepNum"?: number;
         /**
           * Additional information about step
          */
@@ -1144,7 +1144,7 @@ export namespace Components {
         "disabled"?: boolean;
         "selected"?: boolean;
         "tabId"?: string;
-        "tabPosition": number;
+        "tabPosition"?: number;
     }
     interface IcTabContext {
         /**
@@ -1188,7 +1188,7 @@ export namespace Components {
         "contextId"?: string;
         "panelId"?: string;
         "selectedTab"?: string;
-        "tabPosition": number;
+        "tabPosition"?: number;
     }
     interface IcTextField {
         "ariaActiveDescendant"?: string;
@@ -2893,8 +2893,8 @@ declare namespace LocalJSX {
         "status"?: IcStatusTagStatuses;
     }
     interface IcStep {
-        "lastStep": boolean;
-        "stepNum": number;
+        "lastStep"?: boolean;
+        "stepNum"?: number;
         /**
           * Additional information about step
          */
@@ -2982,7 +2982,7 @@ declare namespace LocalJSX {
         "onTabFocus"?: (event: IcTabCustomEvent<IcTabClickEventDetail>) => void;
         "selected"?: boolean;
         "tabId"?: string;
-        "tabPosition": number;
+        "tabPosition"?: number;
     }
     interface IcTabContext {
         /**
@@ -3029,7 +3029,7 @@ declare namespace LocalJSX {
         "contextId"?: string;
         "panelId"?: string;
         "selectedTab"?: string;
-        "tabPosition": number;
+        "tabPosition"?: number;
     }
     interface IcTextField {
         "ariaActiveDescendant"?: string;

--- a/packages/web-components/src/components/ic-step/ic-step.tsx
+++ b/packages/web-components/src/components/ic-step/ic-step.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, Prop, Element } from "@stencil/core";
 import checkIcon from "../../assets/check-icon.svg";
-import { onComponentRequiredPropUndefined } from "../../utils/helpers";
 import { IcStepTypes } from "./ic-step.types";
 
 @Component({
@@ -28,22 +27,12 @@ export class Step {
   /**
    * @internal The step number, managed by ic-stepper
    */
-  @Prop() stepNum!: number;
+  @Prop() stepNum?: number;
 
   /**
    * @internal Final step in series flag, managed by ic-stepper
    */
-  @Prop() lastStep!: boolean;
-
-  componentDidLoad(): void {
-    onComponentRequiredPropUndefined(
-      [
-        { prop: this.stepNum, propName: "step-num" },
-        { prop: this.lastStep, propName: "last-step" },
-      ],
-      "Step"
-    );
-  }
+  @Prop() lastStep?: boolean;
 
   render() {
     let icon;

--- a/packages/web-components/src/components/ic-tab-panel/ic-tab-panel.tsx
+++ b/packages/web-components/src/components/ic-tab-panel/ic-tab-panel.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, Host, Prop, h } from "@stencil/core";
-import { onComponentRequiredPropUndefined } from "../../utils/helpers";
 import {
   IcThemeForegroundEnum,
   IcThemeForegroundNoDefault,
@@ -19,7 +18,7 @@ export class TabPanel {
   @Prop({ reflect: true }) contextId?: string = "default";
 
   /** @internal The position of the tab panel inside the tabs array in context. */
-  @Prop({ reflect: true }) tabPosition!: number;
+  @Prop({ reflect: true }) tabPosition?: number;
 
   /** @internal The shared ID that links the panel and tab. */
   @Prop({ reflect: true }) panelId?: string;
@@ -29,13 +28,6 @@ export class TabPanel {
 
   /** @internal Determines whether the light or dark variant of the tabs should be displayed. */
   @Prop() appearance?: IcThemeForegroundNoDefault = "dark";
-
-  componentDidLoad(): void {
-    onComponentRequiredPropUndefined(
-      [{ prop: this.tabPosition, propName: "tab-position" }],
-      "Tab Panel"
-    );
-  }
 
   render() {
     const { panelId, selectedTab, appearance } = this;

--- a/packages/web-components/src/components/ic-tab/ic-tab.tsx
+++ b/packages/web-components/src/components/ic-tab/ic-tab.tsx
@@ -8,7 +8,6 @@ import {
   h,
 } from "@stencil/core";
 
-import { onComponentRequiredPropUndefined } from "../../utils/helpers";
 import { IcTabClickEventDetail } from "./ic-tab.types";
 import {
   IcThemeForegroundNoDefault,
@@ -41,7 +40,7 @@ export class Tab {
   @Prop({ reflect: true }) tabId?: string;
 
   /** @internal The position of the tab inside the tabs array in context. */
-  @Prop() tabPosition!: number;
+  @Prop() tabPosition?: number;
 
   /** @internal Determines whether the light or dark variant of the tabs should be displayed. */
   @Prop() appearance?: IcThemeForegroundNoDefault = "dark";
@@ -94,13 +93,6 @@ export class Tab {
 
   componentDidUpdate(): void {
     this.isInitialRender = false;
-  }
-
-  componentDidLoad(): void {
-    onComponentRequiredPropUndefined(
-      [{ prop: this.tabPosition, propName: "tab-position" }],
-      "Tab"
-    );
   }
 
   render() {

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -29,7 +29,9 @@ export class Tooltip {
   @Watch("label")
   updateLabel(newValue: string): void {
     const describedBySpan = this.el.previousElementSibling as HTMLElement;
-    describedBySpan.innerText = newValue;
+    if (describedBySpan !== null) {
+      describedBySpan.innerText = newValue;
+    }
   }
 
   private toolTip: HTMLDivElement;


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Removes required(!) decorator to fix errors appearing in console. Not needed as parent components set the props

## Related issue
#193 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 