### PR TITLE
fix(web-components): fixes searchbar debounce prop

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.e2e.ts
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.e2e.ts
@@ -537,7 +537,7 @@ describe("ic-search-bar", () => {
     expect(searchBar.getAttribute("value")).toBe("");
     expect(searchBar.getAttribute("value").length).toBe(0);
   });
-  
+
   it("should emit icSubmitSearch when search button pressed with Space", async () => {
     const page = await newE2EPage();
     await page.setContent(`<ic-search-bar label="Test Label"></ic-search-bar>`);
@@ -1059,5 +1059,33 @@ describe("ic-search-bar", () => {
     });
 
     expect(focusedElement).toBe("button");
+  });
+
+  it("should emit icChange on delay", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `<ic-search-bar label="Test Label" debounce="500"></ic-search-bar>`
+    );
+
+    await page.waitForChanges();
+    const icChange = await page.spyOnEvent("icChange");
+
+    await focusAndTypeIntoInput("foo", page);
+
+    await page.waitForTimeout(600);
+    expect(icChange).toHaveReceivedEventDetail({
+      value: "foo",
+    });
+
+    await focusAndTypeIntoInput("bar", page);
+    await page.waitForChanges();
+    await page.waitForTimeout(100);
+    expect(icChange).toHaveReceivedEventDetail({
+      value: "foo",
+    });
+    await page.waitForTimeout(500);
+    expect(icChange).toHaveReceivedEventDetail({
+      value: "foobar",
+    });
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes debounce prop not working, which caused icChange event to emit immediately.

- No longer need to watch changes to debounce prop of ic-search-bar
- The debounce value is passed to ic-text-field
- icChange and icInput are emitted from ic-text-field. Due to the way Stencil scopes events in the shadowDOM, they appear to consumers as if they are emitted by the parent component
- debounceAriaLiveUpdate was incorrectly updating the debounce prop, instead of using private state. This means the debounce prop no longer needs to be mutable.
- Adds e2e test

## Related issue
#295 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 