### PR TITLE
add width: 100% to select host to fix full width not working with flex

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -4,6 +4,10 @@
    * @prop --input-width: Width of the input field
 */
 
+:host {
+  width: 100%;
+}
+
 ic-input-component-container:hover {
   --border-color: var(--ic-action-dark-hover);
 }

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.css
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.css
@@ -5,6 +5,7 @@
    * @prop --input-width: Width of the input field 
    */
   display: block;
+  width: 100%;
 }
 
 ::placeholder {

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
@@ -294,31 +294,32 @@ import readme from "./readme.md";
 <Canvas>
   <Story name="Full width">
     {(args) =>
-      html`
-        <ic-text-field
-          full-width="true"
-          value="Arabica"
-          max-length="25"
-          label="What is your favourite coffee?"
-          small
-          required="true"
-          placeholder="Placeholder"
-          helper-text="Such as Arabica, Robusta or Liberica"
-        >
-          <svg
-            slot="icon"
-            xmlns="http://www.w3.org/2000/svg"
-            height="24px"
-            viewBox="0 0 24 24"
-            width="24px"
-            fill="#000000"
+      html`<div style="display: flex">
+          <ic-text-field
+            full-width="true"
+            value="Arabica"
+            max-length="25"
+            label="What is your favourite coffee?"
+            small
+            required="true"
+            placeholder="Placeholder"
+            helper-text="Such as Arabica, Robusta or Liberica"
           >
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path
-              d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-            />
-          </svg>
-        </ic-text-field>
+            <svg
+              slot="icon"
+              xmlns="http://www.w3.org/2000/svg"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+              fill="#000000"
+            >
+              <path d="M0 0h24v24H0z" fill="none" />
+              <path
+                d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </ic-text-field>
+        </div>
         <ic-text-field
           full-width="true"
           rows="6"
@@ -344,8 +345,7 @@ import readme from "./readme.md";
               d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
             />
           </svg>
-        </ic-text-field>
-      `
+        </ic-text-field> `
     }
   </Story>
 </Canvas>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add width: 100% to select and text field host to fix full width not working when wrapped in display:flex

To test, wrap the full width example in 
`<div style='display: flex'></div>`

## Related issue
#315

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 