### PR TITLE
376 Allow use of slotted link for app title for side navigation

### DIFF
--- a/packages/react/src/stories/ic-side-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-side-navigation.stories.mdx
@@ -510,23 +510,26 @@ export const DailyTippers = () => (
   >
     <div style={{"display": "flex", "height": "100%"}}>
       <IcSideNavigation
-        appTitle="ACME"
         version="v0.0.0"
         status="BETA"
       >
+        <NavLink to="/" slot="app-title">
+          ACME
+        </NavLink>
+        <NavLink to="/" slot="app-icon">
         <svg
-          slot="app-icon"
           xmlns="http://www.w3.org/2000/svg"
           height="24px"
           viewBox="0 0 24 24"
           width="24px"
-          fill="#000000"
+          fill="currentcolor"
         >
           <path d="M0 0h24v24H0V0z" fill="none" />
           <path
             d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"
           />
         </svg>
+        </NavLink>
         <IcNavigationItem
           slot="primary-navigation"
         >

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1039,7 +1039,7 @@ export namespace Components {
     }
     interface IcSideNavigation {
         /**
-          * The title of the app to be displayed.
+          * The app title to be displayed. This is required, unless a slotted app title link is used.
          */
         "appTitle": string;
         /**
@@ -2935,9 +2935,9 @@ declare namespace LocalJSX {
     }
     interface IcSideNavigation {
         /**
-          * The title of the app to be displayed.
+          * The app title to be displayed. This is required, unless a slotted app title link is used.
          */
-        "appTitle": string;
+        "appTitle"?: string;
         /**
           * If `true`, the icon and label will appear when side navigation is collapsed.
          */

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -147,7 +147,7 @@
   }
 }
 
-:host .title-link:link {
+:host .title-link {
   display: flex;
   align-items: center;
   transition: box-shadow var(--ic-easing-transition-fast),
@@ -162,6 +162,13 @@
   color: var(--ic-theme-text);
 }
 
+slot[name="app-title"]::slotted(a),
+slot[name="app-icon"]::slotted(a) {
+  color: var(--ic-theme-text);
+  outline: none;
+  text-decoration: none;
+}
+
 :host .title-link:hover {
   border-radius: var(--ic-border-radius);
   background-color: var(--ic-theme-hover);
@@ -171,7 +178,8 @@
   background-color: var(--ic-theme-active);
 }
 
-:host .title-link:focus {
+:host .title-link:focus,
+:host .title-link:focus-within {
   border-radius: var(--ic-border-radius);
   box-shadow: var(--ic-border-focus);
   outline: var(--ic-hc-focus-outline);

--- a/packages/web-components/src/components/ic-side-navigation/readme.md
+++ b/packages/web-components/src/components/ic-side-navigation/readme.md
@@ -9,7 +9,7 @@
 
 | Property                   | Attribute                     | Description                                                                                                         | Type      | Default     |
 | -------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `appTitle` _(required)_    | `app-title`                   | The title of the app to be displayed.                                                                               | `string`  | `undefined` |
+| `appTitle`                 | `app-title`                   | The app title to be displayed. This is required, unless a slotted app title link is used.                           | `string`  | `undefined` |
 | `collapsedIconLabels`      | `collapsed-icon-labels`       | If `true`, the icon and label will appear when side navigation is collapsed.                                        | `boolean` | `false`     |
 | `disableAutoParentStyling` | `disable-auto-parent-styling` | If `true`, automatic parent wrapper styling will be disabled.                                                       | `boolean` | `false`     |
 | `expanded`                 | `expanded`                    | If `true`, the side navigation will load in an expanded state.                                                      | `boolean` | `false`     |
@@ -24,6 +24,7 @@
 | Slot                     | Description                                                                                |
 | ------------------------ | ------------------------------------------------------------------------------------------ |
 | `"app-icon"`             | Content will be rendered adjacent to the app title at the very top of the side navigation. |
+| `"app-title"`            | Handle routing by nesting a route in the app title.                                        |
 | `"primary-navigation"`   | Content will be rendered at the top of the side navigation.                                |
 | `"secondary-navigation"` | Content will be rendered at the bottom of the side navigation.                             |
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update app title to allow for slotted links for side nav.
Update React Router story to use slotted app title.

## Related issue
#376 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 