### PR TITLE
feat(react): add slotted svg component to react library

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,1 +1,2 @@
-export * from './components';
+export * from "./components";
+export { SlottedSVG } from "./react-component-lib/slottedSVG";

--- a/packages/react/src/react-component-lib/slottedSVG.tsx
+++ b/packages/react/src/react-component-lib/slottedSVG.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from "react";
+
+const defaultProps = {
+  xmlns: "http://www.w3.org/2000/svg",
+};
+
+function slot(name = "") {
+  return { ref: (e: any) => (e ? e.setAttribute("slot", name) : null) };
+}
+
+export const SlottedSVG: FC<any> = ({ props, path, slot: slotName }) => (
+  <svg {...slot(slotName)} {...props} {...defaultProps}>
+    <path d={path} />
+  </svg>
+);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add slotted svg component to react library in order to remove remove error that appears in typescript applications.
Tested by packing this work, and replacing the current slotted SVG in the design system with the slotted svg imported from this work. Everything seems to work as normal.

## Related issue
#280

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 