### PR TITLE
build(root): sets PR target to develop if set to main

### DIFF
--- a/.github/workflows/check-pr-target.yml
+++ b/.github/workflows/check-pr-target.yml
@@ -1,7 +1,7 @@
 name: Prevent PRs to main
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 jobs:
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Vankka/pr-target-branch-action@v2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           target: main
           exclude: develop # Don't prevent going from develop -> main
+          change-to: develop
+          comment: |
+            Your PR was set to target `main`, PRs should be target `develop`
+            The base branch of this PR has been automatically changed to `develop`, please check that there are no merge conflicts


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Changes PR target to develop if it is incorrectly set to main. This means that any dependabot PRs will automatically get changed to develop

## Related issue
#2 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 