### PR TITLE
Convert px values to rem to ensure the components appear correctly when using different browser font sizes

### DIFF
--- a/packages/web-components/src/assets/back-icon.svg
+++ b/packages/web-components/src/assets/back-icon.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z" fill="currentColor"/>
 </svg>

--- a/packages/web-components/src/assets/chevron-icon.svg
+++ b/packages/web-components/src/assets/chevron-icon.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M9.70687 6L8.29688 7.41L12.8769 12L8.29688 16.59L9.70687 18L15.7069 12L9.70687 6Z" fill="currentColor"/>
 </svg>

--- a/packages/web-components/src/assets/error-icon.svg
+++ b/packages/web-components/src/assets/error-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
     <title>error icon</title>
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/>

--- a/packages/web-components/src/assets/info-icon.svg
+++ b/packages/web-components/src/assets/info-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/>
     <title>info icon</title>

--- a/packages/web-components/src/assets/neutral-icon.svg
+++ b/packages/web-components/src/assets/neutral-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"/>
     <title>neutral icon</title>

--- a/packages/web-components/src/assets/success-icon.svg
+++ b/packages/web-components/src/assets/success-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
     <title>success icon</title>
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>

--- a/packages/web-components/src/assets/warning-icon.svg
+++ b/packages/web-components/src/assets/warning-icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
     <title>warning icon</title>
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>

--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -71,6 +71,12 @@
   margin-left: 1.125rem;
 }
 
+.alert-icon > svg {
+  height: var(--ic-space-lg);
+  width: var(--ic-space-lg);
+  display: inline-block;
+}
+
 .icon-neutral > svg {
   fill: var(--ic-architectural-500);
 }

--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -5,7 +5,7 @@
 }
 
 .container {
-  min-height: 56px;
+  min-height: 3.5rem;
   border-radius: var(--ic-border-radius);
   position: relative;
   display: flex;
@@ -67,8 +67,8 @@
 
 .alert-icon {
   height: var(--ic-space-lg);
-  width: 22px;
-  margin-left: 18px;
+  width: 1.375rem;
+  margin-left: 1.125rem;
 }
 
 .icon-neutral > svg {
@@ -94,7 +94,7 @@
 .alert-content {
   display: flex;
   align-items: center;
-  margin-left: 10px;
+  margin-left: 0.625rem;
   width: 100%;
 }
 
@@ -126,8 +126,8 @@
 
 .dismiss-icon {
   margin-right: var(--ic-space-xxxs);
-  margin-left: -6px;
-  padding: 6px;
+  margin-left: -0.375rem;
+  padding: 0.375rem;
   border: none;
   border-radius: 50%;
   background-color: inherit;
@@ -137,8 +137,8 @@
 }
 
 .dismiss-icon svg {
-  width: 18px;
-  height: 18px;
+  width: 1.125rem;
+  height: 1.125rem;
 }
 
 .dismiss-icon:hover {
@@ -156,7 +156,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    font-size: 1px;
+    font-size: 0.063rem;
   }
 
   .alert-title {
@@ -164,7 +164,7 @@
   }
 
   .alert-action-container {
-    margin-bottom: 14px;
+    margin-bottom: 0.875rem;
   }
 }
 

--- a/packages/web-components/src/components/ic-back-to-top/assets/ArrowUpward.svg
+++ b/packages/web-components/src/components/ic-back-to-top/assets/ArrowUpward.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" aria-hidden="true">
     <path d="M0 8L1.41 9.41L7 3.83V16H9V3.83L14.58 9.42L16 8L8 0L0 8Z"/>
 </svg>

--- a/packages/web-components/src/components/ic-back-to-top/ic-back-to-top.css
+++ b/packages/web-components/src/components/ic-back-to-top/ic-back-to-top.css
@@ -10,7 +10,7 @@ button {
   position: fixed;
   right: var(--ic-space-md);
   bottom: var(--ic-space-md);
-  height: 40px;
+  height: 2.5rem;
   align-items: center;
   padding: var(--ic-space-xs) var(--ic-space-md) var(--ic-space-xs)
     var(--ic-space-sm);
@@ -18,11 +18,11 @@ button {
   gap: var(--ic-space-xs);
   display: flex;
   background-color: var(--ic-architectural-white);
-  border: 1px solid var(--ic-action-default);
+  border: 0.063rem solid var(--ic-action-default);
   outline-width: inherit;
   box-sizing: border-box;
   box-shadow: var(--ic-elevation-overlay);
-  border-radius: 80px;
+  border-radius: 5rem;
   text-decoration: none;
   visibility: hidden;
   opacity: 0;
@@ -35,13 +35,13 @@ button {
 button:hover {
   text-decoration: none;
   background-color: var(--ic-action-default-bg-hover-no-alpha);
-  border: 1px solid var(--ic-action-default-hover);
+  border: 0.063rem solid var(--ic-action-default-hover);
 }
 
 button:active {
   text-decoration: none;
   background-color: var(--ic-action-default-bg-active-no-alpha);
-  border: 1px solid var(--ic-action-default-active);
+  border: 0.063rem solid var(--ic-action-default-active);
 }
 
 button:focus {
@@ -59,7 +59,7 @@ button:focus {
 .ic-back-to-top-link.by-footer {
   position: relative;
   right: var(--ic-space-md);
-  bottom: 56px;
+  bottom: 3.5rem;
 }
 
 .ic-back-to-top-link.offset-banner {

--- a/packages/web-components/src/components/ic-back-to-top/ic-back-to-top.css
+++ b/packages/web-components/src/components/ic-back-to-top/ic-back-to-top.css
@@ -72,6 +72,12 @@ button:focus {
   padding-top: var(--ic-space-xxxs);
 }
 
+.ic-back-to-top-icon > svg {
+  height: var(--ic-space-md);
+  width: var(--ic-space-md);
+  display: inline-block;
+}
+
 .ic-back-to-top-link span {
   color: var(--ic-action-default);
 }

--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -279,6 +279,7 @@
 div.loading-container {
   position: relative;
   align-items: center;
+  width: 100%;
 }
 
 ic-loading-indicator {

--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -16,10 +16,10 @@
   font-family: var(--ic-font-body-family);
   text-decoration: none;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 0.875rem;
   transition: var(--ic-easing-transition-fast);
   border-radius: var(--ic-border-radius);
-  min-width: 100px;
+  min-width: 6.25rem;
   display: inline-flex;
   gap: var(--ic-space-xs);
   flex-direction: row;
@@ -115,7 +115,7 @@
 /* Secondary */
 
 :host(.button-variant-secondary) .button {
-  border: 1px solid var(--button-default);
+  border: 0.063rem solid var(--button-default);
   color: var(--button-default);
 }
 
@@ -236,7 +236,7 @@
 /* Sizing */
 
 :host(.button-size-default) .button {
-  height: 40px;
+  height: 2.5rem;
   padding: var(--ic-space-xs) var(--ic-space-md);
 }
 
@@ -253,7 +253,7 @@
 :host(.button-size-default.button-variant-icon) .button {
   height: var(--ic-space-xl);
   width: var(--ic-space-xl);
-  padding: 6px;
+  padding: 0.375rem;
 }
 
 :host(.button-size-small.button-variant-icon) .button {
@@ -263,8 +263,8 @@
 }
 
 :host(.button-size-large.button-variant-icon) .button {
-  height: 40px;
-  width: 40px;
+  height: 2.5rem;
+  width: 2.5rem;
   padding: var(--ic-space-xs);
 }
 
@@ -341,13 +341,13 @@ div.icon-container {
 /** SEARCH **/
 
 :host(.search-submit-button) ::slotted(svg) {
-  --icon-height: 20px;
-  --icon-width: 20px;
+  --icon-height: 1.25rem;
+  --icon-width: 1.25rem;
 }
 
 :host(.search-submit-button-small) ::slotted(svg) {
-  --icon-height: 16px;
-  --icon-width: 16px;
+  --icon-height: 1rem;
+  --icon-width: 1rem;
 }
 
 :host(.clear-button) {
@@ -374,8 +374,8 @@ div.icon-container {
 }
 
 :host(.menu-close-button) ::slotted(svg) {
-  --icon-height: 14px;
-  --icon-width: 14px;
+  --icon-height: 0.875rem;
+  --icon-width: 0.875rem;
 }
 
 :host(.popout-menu-button) .button {
@@ -405,6 +405,6 @@ div.icon-container {
 /** High Contrast **/
 @media (forced-colors: active) {
   .button {
-    border: 2px solid transparent;
+    border: 0.125rem solid transparent;
   }
 }

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -7,7 +7,6 @@ import {
   Listen,
   Method,
   Prop,
-  Watch,
   h,
 } from "@stencil/core";
 
@@ -106,20 +105,12 @@ export class Button {
    */
   @Event() icBlur!: EventEmitter<void>;
 
-  // CalculatedWidth must have a default value, since width is only calculated once button is rendered (with text).
-  private calculatedWidth: number = 68;
   private inheritedAttributes: { [k: string]: unknown } = {};
   private buttonEl: HTMLElement;
   private hasTooltip: boolean = false;
   private buttonIdNum = buttonIds++;
   private tooltipEl: HTMLIcTooltipElement;
   private id: string;
-
-  @Watch("loading")
-  calculateWidth(): void {
-    // Assume even padding on left and right
-    this.calculatedWidth = this.el.offsetWidth - 2 * this.el.offsetLeft;
-  }
 
   @Listen("click", { capture: true })
   handleHostClick(event: Event): void {
@@ -153,10 +144,6 @@ export class Button {
       this.tooltipEl.label = newValue;
       this.buttonEl.setAttribute("aria-label", newValue);
     }
-  }
-
-  private getLoadingBarWidth(): { [key: string]: string } {
-    return { width: `${this.calculatedWidth.toString()}px` };
   }
 
   private hasIconSlot(): boolean {
@@ -217,7 +204,6 @@ export class Button {
   }
 
   componentDidLoad(): void {
-    this.calculateWidth();
     this.updateTheme();
   }
 
@@ -281,7 +267,7 @@ export class Button {
             </div>
           )}
           {this.loading ? (
-            <div class="loading-container" style={this.getLoadingBarWidth()}>
+            <div class="loading-container">
               <ic-loading-indicator
                 type="linear"
                 appearance={

--- a/packages/web-components/src/components/ic-card/ic-card.css
+++ b/packages/web-components/src/components/ic-card/ic-card.css
@@ -17,7 +17,7 @@ button {
 
 .card,
 .card.clickable {
-  border: 1px solid var(--ic-architectural-300);
+  border: 0.063rem solid var(--ic-architectural-300);
   border-radius: var(--ic-border-radius);
   box-sizing: border-box;
   padding: var(--ic-space-md);
@@ -28,7 +28,7 @@ button {
 
 .dark.card,
 .dark.card.clickable {
-  border: 1px solid var(--ic-architectural-700);
+  border: 0.063rem solid var(--ic-architectural-700);
 }
 
 .card.clickable:hover {
@@ -76,7 +76,7 @@ button {
 .card.clickable .card-title {
   color: var(--ic-hyperlink);
   text-decoration: underline;
-  text-decoration-thickness: 1px;
+  text-decoration-thickness: 0.063rem;
 }
 
 .card.clickable:hover .card-title,
@@ -92,7 +92,7 @@ button {
 
 .card.disabled .card-title {
   text-decoration: underline;
-  text-decoration-thickness: 1px;
+  text-decoration-thickness: 0.063rem;
   text-decoration-color: var(--ic-color-tertiary-text);
   color: var(--ic-color-tertiary-text);
 }

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.css
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.css
@@ -18,7 +18,7 @@ ic-input-label ic-typography {
 
 .screen-reader-only-text {
   position: absolute;
-  left: -9999px;
+  left: -624.938rem;
   background-color: #fff;
   color: #000;
   text-transform: none;

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
@@ -6,7 +6,7 @@
 }
 
 :host([small]) .container {
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 
 .container {
@@ -27,7 +27,7 @@
   height: var(--ic-space-lg);
   width: var(--ic-space-lg);
   background-color: transparent;
-  border: 1px solid var(--ic-architectural-300);
+  border: 0.063rem solid var(--ic-architectural-300);
   border-radius: var(--ic-border-radius);
   outline: none;
   cursor: pointer;
@@ -36,7 +36,7 @@
 
 .checkbox:checked {
   background-color: var(--ic-action-default);
-  border: 1px solid var(--ic-action-default);
+  border: 0.063rem solid var(--ic-action-default);
   transition: var(--ic-easing-transition-slow);
 }
 
@@ -47,7 +47,7 @@
 .checkbox:indeterminate,
 .checkbox.indeterminate:checked {
   background-color: transparent;
-  border: 2px solid var(--ic-action-default);
+  border: 0.125rem solid var(--ic-action-default);
 }
 
 .checkbox:checked:hover {
@@ -57,7 +57,7 @@
 .checkbox:indeterminate:hover,
 .checkbox.indeterminate:checked:hover {
   background-color: var(--ic-action-default-bg-hover);
-  border: 2px solid var(--ic-action-default-hover);
+  border: 0.125rem solid var(--ic-action-default-hover);
 }
 
 .checkbox:checked:active {
@@ -67,19 +67,19 @@
 .checkbox:indeterminate:active,
 .checkbox.indeterminate:checked:active {
   background-color: var(--ic-action-default-bg-active);
-  border: 2px solid var(--ic-action-default-active);
+  border: 0.125rem solid var(--ic-action-default-active);
 }
 
 .checkbox:hover {
   background-color: var(--ic-action-default-bg-hover);
-  box-shadow: 0 0 0 4px var(--ic-action-default-bg-hover);
-  border: 1px solid var(--ic-action-default-hover);
+  box-shadow: 0 0 0 0.25rem var(--ic-action-default-bg-hover);
+  border: 0.063rem solid var(--ic-action-default-hover);
 }
 
 .checkbox:active {
   background-color: var(--ic-action-default-bg-active);
-  box-shadow: 0 0 0 4px var(--ic-action-default-bg-active);
-  border: 1px solid var(--ic-action-default-active);
+  box-shadow: 0 0 0 0.25rem var(--ic-action-default-bg-active);
+  border: 0.063rem solid var(--ic-action-default-active);
 }
 
 .checkbox:focus {
@@ -87,7 +87,7 @@
 }
 
 .checkbox:disabled {
-  border: 1px dashed var(--ic-architectural-200);
+  border: 0.063rem dashed var(--ic-architectural-200);
 }
 
 .checkbox-label {
@@ -110,11 +110,11 @@
 
 .indeterminate-symbol {
   position: relative;
-  width: 14px;
+  width: 0.875rem;
   height: var(--ic-space-xxxs);
-  top: 11px;
-  right: -19px;
-  margin-left: -14px;
+  top: 0.688rem;
+  right: -1.188rem;
+  margin-left: -0.875rem;
   z-index: 1;
   background-color: var(--ic-action-default);
   pointer-events: none;
@@ -129,7 +129,7 @@
 }
 
 .additional-field-wrapper {
-  margin-left: 44px;
+  margin-left: 2.75rem;
   margin-top: var(--ic-space-xs);
 }
 
@@ -137,23 +137,23 @@
   color: var(--ic-action-default);
   height: var(--ic-space-md);
   width: var(--ic-space-xl);
-  border-radius: 0 0 0 3px;
-  border-bottom: 2px solid var(--ic-action-default);
-  border-left: 2px solid var(--ic-action-default);
+  border-radius: 0 0 0 0.188rem;
+  border-bottom: 0.125rem solid var(--ic-action-default);
+  border-left: 0.125rem solid var(--ic-action-default);
 }
 
 .dynamic-container {
   display: flex;
   position: relative;
-  margin-left: 15px;
-  margin-top: -6px;
+  margin-left: 0.938rem;
+  margin-top: -0.375rem;
   margin-bottom: var(--ic-space-md);
   gap: var(--ic-space-xs);
 }
 
 .dynamic-text {
   color: var(--ic-action-default);
-  margin-top: 7px;
+  margin-top: 0.438rem;
   margin-bottom: var(--ic-space-xs);
   border-radius: 2%;
 }
@@ -176,7 +176,7 @@
   }
 
   .checkbox:focus-visible {
-    outline: 2px solid highlight;
+    outline: 0.125rem solid highlight;
   }
 
   .checkbox:disabled:not(:checked) {

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -148,7 +148,7 @@ export class Checkbox {
               class="checkmark"
               width="1.5rem"
               height="1.5rem"
-              viewBox="0 0 100% 100%"
+              viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
               fill-rule="evenodd"
               clip-rule="evenodd"

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -146,8 +146,9 @@ export class Checkbox {
           {this.checked && !this.indeterminate && (
             <svg
               class="checkmark"
-              width="24"
-              height="24"
+              width="1.5rem"
+              height="1.5rem"
+              viewBox="0 0 100% 100%"
               xmlns="http://www.w3.org/2000/svg"
               fill-rule="evenodd"
               clip-rule="evenodd"

--- a/packages/web-components/src/components/ic-chip/ic-chip.css
+++ b/packages/web-components/src/components/ic-chip/ic-chip.css
@@ -7,8 +7,8 @@
 .chip {
   display: flex;
   padding: var(--ic-space-xxs);
-  font-size: 14px;
-  border-radius: 80px;
+  font-size: 0.875rem;
+  border-radius: 5rem;
   text-align: center;
   align-items: center;
   text-decoration: none;
@@ -58,16 +58,16 @@ ic-tooltip:focus-within {
 
 .outline {
   color: var(--ic-architectural-900);
-  border: 1px solid var(--ic-architectural-900);
-  padding: calc(var(--ic-space-xxs) - 1px);
+  border: 0.063rem solid var(--ic-architectural-900);
+  padding: calc(var(--ic-space-xxs) - 0.063rem);
 }
 
 .outline.small {
-  padding: calc(var(--ic-space-xxxs) - 1px);
+  padding: calc(var(--ic-space-xxxs) - 0.063rem);
 }
 
 .outline.large {
-  padding: calc(var(--ic-space-xs) - 1px);
+  padding: calc(var(--ic-space-xs) - 0.063rem);
 }
 
 .outline.disabled {
@@ -86,7 +86,7 @@ ic-tooltip:focus-within {
   background: none;
   cursor: pointer;
   margin: var(--ic-space-xxxs);
-  height: 20px;
+  height: 1.25rem;
 }
 
 .dismiss-icon:focus {
@@ -120,15 +120,15 @@ ic-tooltip {
   }
 
   .filled.small {
-    padding: calc(var(--ic-space-xxxs) - 1px);
+    padding: calc(var(--ic-space-xxxs) - 0.063rem);
   }
 
   .filled {
-    padding: calc(var(--ic-space-xxxs) + 1px);
+    padding: calc(var(--ic-space-xxxs) + 0.063rem);
   }
 
   .filled.large {
-    padding: calc(var(--ic-space-xs) - 1px);
+    padding: calc(var(--ic-space-xs) - 0.063rem);
   }
 
   .chip.disabled {

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
@@ -46,7 +46,7 @@
 
 .offscreen {
   position: absolute;
-  left: -9999px;
+  left: -624.938rem;
   background-color: #fff;
   color: #000;
   text-transform: none;

--- a/packages/web-components/src/components/ic-data-entity/ic-data-entity.css
+++ b/packages/web-components/src/components/ic-data-entity/ic-data-entity.css
@@ -17,7 +17,7 @@
 .divider {
   margin-top: var(--ic-space-lg);
   margin-bottom: var(--ic-space-md);
-  height: 1px;
+  height: 0.063rem;
   background-color: var(--ic-architectural-300);
 }
 

--- a/packages/web-components/src/components/ic-data-row/ic-data-row.css
+++ b/packages/web-components/src/components/ic-data-row/ic-data-row.css
@@ -17,8 +17,8 @@
 }
 
 .label {
-  width: 200px;
-  min-width: 200px;
+  width: 12.5rem;
+  min-width: 12.5rem;
   margin-right: var(--ic-space-md);
   color: var(--ic-color-tertiary-text);
 }
@@ -41,12 +41,12 @@ slot[name="value"]::slotted(ic-text-field[readonly][hide-label][rows]) {
 
 .end-component {
   width: fit-content;
-  margin-left: 56px;
+  margin-left: 3.5rem;
 }
 
 .divider {
   margin-top: var(--ic-space-md);
-  height: 1px;
+  height: 0.063rem;
   background-color: var(--ic-architectural-300);
 }
 
@@ -55,8 +55,8 @@ slot[name="value"]::slotted(ic-text-field[readonly][hide-label][rows]) {
 }
 
 :host(.breakpoint-medium) .label {
-  width: 160px;
-  min-width: 160px;
+  width: 10rem;
+  min-width: 10rem;
 }
 
 :host(.breakpoint-xs) .text-cells {
@@ -64,7 +64,7 @@ slot[name="value"]::slotted(ic-text-field[readonly][hide-label][rows]) {
 }
 
 :host(.breakpoint-xs) .label {
-  width: 128px;
+  width: 8rem;
   margin-bottom: var(--ic-space-xs);
 }
 

--- a/packages/web-components/src/components/ic-divider/ic-divider.css
+++ b/packages/web-components/src/components/ic-divider/ic-divider.css
@@ -2,7 +2,7 @@ hr {
   padding: 0;
   margin: 0;
   border: none;
-  height: 1px;
+  height: 0.063rem;
   background-color: var(--ic-keyline-darken-rgb);
 }
 

--- a/packages/web-components/src/components/ic-footer-link-group/ic-footer-link-group.css
+++ b/packages/web-components/src/components/ic-footer-link-group/ic-footer-link-group.css
@@ -1,7 +1,7 @@
 @import "../../global/normalize.css";
 
 :host(.footer-link-group-sparse) {
-  --footer-link-group-margin-right: 95px;
+  --footer-link-group-margin-right: 5.938rem;
   --footer-link-group-border-bottom: 0 solid transparent;
   --footer-link-group-title-margin-top: 0;
   --footer-link-group-title-margin-bottom: var(--ic-space-md);

--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -2,7 +2,7 @@
 
 :host(.footer-link-ungrouped-sparse) {
   --footer-link-margin-left: 0;
-  --footer-link-margin-right: 40px;
+  --footer-link-margin-right: 2.5rem;
   --footer-link-margin-bottom: 0;
 }
 

--- a/packages/web-components/src/components/ic-footer/ic-footer.css
+++ b/packages/web-components/src/components/ic-footer/ic-footer.css
@@ -5,15 +5,15 @@
 }
 
 :host(.footer-sparse) {
-  --footer-links-padding: 24px 0;
-  --footer-compliance-padding: 24px 0 8px 0;
+  --footer-links-padding: 1.5rem 0;
+  --footer-compliance-padding: 1.5rem 0 0.5rem 0;
   --footer-logo-margin-bottom: var(--ic-space-lg);
   --footer-link-inner-flex-direction: row;
 }
 
 :host(.footer-small) {
   --footer-links-padding: 0 0;
-  --footer-compliance-padding: 16px 0 8px;
+  --footer-compliance-padding: 1rem 0 0.5rem;
   --footer-logo-margin-bottom: var(--ic-space-md);
   --footer-link-inner-flex-direction: column;
 }
@@ -50,7 +50,7 @@ footer {
 }
 
 .footer-description-inner {
-  padding: 16px 0;
+  padding: 1rem 0;
 }
 
 /* Links */

--- a/packages/web-components/src/components/ic-hero/ic-hero.css
+++ b/packages/web-components/src/components/ic-hero/ic-hero.css
@@ -14,14 +14,14 @@
 
 :host(.has-background-image) {
   background-repeat: no-repeat;
-  background-position: right -100px;
-  background-size: auto calc(100% + 100px);
+  background-position: right -6.25rem;
+  background-size: auto calc(100% + 6.25rem);
   box-shadow: var(--ic-elevation-inset);
 }
 
 @media (prefers-reduced-motion) {
   :host(.has-background-image) {
-    background-position: right -100px !important;
+    background-position: right -6.25rem !important;
   }
 }
 
@@ -89,12 +89,12 @@ ic-typography.heading-bottom-spacing {
 @media (min-width: 1044px) {
   :host,
   .section-container {
-    min-height: 208px;
+    min-height: 13rem;
   }
 
   :host([small]),
   :host([small]) .section-container {
-    min-height: 173px;
+    min-height: 10.813rem;
   }
 
   .left-container:not(.left-container-full-width) {
@@ -102,21 +102,21 @@ ic-typography.heading-bottom-spacing {
   }
 
   .left-container {
-    min-height: 144px;
+    min-height: 9rem;
   }
 
   .right-container {
     flex-basis: 33.3%;
-    margin-left: 50px;
+    margin-left: 3.125rem;
   }
 
   .secondary-container {
-    min-height: 144px;
+    min-height: 9rem;
   }
 
   .secondary-heading,
   .secondary-subheading {
-    margin-left: 63px;
+    margin-left: 3.938rem;
   }
 }
 
@@ -127,34 +127,34 @@ ic-typography.heading-bottom-spacing {
 
   :host,
   .section-container {
-    min-height: 256px;
+    min-height: 16rem;
   }
 
   :host([small]),
   :host([small]) .section-container {
-    min-height: 240px;
+    min-height: 15rem;
   }
 
   :host([secondary-heading]),
   :host([secondary-heading]) .section-container {
-    min-height: 224px;
+    min-height: 14rem;
   }
 
   .left-container {
-    min-height: 160px;
+    min-height: 10rem;
   }
 
   .secondary-container {
-    min-height: 160px;
+    min-height: 10rem;
   }
 
   .secondary-heading,
   .secondary-subheading {
-    margin-left: 94.75px;
+    margin-left: 5.922rem;
   }
 
   .right-container {
-    margin-left: 50px;
+    margin-left: 3.125rem;
   }
 }
 
@@ -165,34 +165,34 @@ ic-typography.heading-bottom-spacing {
 
   :host,
   .section-container {
-    min-height: 256px;
+    min-height: 16rem;
   }
 
   :host([small]),
   :host([small]) .section-container {
-    min-height: 240px;
+    min-height: 15rem;
   }
 
   :host([secondary-heading]),
   :host([secondary-heading]) .section-container {
-    min-height: 224px;
+    min-height: 14rem;
   }
 
   .left-container {
-    min-height: 160px;
+    min-height: 10rem;
   }
 
   .secondary-container {
-    min-height: 160px;
+    min-height: 10rem;
   }
 
   .secondary-heading,
   .secondary-subheading {
-    margin-left: 34px;
+    margin-left: 2.125rem;
   }
 
   .right-container {
-    margin-left: 50px;
+    margin-left: 3.125rem;
   }
 }
 
@@ -203,17 +203,17 @@ ic-typography.heading-bottom-spacing {
 
   :host,
   .section-container {
-    min-height: 208px;
+    min-height: 13rem;
   }
 
   :host([small]),
   :host([small]) .section-container {
-    min-height: 173px;
+    min-height: 10.813rem;
   }
 
   :host([secondary-heading]),
   :host([secondary-heading]) .section-container {
-    min-height: 280px;
+    min-height: 17.5rem;
   }
 
   :host([secondary-heading]) .section-container,
@@ -233,7 +233,7 @@ ic-typography.heading-bottom-spacing {
   }
 
   .right-container {
-    margin-bottom: 40px;
+    margin-bottom: 2.5rem;
   }
 }
 
@@ -244,17 +244,17 @@ ic-typography.heading-bottom-spacing {
 
   :host,
   .section-container {
-    min-height: 192px;
+    min-height: 12rem;
   }
 
   :host([small]),
   :host([small]) .section-container {
-    min-height: 173px;
+    min-height: 10.813rem;
   }
 
   :host([secondary-heading]),
   :host([secondary-heading]) .section-container {
-    min-height: 264px;
+    min-height: 16.5rem;
   }
 
   :host([secondary-heading]) .section-container,

--- a/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
+++ b/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
@@ -4,12 +4,12 @@ ic-input-component-container {
    */
 
   display: flex;
-  border: 1px solid var(--border-color, var(--ic-architectural-400));
+  border: 0.063rem solid var(--border-color, var(--ic-architectural-400));
   border-radius: var(--ic-border-radius);
   transition: var(--ic-easing-transition-slow);
-  height: 40px;
-  width: var(--input-width, 320px);
-  padding: 1px;
+  height: 2.5rem;
+  width: var(--input-width, 20rem);
+  padding: 0.063rem;
   background-color: var(--ic-architectural-white);
   box-sizing: border-box;
   position: relative;
@@ -23,7 +23,7 @@ ic-input-component-container.fullwidth {
 
 ic-input-component-container.disabled,
 ic-input-component-container.disabled:hover {
-  border: 1px dashed var(--ic-architectural-200);
+  border: 0.063rem dashed var(--ic-architectural-200);
 }
 
 ic-input-component-container.readonly,
@@ -57,19 +57,19 @@ ic-input-component-container.multiline {
 
 ic-input-component-container .icon-container {
   margin-top: var(--ic-space-xxs);
-  margin-left: 7px;
+  margin-left: 0.438rem;
   display: flex;
   align-items: center;
 }
 
 ic-input-component-container.multiline .icon-container,
 ic-input-component-container.multiline.small .icon-container {
-  margin-top: 6px;
+  margin-top: 0.375rem;
   display: block;
 }
 
 ic-input-component-container.readonly .icon-container {
-  margin-left: -5px;
+  margin-left: -0.313rem;
 }
 
 ic-input-component-container.disabled ::placeholder {
@@ -77,7 +77,7 @@ ic-input-component-container.disabled ::placeholder {
 }
 
 ic-input-component-container .inline-success {
-  margin: var(--ic-space-xs) 6px;
+  margin: var(--ic-space-xs) 0.375rem;
   display: flex;
   align-items: center;
 }
@@ -98,8 +98,8 @@ ic-input-component-container:hover {
 .focus-indicator {
   display: flex;
   width: 100%;
-  margin: -2px;
-  padding: 2px;
+  margin: -0.125rem;
+  padding: 0.125rem;
   border-radius: var(--ic-border-radius);
   transition: var(--ic-easing-transition-fast);
 }
@@ -121,12 +121,12 @@ ic-input-component-container:hover {
   }
 
   ic-input-component-container:focus-within {
-    border: 1px solid Highlight;
-    outline: 2px solid Highlight;
+    border: 0.063rem solid Highlight;
+    outline: 0.125rem solid Highlight;
   }
 
   ic-input-component-container.disabled,
   ic-input-component-container.disabled:hover {
-    border: 1px dashed GrayText;
+    border: 0.063rem dashed GrayText;
   }
 }

--- a/packages/web-components/src/components/ic-input-validation/ic-input-validation.css
+++ b/packages/web-components/src/components/ic-input-validation/ic-input-validation.css
@@ -1,6 +1,6 @@
 ic-input-validation {
-  min-height: 28px;
-  width: var(--input-width, 320px);
+  min-height: 1.75rem;
+  width: var(--input-width, 20rem);
   margin-top: var(--ic-space-xxxs);
   display: flex;
 }
@@ -22,8 +22,8 @@ ic-input-validation span.status-icon {
 }
 
 ic-input-validation span.status-icon > svg {
-  height: 20px;
-  width: 20px;
+  height: 1.25rem;
+  width: 1.25rem;
 }
 
 ic-input-validation span.icon-success > svg {

--- a/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.css
+++ b/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.css
@@ -7,7 +7,7 @@
 
   display: block;
 
-  --linear-border-radius: 4px;
+  --linear-border-radius: 0.25rem;
   --inner-color: var(--ic-action-default);
   --outer-color: var(--ic-architectural-100);
   --label-color: var(--ic-color-primary-text);
@@ -29,23 +29,23 @@
 }
 
 :host([size="small"]) {
-  --circular-diameter: 40px;
+  --circular-diameter: 2.5rem;
   --linear-line-height: var(--ic-space-xxs);
 }
 
 :host([size="default"]) {
-  --circular-diameter: 80px;
+  --circular-diameter: 5rem;
 }
 
 :host([size="large"]) {
-  --circular-diameter: 120px;
+  --circular-diameter: 7.5rem;
 }
 
 :host([size="icon"]) {
   display: inline-block;
 
   --margin: var(--ic-space-xxxs);
-  --circular-diameter: 20px;
+  --circular-diameter: 1.25rem;
 }
 
 :host([label]) {

--- a/packages/web-components/src/components/ic-menu/ic-menu.css
+++ b/packages/web-components/src/components/ic-menu/ic-menu.css
@@ -9,7 +9,7 @@
 :host {
   border-radius: var(--ic-border-radius);
   max-height: 0;
-  width: var(--input-width, 320px);
+  width: var(--input-width, 20rem);
   color: var(--ic-color-primary-text);
   background-color: var(--ic-architectural-white);
   position: relative;
@@ -25,7 +25,7 @@
 .menu {
   text-decoration: none;
   list-style-type: none;
-  border: 1px solid var(--ic-architectural-400);
+  border: 0.063rem solid var(--ic-architectural-400);
   border-radius: var(--ic-border-radius);
   background-color: var(--ic-architectural-white);
   visibility: hidden;
@@ -48,7 +48,7 @@
 
 :host([open]) .menu {
   visibility: visible;
-  max-height: 322px;
+  max-height: 720.125rem;
 }
 
 :host(.full-width) {
@@ -56,7 +56,7 @@
 }
 
 .option {
-  padding: 8px 7px;
+  padding: 0.5rem 0.438rem;
   cursor: pointer;
   display: flex;
   justify-content: space-between;
@@ -64,15 +64,15 @@
 }
 
 :host([small]) .option {
-  padding: 4px 7px;
+  padding: 0.25rem 0.438rem;
 }
 
 .option:last-child {
-  border-radius: 0 0 1px 1px;
+  border-radius: 0 0 0.063rem 0.063rem;
 }
 
 .option:first-child {
-  border-radius: 1px 1px 0 0;
+  border-radius: 0.063rem 0.063rem 0 0;
 }
 
 .option:not(.disabled-option):hover {
@@ -96,8 +96,8 @@
 }
 
 .check-icon {
-  height: 24px;
-  margin-left: 8px;
+  height: 1.5rem;
+  margin-left: 0.5rem;
   pointer-events: none;
 }
 
@@ -106,16 +106,16 @@
 }
 
 .option-group-title {
-  padding: 24px 7px 8px;
+  padding: 1.5rem 0.438rem 0.5rem;
   color: var(--ic-color-tertiary-text);
 }
 
 :host([small]) .option-group-title {
-  padding: 12px 7px 4px;
+  padding: 0.75rem 0.438rem 0.25rem;
 }
 
 .last-recommended-option {
-  border-bottom: 1px solid var(--ic-architectural-400);
+  border-bottom: 0.063rem solid var(--ic-architectural-400);
 }
 
 .disabled-option {
@@ -141,6 +141,6 @@
 @media (forced-colors: active) {
   .focused-option:focus {
     outline: none;
-    border: 2px solid transparent;
+    border: 0.125rem solid transparent;
   }
 }

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
@@ -5,7 +5,7 @@
 }
 
 :host(.in-side-menu) {
-  border-bottom: 1px solid var(--ic-architectural-200);
+  border-bottom: 0.063rem solid var(--ic-architectural-200);
   padding: var(--ic-space-md) 0;
 }
 
@@ -24,13 +24,13 @@
 }
 
 :host(.in-side-menu) .navigation-group {
-  height: 40px;
+  height: 2.5rem;
   width: 100%;
   text-align: left;
 }
 
 :host(.in-side-menu) .navigation-group .ic-typography-label {
-  width: 190px;
+  width: 11.875rem;
 }
 
 :host(.in-side-menu) .navigation-group-side-menu {
@@ -124,12 +124,12 @@
 
 :host .navigation-group-dropdown {
   background-color: var(--ic-architectural-20);
-  border-bottom: 1px solid var(--ic-architectural-300);
+  border-bottom: 0.063rem solid var(--ic-architectural-300);
   position: absolute;
   left: 0;
   right: 0;
   padding: var(--ic-space-xs) var(--ic-space-md);
-  box-shadow: 0 6px 8px -6px rgba(0 0 0 / 20%);
+  box-shadow: 0 0.375rem 0.5rem -0.375rem rgba(0 0 0 / 20%);
 }
 
 :host .navigation-group-dropdown-items-list {
@@ -138,7 +138,7 @@
   flex-flow: column wrap;
   align-content: flex-start;
   padding-left: var(--ic-space-md);
-  max-height: 264px;
+  max-height: 16.5rem;
 }
 
 :host .chevron-toggle-icon-wrapper {

--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -47,7 +47,7 @@ ic-typography {
 :host(.navigation-item-selected) ::slotted(a.active)::after,
 :host(.navigation-item-top-nav) ::slotted(a.active)::after {
   content: "";
-  height: 4px;
+  height: 0.25rem;
   width: 100%;
   position: absolute;
   bottom: 0;
@@ -113,7 +113,7 @@ ic-typography {
 
 :host(.navigation-item-side-menu) .link,
 :host(.navigation-item-side-menu) ::slotted(a) {
-  height: 40px;
+  height: 2.5rem;
   width: 100%;
   color: var(--ic-color-primary-text);
   display: flex;
@@ -165,9 +165,9 @@ ic-typography {
 
 :host(.navigation-item-top-nav-child) .link,
 :host(.navigation-item-top-nav-child) ::slotted(a) {
-  height: 40px;
+  height: 2.5rem;
   width: fit-content;
-  min-width: 145px;
+  min-width: 9.063rem;
   color: var(--ic-color-primary-text);
   display: flex;
   align-items: center;
@@ -238,8 +238,8 @@ ic-typography {
   position: absolute;
   left: 0;
   width: var(--ic-space-xs);
-  height: 40px;
-  margin-right: 5px;
+  height: 2.5rem;
+  margin-right: 0.313rem;
   background-color: var(--ic-action-default);
   transition: left 0s;
 }
@@ -365,7 +365,7 @@ ic-typography {
   width: var(--navigation-group-width);
   color: var(--navigation-item-child-color) !important;
   display: flex;
-  gap: 10px;
+  gap: 0.625rem;
   box-sizing: border-box;
   min-width: 0;
   transition: box-shadow var(--ic-easing-transition-fast);
@@ -403,7 +403,7 @@ ic-typography {
 
 :host(.navigation-item-side-nav.navigation-item-selected) .link,
 :host(.navigation-item-side-nav.navigation-item) ::slotted(a.active) {
-  box-shadow: inset 5px 0 0 var(--ic-theme-text);
+  box-shadow: inset 0.313rem 0 0 var(--ic-theme-text);
 }
 
 :host(.navigation-item-side-nav.navigation-item-selected) .link::before,
@@ -413,8 +413,8 @@ ic-typography {
   position: absolute;
   top: 0;
   right: 0;
-  left: 5px;
-  border-radius: 11px !important;
+  left: 0.313rem;
+  border-radius: 0.688rem !important;
   bottom: 0;
   transition: var(--ic-easing-transition-slow);
 }
@@ -460,7 +460,7 @@ ic-typography {
 :host(.navigation-item-side-nav.navigation-item-selected) .link:focus,
 :host(.navigation-item-side-nav) ::slotted(a.active:focus) {
   margin: 0 auto;
-  box-shadow: inset 5px 0 0 var(--ic-theme-text);
+  box-shadow: inset 0.313rem 0 0 var(--ic-theme-text);
   border-radius: 0;
 }
 
@@ -471,7 +471,7 @@ ic-typography {
 :host(.navigation-item-page-header).link,
 :host(.navigation-item-page-header) a,
 :host(.navigation-item-page-header) ::slotted(a) {
-  height: 44px !important;
+  height: 2.75rem !important;
   color: var(--ic-color-primary-text) !important;
   transition: all var(--ic-easing-transition-fast) !important;
   box-shadow: rgba(23 89 188 / 0%) !important;

--- a/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.css
+++ b/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.css
@@ -14,7 +14,7 @@
   position: fixed;
   top: 0;
   right: 0;
-  width: 256px;
+  width: 16rem;
   bottom: 0;
   background-color: var(--ic-architectural-20);
   color: var(--ic-color-primary-text);
@@ -30,7 +30,7 @@
 
 .menu-close-button-container {
   position: relative;
-  left: 190px;
+  left: 11.875rem;
   padding: var(--ic-space-md) 0;
 }
 
@@ -40,12 +40,12 @@
 
 .menu-buttons-container {
   padding: var(--ic-space-sm) 0;
-  border-bottom: 1px solid var(--ic-architectural-200);
+  border-bottom: 0.063rem solid var(--ic-architectural-200);
 }
 
 .menu-buttons-container-nav-item-above {
   margin-top: var(--ic-space-md);
-  border-top: 1px solid var(--ic-architectural-200);
+  border-top: 0.063rem solid var(--ic-architectural-200);
 }
 
 .menu-status-version-container {
@@ -56,14 +56,14 @@
 .menu-status {
   background-color: var(--ic-architectural-500);
   color: var(--ic-color-white-text);
-  border-radius: 80px;
+  border-radius: 5rem;
   width: fit-content;
   padding: var(--ic-space-xxs) var(--ic-space-sm);
   margin-right: var(--ic-space-xs);
 }
 
 .menu-version {
-  border-radius: 16px;
+  border-radius: 1rem;
   background-color: var(--ic-architectural-100);
   padding: var(--ic-space-xxs) var(--ic-space-sm);
 }
@@ -73,14 +73,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 90px;
+  max-width: 5.625rem;
 }
 
 .navigation-landmark-text {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: 0.063rem;
+  height: 0.063rem;
   padding: 0;
-  margin: -1px;
+  margin: -0.063rem;
   overflow: hidden;
 }

--- a/packages/web-components/src/components/ic-page-header/ic-page-header.css
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.css
@@ -15,7 +15,7 @@ header {
 }
 
 header.border-bottom {
-  border-bottom: 1px solid var(--ic-architectural-300);
+  border-bottom: 0.063rem solid var(--ic-architectural-300);
 }
 
 header.tabs {
@@ -41,7 +41,7 @@ header.tabs {
   display: flex;
   flex-direction: column;
   flex: 1;
-  min-width: 304px;
+  min-width: 19rem;
   grid-area: title-area;
 }
 
@@ -83,8 +83,8 @@ header.tabs {
 .tabs-slot {
   display: flex;
   overflow-x: auto;
-  padding: 8px;
-  margin: -8px;
+  padding: 0.5rem;
+  margin: -0.5rem;
 }
 
 .input-area {
@@ -95,7 +95,7 @@ header.tabs {
   ::slotted(ic-text-field) {
     --input-width: 100%;
 
-    max-width: 320px;
+    max-width: 20rem;
   }
 
   .main-content {

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
@@ -8,7 +8,7 @@
 }
 
 :host([small]) {
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 
 :host([additional-field-display="static"]) ::slotted(ic-textfield) {
@@ -64,13 +64,13 @@
   position: relative;
   top: 0;
   left: 0;
-  height: var(--ic-space-lg);
-  width: var(--ic-space-lg);
+  height: 1.25rem;
+  width: 1.25rem;
   background-color: transparent;
-  border: 1px solid #a7acb3;
+  border: 0.063rem solid #a7acb3;
   border-radius: 50%;
   transition: var(--ic-easing-transition-fast);
-  box-sizing: border-box;
+  margin: 0 0.063rem;
 }
 
 /* Show the indicator (dot/circle) when checked */
@@ -81,22 +81,22 @@
 /* On mouse-over, add a light blue background color */
 .container:hover input ~ .checkmark {
   background-color: var(--ic-action-default-bg-hover);
-  box-shadow: 0 0 0 4px var(--ic-action-default-bg-hover);
-  border: 1px solid var(--ic-action-default);
+  box-shadow: 0 0 0 0.25rem var(--ic-action-default-bg-hover);
+  border: 0.063rem solid var(--ic-action-default);
 }
 
 /* When pressed, adds the active colours */
 .container:active input ~ .checkmark {
   background-color: var(--ic-action-default-bg-active);
-  border: 1px solid var(--ic-action-default-active);
-  box-shadow: 0 0 0 4px var(--ic-action-default-bg-active);
+  border: 0.063rem solid var(--ic-action-default-active);
+  box-shadow: 0 0 0 0.25rem var(--ic-action-default-bg-active);
 }
 
 /* When pressed, adds the active colours */
 .container:active input:checked ~ .checkmark {
   background-color: var(--ic-action-default-bg-active);
-  border: 2px solid var(--ic-action-default-active);
-  box-shadow: 0 0 0 4px var(--ic-action-default-bg-active);
+  border: 0.125rem solid var(--ic-action-default-active);
+  box-shadow: 0 0 0 0.25rem var(--ic-action-default-bg-active);
 }
 
 /* When pressed and selected, adds the active colours */
@@ -106,18 +106,19 @@
 
 /* When the radio button is checked */
 .container input:checked ~ .checkmark {
-  border: 2px solid var(--ic-action-default);
+  border: 0.125rem solid var(--ic-action-default);
+  margin: 0;
 }
 
 /* When the radio button is checked and disabled */
 .container input:checked:disabled ~ .checkmark {
   background-color: transparent;
-  border: 2px solid var(--ic-architectural-200);
+  border: 0.125rem solid var(--ic-architectural-200);
 }
 
 /* When the radio button is disabled */
 .container input:disabled ~ .checkmark {
-  border: 1px dashed var(--ic-architectural-200);
+  border: 0.063rem dashed var(--ic-architectural-200);
 }
 
 /* When the radio button is disabled */
@@ -129,7 +130,7 @@
 .container:hover input:disabled ~ .checkmark {
   background-color: transparent;
   box-shadow: none;
-  border: 2px solid none;
+  border: 0.125rem solid none;
 }
 
 .container:active input:disabled ~ .checkmark::after {
@@ -141,22 +142,22 @@
   content: "";
   position: absolute;
   display: none;
-  top: calc(50% - var(--ic-space-xs));
-  left: calc(50% - var(--ic-space-xs));
-  width: var(--ic-space-md);
-  height: var(--ic-space-md);
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1rem;
+  height: 1rem;
   border-radius: 50%;
   background: var(--ic-action-default);
 }
 
 .radio-label {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 400;
   margin-left: var(--ic-space-sm);
 }
 
 .addition-field-wrapper {
-  margin-left: 44px;
+  margin-left: 2.75rem;
 }
 
 /* The line */
@@ -164,10 +165,10 @@
   color: var(--ic-action-default);
   height: var(--ic-space-md);
   width: var(--ic-space-xl);
-  border-radius: 0 0 0 3px;
-  border-bottom: 2px solid var(--ic-action-default);
-  border-left: 2px solid var(--ic-action-default);
-  margin-left: -1px;
+  border-radius: 0 0 0 0.188rem;
+  border-bottom: 0.125rem solid var(--ic-action-default);
+  border-left: 0.125rem solid var(--ic-action-default);
+  margin-left: -0.063rem;
 }
 
 /* The dynamic container */
@@ -175,7 +176,7 @@
   display: flex;
   position: relative;
   margin-left: var(--ic-space-md);
-  margin-top: 6px;
+  margin-top: 0.375rem;
   gap: var(--ic-space-xs);
 }
 
@@ -185,7 +186,7 @@
 
 .dynamic-text {
   color: var(--ic-action-default);
-  margin-top: 5px;
+  margin-top: 0.313rem;
   margin-bottom: var(--ic-space-xs);
   border-radius: 2%;
 }

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
@@ -1,11 +1,11 @@
 @import "../../global/normalize.css";
 
 :host(.search) {
-  --divider-height: 24px;
+  --divider-height: 1.5rem;
 }
 
 :host(.search.small) {
-  --divider-height: 16px;
+  --divider-height: 1rem;
 }
 
 :host(.fullwidth) {
@@ -28,7 +28,7 @@
 
 .clear-button-container {
   align-items: center;
-  margin-right: 1px;
+  margin-right: 0.063rem;
   display: none;
   visibility: hidden;
 }
@@ -41,8 +41,8 @@
 
 .clear-button:focus {
   background-color: var(--ic-focus-blue);
-  box-shadow: inset 0 0 0 2px var(--ic-focus-glow);
-  border-radius: 4px;
+  box-shadow: inset 0 0 0 0.125rem var(--ic-focus-glow);
+  border-radius: 0.25rem;
 }
 
 .clear-button:focus * {
@@ -65,7 +65,7 @@
 
 .search-submit-button:focus {
   background-color: var(--ic-focus-blue) !important;
-  box-shadow: inset 0 0 0 2px var(--ic-focus-glow) !important;
+  box-shadow: inset 0 0 0 0.125rem var(--ic-focus-glow) !important;
   border-radius: var(--ic-space-xxs);
   height: var(--ic-space-xl);
   margin-top: var(--ic-space-xxxs);
@@ -76,7 +76,7 @@
 }
 
 .divider {
-  width: 1px;
+  width: 0.063rem;
   background-color: var(--ic-action-dark-active);
   height: var(--divider-height);
 }
@@ -86,7 +86,7 @@
 }
 
 .menu-container {
-  width: var(--input-width, 320px);
+  width: var(--input-width, 20rem);
   position: relative;
   top: var(--ic-space-xxxs);
 }
@@ -106,12 +106,12 @@ ic-menu {
 .search-results-status {
   border: 0;
   clip: rect(0, 0, 0, 0, 0);
-  height: 1px;
-  margin-bottom: -1px;
-  margin-right: -1px;
+  height: 0.063rem;
+  margin-bottom: -0.063rem;
+  margin-right: -0.063rem;
   overflow: hidden;
   padding: 0;
   position: absolute;
   white-space: nowrap;
-  width: 1px;
+  width: 0.063rem;
 }

--- a/packages/web-components/src/components/ic-select/assets/Expand.svg
+++ b/packages/web-components/src/components/ic-select/assets/Expand.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 <path d="M7 9.5L12 14.5L17 9.5H7Z" fill="currentColor" />
 </svg>

--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -44,10 +44,10 @@ select {
   letter-spacing: 0.005rem;
   width: 100%;
   height: 100%;
-  padding-left: 6px;
+  padding-left: 0.375rem;
   appearance: none;
   background-repeat: no-repeat;
-  background-position: right 6px center;
+  background-position: right 0.375rem center;
   background-image: url("data:image/svg+xml;utf8,<svg fill='black' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
 }
 
@@ -79,7 +79,7 @@ select:not([disabled]) {
 .select-input {
   width: 100%;
   height: 100%;
-  padding: 0 6px;
+  padding: 0 0.375rem;
   display: flex;
   cursor: pointer;
   align-items: center;
@@ -123,12 +123,12 @@ select:not([disabled]) {
 
 :host([searchable]) .expand-icon {
   padding-left: var(--ic-space-xxs);
-  height: 36px;
+  height: 2.25rem;
 }
 
 :host([searchable]) .expand-icon > svg {
-  height: 36px;
-  padding: 0 6px;
+  height: 2.25rem;
+  padding: 0 0.375rem;
 }
 
 :host([searchable]:not([disabled])) .expand-icon > svg {
@@ -161,18 +161,18 @@ select:not([disabled]) {
 .clear-button-container {
   display: flex;
   gap: var(--ic-space-xxs);
-  padding-left: 38px;
+  padding-left: 2.375rem;
 }
 
 :host([small]) .clear-button-container {
-  padding-left: 30px;
+  padding-left: 1.875rem;
 }
 
 .divider {
-  width: 1px;
+  width: 0.063rem;
   background-color: var(--ic-architectural-400);
   margin: var(--ic-space-xxs) 0;
-  border-radius: 1px;
+  border-radius: 0.063rem;
   height: var(--ic-space-lg);
 }
 
@@ -182,7 +182,7 @@ select:not([disabled]) {
 
 .clear-button {
   position: absolute;
-  right: 44px;
+  right: 2.75rem;
   border-radius: var(--ic-border-radius);
   transition: box-shadow var(--ic-easing-transition),
     border-radius var(--ic-easing-transition);
@@ -190,8 +190,8 @@ select:not([disabled]) {
 
 .clear-button:focus {
   background-color: var(--ic-focus-blue);
-  box-shadow: inset 0 0 0 2px var(--ic-focus-glow);
-  border-radius: 4px;
+  box-shadow: inset 0 0 0 0.125rem var(--ic-focus-glow);
+  border-radius: 0.25rem;
 }
 
 .clear-button:focus * {
@@ -201,10 +201,10 @@ select:not([disabled]) {
 .searchable-select-results-status {
   border: 0;
   clip: rect(0, 0, 0, 0, 0);
-  height: 1px;
+  height: 0.063rem;
   overflow: hidden;
   padding: 0;
   position: absolute;
   white-space: nowrap;
-  width: 1px;
+  width: 0.063rem;
 }

--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -116,6 +116,12 @@ select:not([disabled]) {
   color: var(--ic-action-dark);
 }
 
+.expand-icon > svg {
+  display: inline-block;
+  width: var(--ic-space-lg);
+  height: var(--ic-space-lg);
+}
+
 :host([disabled]) .expand-icon,
 :host([disabled]) .expand-icon > svg > path {
   color: var(--ic-architectural-200);

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -425,7 +425,7 @@
   }
 
   .app-title-wrapper ic-typography {
-    margin: calc(-1 * .281rem) 0 calc(-1 * .281rem) var(--ic-space-md);
+    margin: calc(-1 * 0.281rem) 0 calc(-1 * 0.281rem) var(--ic-space-md);
     font-weight: var(--ic-font-weight-semibold);
   }
 
@@ -487,6 +487,9 @@
   .bottom-side-nav .menu-expand-button svg {
     justify-items: flex-start;
     align-self: center;
+    display: inline-block;
+    width: var(--ic-space-lg);
+    height: var(--ic-space-lg);
   }
 
   .bottom-side-nav .menu-expand-button:hover {

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -5,12 +5,12 @@
   --side-navigation-position-left: 0;
   --side-navigation-position-top: var(--ic-space-xxl);
   --side-navigation-height: var(--ic-space-xxl);
-  --sm-side-navigation-top-bar-height: 56px;
-  --sm-side-navigation-collapsed-labels-width: 96px;
+  --sm-side-navigation-top-bar-height: 3.5rem;
+  --sm-side-navigation-collapsed-labels-width: 6rem;
   --sm-side-navigation-expand-transition-duration: var(
     --ic-transition-duration-slow
   );
-  --side-navigation-width: 320px;
+  --side-navigation-width: 20rem;
 }
 
 :host > * {
@@ -88,7 +88,7 @@
   bottom: 0;
   left: 0;
   z-index: 2;
-  box-shadow: -3px -3px 8px rgb(0 0 0 / 20%);
+  box-shadow: -0.188rem -0.188rem 0.5rem rgb(0 0 0 / 20%);
   background-color: var(--ic-theme-primary);
   display: flex;
   flex-direction: column;
@@ -203,7 +203,7 @@
 }
 
 .menu-button {
-  width: 104px;
+  width: 6.5rem;
 }
 
 .app-status-wrapper {
@@ -218,26 +218,26 @@
 }
 
 .app-status-wrapper .app-version {
-  max-width: 100px;
+  max-width: 6.25rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
 .app-status-wrapper .app-status {
-  border-radius: 80px;
+  border-radius: 5rem;
   background-color: var(--ic-theme-text);
   color: var(--ic-color-primary-text);
   padding: var(--ic-space-xxs) var(--ic-space-lg);
   margin-right: var(--ic-space-xs);
-  max-width: 100px;
+  max-width: 6.25rem;
 }
 
 .app-status-wrapper .app-status-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 96px;
+  max-width: 6rem;
 }
 
 :host(.dark) .app-status-wrapper .app-status {
@@ -246,32 +246,32 @@
 
 .navigation-landmark-title {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: 0.063rem;
+  height: 0.063rem;
   padding: 0;
-  margin: -1px;
+  margin: -0.063rem;
   overflow: hidden;
 }
 
 /* Navigation Group */
 
 ::slotted(ic-navigation-group) {
-  --navigation-group-height: 44px;
+  --navigation-group-height: 2.75rem;
   --navigation-group-width: 100%;
   --navigation-group-justify-content: space-between;
   --navigation-group-hover: var(--ic-theme-hover);
   --navigation-group-text-hover: var(--ic-theme-text);
-  --navigation-item-child-height: 56px;
+  --navigation-item-child-height: 3.5rem;
   --navigation-item-child-active: var(--ic-action-dark-bg-active);
   --navigation-item-child-color: var(--ic-theme-text);
-  --navigation-group-expand-toggle-padding: 4px;
+  --navigation-group-expand-toggle-padding: 0.25rem;
 }
 
 /* Navigation Items */
 
 ::slotted(ic-navigation-item),
 ::slotted(ic-navigation-group) {
-  --navigation-item-height: 56px;
+  --navigation-item-height: 3.5rem;
   --navigation-item-width: auto;
   --navigation-item-justify-content: flex-start;
 }
@@ -350,7 +350,7 @@
 
     position: relative;
     padding: 0;
-    box-shadow: -3px 3px 8px rgb(0 0 0 / 20%);
+    box-shadow: -0.188rem 0.188rem 0.5rem rgb(0 0 0 / 20%);
   }
 
   :host(.inline) .top-bar {
@@ -358,11 +358,11 @@
   }
 
   :host(.anchor-right) .top-bar {
-    box-shadow: 3px 3px 8px rgb(0 0 0 / 20%);
+    box-shadow: 0.188rem 0.188rem 0.5rem rgb(0 0 0 / 20%);
   }
 
   :host(.anchor-right) .bottom-wrapper {
-    box-shadow: 3px -3px 8px rgb(0 0 0 / 20%);
+    box-shadow: 0.188rem -0.188rem 0.5rem rgb(0 0 0 / 20%);
   }
 
   .side-navigation,
@@ -425,13 +425,13 @@
   }
 
   .app-title-wrapper ic-typography {
-    margin: calc(-1 * 4.5px) 0 calc(-1 * 4.5px) var(--ic-space-md);
+    margin: calc(-1 * .281rem) 0 calc(-1 * .281rem) var(--ic-space-md);
     font-weight: var(--ic-font-weight-semibold);
   }
 
   :host(.sm-collapsed) .app-title-wrapper ic-typography {
     position: absolute;
-    left: -9999px;
+    left: -624.938rem;
     opacity: 0;
     transition: opacity var(--ic-easing-transition-slow);
   }
@@ -537,14 +537,14 @@
 
   :host(.sm-collapsed) ::slotted(ic-navigation-group) {
     --navigation-group-title-position: absolute;
-    --navigation-group-title-position-left: -9999px;
+    --navigation-group-title-position-left: -624.938rem;
     --navigation-group-title-opacity: none;
   }
 
   :host(.sm-expanded) ::slotted(ic-navigation-group) {
     --navigation-group-title-position: relative;
     --navigation-group-title-position-left: 0;
-    --navigation-group-expand-toggle-padding: 4px;
+    --navigation-group-expand-toggle-padding: 0.25rem;
     --navigation-group-title-opacity: flex;
   }
 
@@ -566,7 +566,7 @@
     --navigation-group-justify-content: center;
     --navigation-item-label-opacity: 1;
     --navigation-group-item-min-width: 100%;
-    --navigation-group-expand-toggle-padding: 16px;
+    --navigation-group-expand-toggle-padding: 1rem;
   }
 
   :host(.collapsed-labels) .bottom-side-nav .menu-expand-button {

--- a/packages/web-components/src/components/ic-status-tag/ic-status-tag.css
+++ b/packages/web-components/src/components/ic-status-tag/ic-status-tag.css
@@ -2,10 +2,10 @@
 
 .tag {
   padding: var(--ic-space-xs) var(--ic-space-sm);
-  font-size: 14px;
-  border-radius: 80px;
+  font-size: 0.875rem;
+  border-radius: 5rem;
   display: inline-block;
-  min-width: 40px;
+  min-width: 2.5rem;
   text-align: center;
 }
 
@@ -36,25 +36,25 @@
 .outlined-neutral {
   background-color: var(--ic-architectural-200);
   color: var(--ic-color-secondary-text);
-  border: 1px solid var(--ic-architectural-400);
+  border: 0.063rem solid var(--ic-architectural-400);
 }
 
 .outlined-success {
   background-color: var(--ic-status-success-background);
   color: var(--ic-status-success);
-  border: 1px solid var(--ic-status-success);
+  border: 0.063rem solid var(--ic-status-success);
 }
 
 .outlined-warning {
   background-color: var(--ic-status-warning-background);
   color: var(--ic-status-warning-dark);
-  border: 1px solid var(--ic-status-warning-dark);
+  border: 0.063rem solid var(--ic-status-warning-dark);
 }
 
 .outlined-danger {
   background-color: var(--ic-status-error-background);
   color: var(--ic-status-error);
-  border: 1px solid var(--ic-status-error);
+  border: 0.063rem solid var(--ic-status-error);
 }
 
 @media (forced-colors: active) {

--- a/packages/web-components/src/components/ic-step/ic-step.css
+++ b/packages/web-components/src/components/ic-step/ic-step.css
@@ -181,6 +181,7 @@
   border: var(--ic-space-xxxs) solid var(--ic-theme-primary);
   padding: var(--ic-space-xxxs);
   margin: 0 calc(-1 * var(--ic-space-xxxs));
+
   /* compensating for the circle being bigger than other steps */
 }
 

--- a/packages/web-components/src/components/ic-step/ic-step.css
+++ b/packages/web-components/src/components/ic-step/ic-step.css
@@ -23,10 +23,10 @@
 
 .visually-hidden {
   position: absolute;
-  left: -10000px;
+  left: -625rem;
   top: auto;
-  width: 1px;
-  height: 1px;
+  width: 0.063rem;
+  height: 0.063rem;
   overflow: hidden;
 }
 
@@ -55,7 +55,7 @@
 :host(.compact) .step-title-area {
   display: flex;
   flex-direction: column;
-  width: 228px;
+  width: 14.25rem;
 }
 
 .info-line {
@@ -87,8 +87,8 @@
 }
 
 :host(.compact) .step-icon svg {
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
 }
 
 /* DEFAULT STEP STYLING */
@@ -105,7 +105,7 @@
   width: 100%;
   align-items: center;
   align-self: flex-start;
-  height: 40px;
+  height: 2.5rem;
 }
 
 :host(.default) .step-icon {
@@ -149,7 +149,7 @@
 }
 
 .active .step-icon-inner {
-  box-shadow: inset var(--ic-architectural-200) 0 0 0 2px;
+  box-shadow: inset var(--ic-architectural-200) 0 0 0 0.125rem;
 }
 
 .current .step-icon-inner {
@@ -162,7 +162,7 @@
 }
 
 .disabled .step-icon-inner {
-  border: 1px dashed var(--ic-architectural-200);
+  border: 0.063rem dashed var(--ic-architectural-200);
   width: calc(var(--ic-space-xl) - var(--ic-space-xxxs));
   height: calc(var(--ic-space-xl) - var(--ic-space-xxxs));
 }
@@ -193,14 +193,14 @@
 }
 
 .aligned-full-width.step-connect {
-  min-width: 100px;
+  min-width: 6.25rem;
   width: 100%;
 }
 
 .disabled .step-connect {
   height: 0;
   background-color: rgb(0 0 0 / 0%);
-  border-top: 2px dashed var(--ic-architectural-200);
+  border-top: 0.125rem dashed var(--ic-architectural-200);
   border-radius: 0;
 }
 
@@ -246,7 +246,7 @@
   .completed .step-icon-inner,
   .current .step-icon-inner {
     forced-color-adjust: none;
-    box-shadow: inset canvastext 0 0 0 2px;
+    box-shadow: inset canvastext 0 0 0 0.125rem;
     background-color: transparent;
     color: canvastext;
   }

--- a/packages/web-components/src/components/ic-stepper/__snapshots__/ic-stepper.spec.ts.snap
+++ b/packages/web-components/src/components/ic-stepper/__snapshots__/ic-stepper.spec.ts.snap
@@ -408,7 +408,7 @@ exports[`default variant of ic-stepper component should add the className 'last-
       <slot></slot>
     </ul>
   </mock:shadow-root>
-  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="completed step">
         <div class="step-top">
@@ -429,7 +429,7 @@ exports[`default variant of ic-stepper component should add the className 'last-
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="current step">
         <div class="step-top">
@@ -452,7 +452,7 @@ exports[`default variant of ic-stepper component should add the className 'last-
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="active step">
         <div class="step-top">
@@ -503,7 +503,7 @@ exports[`default variant of ic-stepper component should ignore the connectorWidt
       <slot></slot>
     </ul>
   </mock:shadow-root>
-  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="completed step">
         <div class="step-top">
@@ -524,7 +524,7 @@ exports[`default variant of ic-stepper component should ignore the connectorWidt
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="current step">
         <div class="step-top">
@@ -547,7 +547,7 @@ exports[`default variant of ic-stepper component should ignore the connectorWidt
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="active step">
         <div class="step-top">
@@ -598,7 +598,7 @@ exports[`default variant of ic-stepper component should render a full-width step
       <slot></slot>
     </ul>
   </mock:shadow-root>
-  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="completed step">
         <div class="step-top">
@@ -619,7 +619,7 @@ exports[`default variant of ic-stepper component should render a full-width step
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="current step">
         <div class="step-top">
@@ -642,7 +642,7 @@ exports[`default variant of ic-stepper component should render a full-width step
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="active step">
         <div class="step-top">
@@ -707,7 +707,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
       <slot></slot>
     </ul>
   </mock:shadow-root>
-  <ic-step aria-label="Step 1. Completed step" class="default" role="listitem" step-title="Create" step-type="completed" style="width: 198px;">
+  <ic-step aria-label="Step 1. Completed step" class="default" role="listitem" step-title="Create" step-type="completed" style="width: 12.375rem;">
     <mock:shadow-root>
       <div class="completed step">
         <div class="step-top">
@@ -718,7 +718,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
               </span>
             </div>
           </div>
-          <div class="step-connect" style="width: 150px;"></div>
+          <div class="step-connect" style="width: 9.375rem;"></div>
         </div>
         <div class="step-title-area">
           <ic-typography class="step-title" variant="subtitle-large">
@@ -728,7 +728,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-current="step" aria-label="Step 2" class="default" role="listitem" step-title="Read" step-type="current" style="width: 198px;">
+  <ic-step aria-current="step" aria-label="Step 2" class="default" role="listitem" step-title="Read" step-type="current" style="width: 12.375rem;">
     <mock:shadow-root>
       <div class="current step">
         <div class="step-top">
@@ -739,7 +739,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
               </span>
             </ic-typography>
           </div>
-          <div class="step-connect" style="width: 150px;">
+          <div class="step-connect" style="width: 9.375rem;">
             <div class="step-connect-inner"></div>
           </div>
         </div>
@@ -751,7 +751,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 3" class="default" role="listitem" step-title="Update" style="width: 198px;">
+  <ic-step aria-label="Step 3" class="default" role="listitem" step-title="Update" style="width: 12.375rem;">
     <mock:shadow-root>
       <div class="active step">
         <div class="step-top">
@@ -762,7 +762,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
               </span>
             </ic-typography>
           </div>
-          <div class="step-connect" style="width: 150px;"></div>
+          <div class="step-connect" style="width: 9.375rem;"></div>
         </div>
         <div class="step-title-area">
           <ic-typography class="step-title" variant="subtitle-large">
@@ -772,7 +772,7 @@ exports[`default variant of ic-stepper component should render a stepper with a 
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 4" class="default last-step" role="listitem" step-title="Delete" style="max-width: 198px; width: 198px;">
+  <ic-step aria-label="Step 4" class="default last-step" role="listitem" step-title="Delete" style="max-width: 12.375rem; width: 12.375rem;">
     <mock:shadow-root>
       <div class="active step">
         <div class="step-top">
@@ -802,7 +802,7 @@ exports[`default variant of ic-stepper component should render a stepper with hi
       <slot></slot>
     </ul>
   </mock:shadow-root>
-  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-title="Create" step-type="completed" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="completed step">
         <div class="step-top">
@@ -823,7 +823,7 @@ exports[`default variant of ic-stepper component should render a stepper with hi
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-title="Read" step-type="current" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="current step">
         <div class="step-top">
@@ -846,7 +846,7 @@ exports[`default variant of ic-stepper component should render a stepper with hi
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 3" class="aligned-full-width default" role="listitem" step-title="Update" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="active step">
         <div class="step-top">
@@ -897,7 +897,7 @@ exports[`default variant of ic-stepper component should render a stepper without
       <slot></slot>
     </ul>
   </mock:shadow-root>
-  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-type="completed" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 1. Completed step" class="aligned-full-width default" role="listitem" step-type="completed" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="completed step">
         <div class="step-top">
@@ -913,7 +913,7 @@ exports[`default variant of ic-stepper component should render a stepper without
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-type="current" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-current="step" aria-label="Step 2" class="aligned-full-width default" role="listitem" step-type="current" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="current step">
         <div class="step-top">
@@ -931,7 +931,7 @@ exports[`default variant of ic-stepper component should render a stepper without
       </div>
     </mock:shadow-root>
   </ic-step>
-  <ic-step aria-label="Step 3. Non-required step" class="aligned-full-width default" role="listitem" step-type="disabled" style="width: NaNpx; min-width: 148px;">
+  <ic-step aria-label="Step 3. Non-required step" class="aligned-full-width default" role="listitem" step-type="disabled" style="width: NaNrem; min-width: 9.25rem;">
     <mock:shadow-root>
       <div class="disabled step">
         <div class="step-top">

--- a/packages/web-components/src/components/ic-stepper/ic-stepper.tsx
+++ b/packages/web-components/src/components/ic-stepper/ic-stepper.tsx
@@ -95,10 +95,15 @@ export class Stepper {
 
     if (this.alignedFullWidth) {
       this.stepperWidth = this.el.offsetWidth;
-      lastStep.style.maxWidth = `${this.stepperWidth / this.steps.length}px`;
+      lastStep.style.maxWidth = this.pxToRem(`${this.stepperWidth / this.steps.length}px`);
       this.lastStepWidth = lastStep.offsetWidth;
     }
   };
+
+  private pxToRem = (px: string, base = 16) => {
+    const tempPx = parseInt(px)
+    return (1 / base) * tempPx + 'rem'
+  }
 
   private initialiseStepStates = (): void => {
     this.steps.forEach((step, index) => {
@@ -172,10 +177,10 @@ export class Stepper {
       if (this.variant === "default") {
         if (!step.lastStep) {
           if (this.alignedFullWidth) {
-            step.style.width = `${
+            step.style.width = this.pxToRem(`${
               (this.stepperWidth - this.lastStepWidth) / (this.steps.length - 1)
-            }px`;
-            step.style.minWidth = "148px";
+            }px`);
+            step.style.minWidth = this.pxToRem("148px");
           }
         } else if (step.lastStep) {
           step.classList.add("last-step");
@@ -184,23 +189,23 @@ export class Stepper {
           } else {
             step.style.maxWidth =
               this.connectorWidth > 100
-                ? `${this.connectorWidth + 48}px`
-                : "148px";
+                ? this.pxToRem(`${this.connectorWidth + 48}px`)
+                : this.pxToRem("148px");
           }
         }
 
         if (this.aligned === "left") {
           step.style.width =
             this.connectorWidth > 100
-              ? `${this.connectorWidth + 48}px`
-              : "148px";
+              ? this.pxToRem(`${this.connectorWidth + 48}px`)
+              : this.pxToRem("148px");
           const stepConnect = step.shadowRoot.querySelector(
             ".step > .step-top > .step-connect"
           ) as HTMLElement;
 
           if (stepConnect) {
             stepConnect.style.width =
-              this.connectorWidth > 100 ? `${this.connectorWidth}px` : "100px";
+              this.connectorWidth > 100 ? this.pxToRem(`${this.connectorWidth}px`) : this.pxToRem("100px");
           }
         }
 

--- a/packages/web-components/src/components/ic-switch/ic-switch.css
+++ b/packages/web-components/src/components/ic-switch/ic-switch.css
@@ -23,19 +23,19 @@ input {
 }
 
 .ic-switch-label-small {
-  margin-bottom: 10px;
+  margin-bottom: 0.625rem;
 }
 
 .ic-switch-toggle {
   display: flex;
   align-items: center;
   justify-content: space-around;
-  width: 64px;
+  width: 4rem;
   height: var(--ic-space-xl);
   position: relative;
   border-radius: 100vw;
   background-color: var(--ic-architectural-200);
-  border: 1px solid var(--ic-architectural-700);
+  border: 0.063rem solid var(--ic-architectural-700);
   box-sizing: border-box;
   transition: var(--ic-transition-duration-fast);
 }
@@ -50,13 +50,13 @@ input {
 
 .ic-switch-toggle::before {
   content: "";
-  width: 21.33px;
-  height: 21.33px;
+  width: 1.333rem;
+  height: 1.333rem;
   border-radius: 50%;
   position: absolute;
   z-index: 2;
   top: 50%;
-  left: 5.33px;
+  left: 0.333rem;
   transform: translate(0, -50%);
   background-color: var(--ic-architectural-700);
   transition: var(--ic-transition-duration-slow);
@@ -65,8 +65,8 @@ input {
 .ic-switch-icon {
   display: inline-block;
   vertical-align: middle;
-  width: 10px;
-  height: 10px;
+  width: 0.625rem;
+  height: 0.625rem;
 }
 
 .ic-switch-icon-circle,
@@ -99,26 +99,26 @@ input {
 }
 
 .ic-switch-input:not([disabled]) + .ic-switch-toggle:hover::before {
-  box-shadow: 0 0 0 12px var(--ic-action-dark-bg-hover);
+  box-shadow: 0 0 0 0.75rem var(--ic-action-dark-bg-hover);
 }
 
 .ic-switch-input:not([disabled]) + .ic-switch-toggle:active::before {
-  box-shadow: 0 0 0 12px var(--ic-action-dark-bg-active);
+  box-shadow: 0 0 0 0.75rem var(--ic-action-dark-bg-active);
 }
 
 .ic-switch-input:not([disabled]):checked + .ic-switch-toggle:hover::before {
-  box-shadow: 0 0 0 12px var(--ic-action-default-bg-hover);
+  box-shadow: 0 0 0 0.75rem var(--ic-action-default-bg-hover);
 }
 
 .ic-switch-input:not([disabled]):checked + .ic-switch-toggle:active::before {
-  box-shadow: 0 0 0 12px var(--ic-action-default-bg-active);
+  box-shadow: 0 0 0 0.75rem var(--ic-action-default-bg-active);
 }
 
 .ic-switch-input:focus:not([disabled]) + .ic-switch-toggle,
 .ic-switch-input:focus-visible:not([disabled]) + .ic-switch-toggle {
-  box-shadow: 0 0 0 1px var(--ic-architectural-white),
-    0 0 0 3px var(--ic-action-default),
-    0 0 0 8px var(--ic-action-default-active-alpha);
+  box-shadow: 0 0 0 0.063rem var(--ic-architectural-white),
+    0 0 0 0.188rem var(--ic-action-default),
+    0 0 0 0.5rem var(--ic-action-default-active-alpha);
 }
 
 .ic-switch-disabled {
@@ -135,7 +135,7 @@ input {
 
 .ic-switch-input:disabled + .ic-switch-toggle {
   background-color: var(--ic-architectural-80);
-  border: 1px dashed var(--ic-architectural-300);
+  border: 0.063rem dashed var(--ic-architectural-300);
 }
 
 .ic-switch-input:disabled ~ .ic-switch-checked-status {
@@ -148,7 +148,7 @@ input {
 
 .ic-switch-input:disabled:checked + .ic-switch-toggle {
   background-color: var(--ic-status-info-background);
-  border: 1px dashed #98c9f5;
+  border: 0.063rem dashed #98c9f5;
 }
 
 .ic-switch-input:disabled:checked + .ic-switch-toggle::before {
@@ -160,7 +160,7 @@ input {
 }
 
 .ic-switch-small .ic-switch-checked-status {
-  padding-left: 6px;
+  padding-left: 0.375rem;
 }
 
 .ic-switch-small .ic-switch-toggle {
@@ -193,7 +193,7 @@ input {
   }
 
   .ic-switch-input:checked + .ic-switch-toggle::before {
-    transform: translate(calc(var(--ic-space-xl) - 2px), -50%);
+    transform: translate(calc(var(--ic-space-xl) - 0.125rem), -50%);
   }
 
   .ic-switch-input:disabled + .ic-switch-toggle,

--- a/packages/web-components/src/components/ic-tab-group/ic-tab-group.css
+++ b/packages/web-components/src/components/ic-tab-group/ic-tab-group.css
@@ -66,8 +66,8 @@
 
 .scroll-arrow {
   display: flex;
-  width: 36px;
-  height: 36px;
+  width: 2.25rem;
+  height: 2.25rem;
   margin: var(--ic-space-xxs) var(--ic-space-xxxs);
   align-items: center;
   justify-content: center;
@@ -107,8 +107,8 @@
 .scroll-splitter-right {
   display: flex;
   height: var(--ic-space-lg);
-  width: 1px;
-  margin-top: 10px;
+  width: 0.063rem;
+  margin-top: 0.625rem;
   background-color: var(--splitter-color);
 }
 
@@ -128,7 +128,7 @@
 .ic-tab-splitter {
   display: block;
   background-color: var(--border-bottom-color);
-  height: 1px;
+  height: 0.063rem;
   right: 0;
   left: 0;
   margin-left: var(--ic-space-xs);

--- a/packages/web-components/src/components/ic-tab/ic-tab.css
+++ b/packages/web-components/src/components/ic-tab/ic-tab.css
@@ -12,7 +12,7 @@
   align-items: center;
   border-radius: 0;
   color: var(--label-color);
-  height: 40px;
+  height: 2.5rem;
   padding: 0 var(--ic-space-md);
   cursor: pointer;
   position: relative;

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.css
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.css
@@ -27,7 +27,7 @@ textarea {
 textarea {
   min-height: var(--ic-space-lg);
   resize: vertical;
-  padding-top: 6px;
+  padding-top: 0.375rem;
 }
 
 input:focus,

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
@@ -4,10 +4,10 @@
   background-color: var(--ic-architectural-800);
   color: #ffff;
   text-align: center;
-  padding: var(--ic-space-xxxs) 10px;
+  padding: var(--ic-space-xxxs) 0.625rem;
   border-radius: var(--ic-border-radius);
   position: absolute;
-  max-width: 320px;
+  max-width: 20rem;
   display: none;
   z-index: calc(var(--ic-z-index-overlay) / 2);
   box-shadow: var(--ic-elevation-overlay);
@@ -88,7 +88,7 @@
 :host(.ic-tooltip)
   .ic-tooltip-container[data-popper-placement^="right"]
   > .ic-tooltip-arrow {
-  left: -14px;
+  left: -0.875rem;
 }
 
 :host(.ic-tooltip)

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -67,12 +67,12 @@
 
 .top-panel-container {
   display: flex;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .navigation-tabs {
-  margin-top: -1px;
+  margin-top: -0.063rem;
 }
 
 .app-details-container {
@@ -108,7 +108,7 @@
 }
 
 :host .app-status {
-  border-radius: 80px;
+  border-radius: 5rem;
   background-color: var(--ic-architectural-white);
   color: var(--ic-color-primary-text);
   padding: var(--ic-space-xxs) var(--ic-space-lg);
@@ -121,7 +121,7 @@
 }
 
 :host .app-version {
-  border-radius: 16px;
+  border-radius: 1rem;
   background-color: var(--ic-theme-active);
   padding: var(--ic-space-xxs) var(--ic-space-sm);
   margin-left: var(--ic-space-xs);
@@ -132,7 +132,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 96px;
+  max-width: 6rem;
 }
 
 slot[name="app-icon"]::slotted(svg) {
@@ -167,17 +167,17 @@ slot[name="toggle-icon"] svg {
 
 .navigation-landmark-text {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: 0.063rem;
+  height: 0.063rem;
   padding: 0;
-  margin: -1px;
+  margin: -0.063rem;
   overflow: hidden;
 }
 
 .navigation-item-list {
   display: flex;
   list-style: none;
-  height: 44px;
+  height: 2.75rem;
 }
 
 :host([content-aligned="left"]) .app-details-container {
@@ -236,7 +236,7 @@ slot[name="toggle-icon"] svg {
   }
 
   .search-menu-container {
-    max-width: 160px;
+    max-width: 10rem;
   }
 
   .search-bar-container {
@@ -244,7 +244,7 @@ slot[name="toggle-icon"] svg {
     justify-content: center;
     align-items: center;
     border-top: var(--ic-keyline-darken);
-    height: 64px;
+    height: 4rem;
     padding-left: var(--ic-space-md);
     padding-right: var(--ic-space-md);
     margin-left: calc(-1 * var(--section-container-margin));
@@ -268,7 +268,7 @@ slot[name="toggle-icon"] svg {
   }
 
   .top-panel-container {
-    min-height: 40px;
+    min-height: 2.5rem;
   }
 
   .searchbox-inline {
@@ -277,7 +277,7 @@ slot[name="toggle-icon"] svg {
 
   .search-bar-container {
     margin-top: 0;
-    height: 56px;
+    height: 3.5rem;
     padding-left: var(--ic-space-xs);
     padding-right: var(--ic-space-xs);
   }

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -370,9 +370,7 @@ export class TopNavigation {
                             <slot name="toggle-icon" slot="icon">
                               <svg
                                 xmlns="http://www.w3.org/2000/svg"
-                                height="24px"
                                 viewBox="0 0 24 24"
-                                width="24px"
                                 fill="#ffffff"
                               >
                                 <path d="M0 0h24v24H0V0z" fill="none" />


### PR DESCRIPTION
## Summary of the changes
Most px values have been converted to rem, the normalize.css, variables.css and screen breakpoints have not been changed.
Checkbox has an added viewBox rule to stop skewing when checked.
Stepper has a function to convert px to rem in the alignment rules.

## Related issue
#290 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 