### PR TITLE
Allow use of gatsby or any slotted links for app title link in top nav

### DIFF
--- a/packages/react/src/stories/ic-top-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-top-navigation.stories.mdx
@@ -476,7 +476,10 @@ export const DailyTippers = () => (
       ),
     ]}
   >
-    <IcTopNavigation appTitle="ApplicationName" status="alpha" version="v0.0.7">
+    <IcTopNavigation status="alpha" version="v0.0.7">
+    <NavLink to="/" slot="router-app-title">
+            ApplicationName
+          </NavLink>
       <svg
         slot="app-icon"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/stories/ic-top-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-top-navigation.stories.mdx
@@ -477,9 +477,9 @@ export const DailyTippers = () => (
     ]}
   >
     <IcTopNavigation status="alpha" version="v0.0.7">
-    <NavLink to="/" slot="router-app-title">
-            ApplicationName
-          </NavLink>
+      <NavLink to="/" slot="app-title">
+        ApplicationName
+      </NavLink>
       <svg
         slot="app-icon"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1384,7 +1384,7 @@ export namespace Components {
     }
     interface IcTopNavigation {
         /**
-          * The app title to be displayed.
+          * The app title to be displayed. This is required, unless a slotted app title link is used.
          */
         "appTitle": string;
         /**
@@ -3318,9 +3318,9 @@ declare namespace LocalJSX {
     }
     interface IcTopNavigation {
         /**
-          * The app title to be displayed.
+          * The app title to be displayed. This is required, unless a slotted app title link is used.
          */
-        "appTitle": string;
+        "appTitle"?: string;
         /**
           * The alignment of the top navigation content.
          */

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -27,8 +27,13 @@
 
 :host .title-link,
 :host .title-link:visited,
-:host .title-link:active {
+:host .title-link:active,
+:host .title-link ::slotted(a),
+:host .title-link:visited ::slotted(a),
+:host .title-link:active ::slotted(a) {
   color: var(--ic-theme-text);
+  text-decoration: none;
+  outline: none;
 }
 
 :host .title-link:hover:not(:focus) {
@@ -43,7 +48,8 @@
   border-radius: var(--ic-border-radius);
 }
 
-:host .title-link:focus {
+:host .title-link:focus,
+:host .title-link:focus-within {
   border-radius: var(--ic-border-radius);
   box-shadow: var(--ic-border-focus);
   outline: var(--ic-hc-focus-outline);

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -31,6 +31,7 @@ import {
 
 /**
  * @slot app-icon - Content will be rendered to left of app title.
+ * @slot app-title - Handle routing by nesting a route in the app title.
  * @slot search - Content will be rendered in search area to left of buttons.
  * @slot toggle-icon - Icon to be displayed on the button to toggle search slot content on smaller devices
  * @slot navigation - Content will be rendered in navigation panel.
@@ -45,9 +46,9 @@ export class TopNavigation {
   @Element() el: HTMLIcTopNavigationElement;
 
   /**
-   * The app title to be displayed.
+   * The app title to be displayed. This is required, unless a slotted app title link is used.
    */
-  @Prop() appTitle!: string;
+  @Prop() appTitle: string;
 
   /**
    *  The URL to navigate to when the app title is clicked.
@@ -261,10 +262,11 @@ export class TopNavigation {
   componentDidLoad(): void {
     checkResizeObserver(this.runResizeObserver);
 
-    onComponentRequiredPropUndefined(
-      [{ prop: this.appTitle, propName: "app-title" }],
-      "Top Navigation"
-    );
+    !isSlotUsed(this.el, "app-title") &&
+      onComponentRequiredPropUndefined(
+        [{ prop: this.appTitle, propName: "app-title" }],
+        "Top Navigation"
+      );
   }
 
   disconnectedCallback(): void {
@@ -299,6 +301,12 @@ export class TopNavigation {
       : "Show search";
     const menuSize = this.deviceSize <= DEVICE_SIZES.S ? "small" : "default";
 
+    const Component = isSlotUsed(this.el, "app-title") ? "div" : "a";
+
+    const attrs = Component == "a" && {
+      href: this.href,
+    };
+
     return (
       <Host
         class={{
@@ -312,17 +320,23 @@ export class TopNavigation {
             <header role="banner">
               <div class="top-panel-container">
                 <div class="app-details-container">
-                  {hasTitle && (
-                    <a class="title-link" href={this.href}>
+                  {(hasTitle || isSlotUsed(this.el, "app-title")) && (
+                    <Component class="title-link" {...attrs}>
                       {this.hasAppIcon && (
                         <div class="app-icon-container" aria-hidden="true">
                           <slot name="app-icon" />
                         </div>
                       )}
                       <ic-typography variant={appTitleVariant}>
-                        <h1 class="title-wrap">{this.appTitle}</h1>
+                        <h1 class="title-wrap">
+                          {isSlotUsed(this.el, "app-title") ? (
+                            <slot name="app-title"></slot>
+                          ) : (
+                            this.appTitle
+                          )}
+                        </h1>
                       </ic-typography>
-                    </a>
+                    </Component>
                   )}
                   {this.status !== "" && (
                     <div class="app-status">

--- a/packages/web-components/src/components/ic-top-navigation/readme.md
+++ b/packages/web-components/src/components/ic-top-navigation/readme.md
@@ -7,14 +7,14 @@
 
 ## Properties
 
-| Property                | Attribute         | Description                                                                                     | Type                                 | Default        |
-| ----------------------- | ----------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------ | -------------- |
-| `appTitle` _(required)_ | `app-title`       | The app title to be displayed.                                                                  | `string`                             | `undefined`    |
-| `contentAligned`        | `content-aligned` | The alignment of the top navigation content.                                                    | `"center" \| "full-width" \| "left"` | `"full-width"` |
-| `href`                  | `href`            | The URL to navigate to when the app title is clicked.                                           | `string`                             | `"/"`          |
-| `inline`                | `inline`          | If `true`, the flyout navigation menu on small devices will be contained by the parent element. | `boolean`                            | `false`        |
-| `status`                | `status`          | The status info to be displayed.                                                                | `string`                             | `""`           |
-| `version`               | `version`         | The version info to be displayed.                                                               | `string`                             | `""`           |
+| Property         | Attribute         | Description                                                                                     | Type                                 | Default        |
+| ---------------- | ----------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------ | -------------- |
+| `appTitle`       | `app-title`       | The app title to be displayed. This is required, unless a slotted app title link is used.       | `string`                             | `undefined`    |
+| `contentAligned` | `content-aligned` | The alignment of the top navigation content.                                                    | `"center" \| "full-width" \| "left"` | `"full-width"` |
+| `href`           | `href`            | The URL to navigate to when the app title is clicked.                                           | `string`                             | `"/"`          |
+| `inline`         | `inline`          | If `true`, the flyout navigation menu on small devices will be contained by the parent element. | `boolean`                            | `false`        |
+| `status`         | `status`          | The status info to be displayed.                                                                | `string`                             | `""`           |
+| `version`        | `version`         | The version info to be displayed.                                                               | `string`                             | `""`           |
 
 
 ## Slots
@@ -22,6 +22,7 @@
 | Slot            | Description                                                                         |
 | --------------- | ----------------------------------------------------------------------------------- |
 | `"app-icon"`    | Content will be rendered to left of app title.                                      |
+| `"app-title"`   | Handle routing by nesting a route in the app title.                                 |
 | `"buttons"`     | Content will be rendered to right of search bar.                                    |
 | `"navigation"`  | Content will be rendered in navigation panel.                                       |
 | `"search"`      | Content will be rendered in search area to left of buttons.                         |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add a slot for use of router links for top navigation app title, and update app title prop to not be required, but still show the console error if a top nav has no app title or slotted app title link.
Updated the react router story to use a routed app title.

## Related issue
#179 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 