### PR TITLE
feat(react): enchances slottedsvg component

### DIFF
--- a/packages/react/src/react-component-lib/slottedSVG.tsx
+++ b/packages/react/src/react-component-lib/slottedSVG.tsx
@@ -8,8 +8,9 @@ function slot(name = "") {
   return { ref: (e: any) => (e ? e.setAttribute("slot", name) : null) };
 }
 
-export const SlottedSVG: FC<any> = ({ props, path, slot: slotName }) => (
-  <svg {...slot(slotName)} {...props} {...defaultProps}>
-    <path d={path} />
+export const SlottedSVG: FC<any> = ({ path, slot: slotName, children, ...props}) => (
+  <svg {...slot(slotName)} {...props} {...defaultProps} >
+    {!!path && <path d={path} />}
+    {children}
   </svg>
 );


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Now possible to pass child elements to the component as an alternative to path prop

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 