### PR TITLE
Add loki visual test update github action

### DIFF
--- a/.github/workflows/update-visual-regression-tests.yml
+++ b/.github/workflows/update-visual-regression-tests.yml
@@ -1,0 +1,26 @@
+name: Update visual regression test images
+
+on: workflow_dispatch
+
+jobs:
+  ic-ui-kit-update-visual-tests:
+    name: 'Update Visual Regression Test References'
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - uses: browser-actions/setup-chrome@latest
+      - name: Install dependencies
+        run: |
+          npm ci --legacy-peer-deps
+          npm run bootstrap -- -- --ci --legacy-peer-deps
+      - name: Update Visual Regression Test References
+        run: |
+          npm run test-visual:update-ci
+      - uses: EndBug/add-and-commit@v9
+        with: 
+          commit: --no-verify
+          default_author: github_actions
+          message: 'feat(web-components): update loki visual regression test references'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test-visual": "npm run build && npm run build-storybook:web-components && lerna run test-visual --stream",
     "test-visual:ci": "npm run build && npm run build-storybook:web-components && lerna run test-visual:ci --stream",
     "test-visual:update": "lerna run test-visual:update --stream",
+    "test-visual:update-ci": "npm run build && lerna run test-visual:update --stream",
     "audit": "audit-ci -m --config audit-ci.json && lerna run audit",
     "prepare": "husky install",
     "prettier": "lerna run prettier",


### PR DESCRIPTION
## Summary of the changes
Adds a manual github action to update loki visual regression test reference images.

## Related issue
#200 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 