### PR TITLE
Change reverse order functionality so it only works when the action slot is used

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -14006,18 +14006,18 @@
       "dev": true
     },
     "node_modules/@ukic/fonts": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.5.tgz",
-      "integrity": "sha512-J8jRhv27Y6208OsQxflEIbENRswkbNAKcKydOtq9xMFMzx5XkO2GD3qRwG9nhHoecGhW3KD4KwVgLtOgHvpU7w=="
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.6.tgz",
+      "integrity": "sha512-aLMk8Wn5mHgh/gGSKBg1v5sXbfgIqEL68S+YZuivKI/e2PkreJ735zW5ez770qWXkJr1d8uBNxgsEePdLL7gfw=="
     },
     "node_modules/@ukic/web-components": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.1.0-beta.5.tgz",
-      "integrity": "sha512-OtHAoBOpGr71V6+U8GfCpRFMUjGj1uYfH4A6tNJVFKtWfqWPz8w9v1fnXkuP6qGwWHPemID7zgmFPrPLIILNjw==",
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.1.0-beta.6.tgz",
+      "integrity": "sha512-bExjr0njVIH327VIE76SOINgGcdviubA6BFf9eJhlzNvh4fXKfa4sgVgMnogy3ECr8U/Z3R0YW3juh7ZIzhZfA==",
       "dependencies": {
         "@popperjs/core": "^2.11.2",
         "@stencil/core": "^2.16.1",
-        "@ukic/fonts": "^2.1.0-beta.5"
+        "@ukic/fonts": "^2.1.0-beta.6"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -44714,18 +44714,18 @@
       "dev": true
     },
     "@ukic/fonts": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.5.tgz",
-      "integrity": "sha512-J8jRhv27Y6208OsQxflEIbENRswkbNAKcKydOtq9xMFMzx5XkO2GD3qRwG9nhHoecGhW3KD4KwVgLtOgHvpU7w=="
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.6.tgz",
+      "integrity": "sha512-aLMk8Wn5mHgh/gGSKBg1v5sXbfgIqEL68S+YZuivKI/e2PkreJ735zW5ez770qWXkJr1d8uBNxgsEePdLL7gfw=="
     },
     "@ukic/web-components": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.1.0-beta.5.tgz",
-      "integrity": "sha512-OtHAoBOpGr71V6+U8GfCpRFMUjGj1uYfH4A6tNJVFKtWfqWPz8w9v1fnXkuP6qGwWHPemID7zgmFPrPLIILNjw==",
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.1.0-beta.6.tgz",
+      "integrity": "sha512-bExjr0njVIH327VIE76SOINgGcdviubA6BFf9eJhlzNvh4fXKfa4sgVgMnogy3ECr8U/Z3R0YW3juh7ZIzhZfA==",
       "requires": {
         "@popperjs/core": "^2.11.2",
         "@stencil/core": "^2.16.1",
-        "@ukic/fonts": "^2.1.0-beta.5"
+        "@ukic/fonts": "^2.1.0-beta.6"
       }
     },
     "@webassemblyjs/ast": {

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -9351,9 +9351,9 @@
       "dev": true
     },
     "node_modules/@ukic/fonts": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.5.tgz",
-      "integrity": "sha512-J8jRhv27Y6208OsQxflEIbENRswkbNAKcKydOtq9xMFMzx5XkO2GD3qRwG9nhHoecGhW3KD4KwVgLtOgHvpU7w=="
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.6.tgz",
+      "integrity": "sha512-aLMk8Wn5mHgh/gGSKBg1v5sXbfgIqEL68S+YZuivKI/e2PkreJ735zW5ez770qWXkJr1d8uBNxgsEePdLL7gfw=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -34305,9 +34305,9 @@
       "dev": true
     },
     "@ukic/fonts": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.5.tgz",
-      "integrity": "sha512-J8jRhv27Y6208OsQxflEIbENRswkbNAKcKydOtq9xMFMzx5XkO2GD3qRwG9nhHoecGhW3KD4KwVgLtOgHvpU7w=="
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.6.tgz",
+      "integrity": "sha512-aLMk8Wn5mHgh/gGSKBg1v5sXbfgIqEL68S+YZuivKI/e2PkreJ735zW5ez770qWXkJr1d8uBNxgsEePdLL7gfw=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",

--- a/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
@@ -69,7 +69,7 @@ export class PageHeader {
   private resizeObserver: ResizeObserver = null;
 
   private resizeObserverCallback = () => {
-    if (this.reverseOrder) {
+    if (this.reverseOrder && isSlotUsed(this.el, "actions")) {
       this.applyReverseOrder();
     }
   };


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add condition that checks if actions slot is being used before running the reverseOrder function.
This is to prevent the console error that appears when the reverseOrder prop is used but the actions
slot is empty

Update package-locks

## Related issue
#354

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 