### PR TITLE
Fix console error

### DIFF
--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -155,7 +155,9 @@ export const getThemeFromContext = (
   el: Element,
   themeFromEvent: IcThemeForeground = null
 ): IcThemeForeground => {
-  const blockColorParent = el.parentElement.closest(
+  const parentElement =
+    el.parentElement || (<ShadowRoot>el.getRootNode()).host.parentElement;
+  const blockColorParent = parentElement.closest(
     IC_BLOCK_COLOR_COMPONENTS.join(",")
   );
 


### PR DESCRIPTION
## Summary of the changes
In ic-top-navigation, navigation-button contained an ic-button so would call the getThemeFromContext, and would have its parent checked. Since it was the parent of a shadow component, el.parentElement returns null causing the error.

My changes add an additional piece of code when it is null to get the shadow parent element, in order to find its actual parent.

## Related issue
7 (In ic-design-system)