### PR TITLE
Bugfix/318 ic search tooltip render issue

### DIFF
--- a/packages/web-components/src/components/ic-checkbox-group/__snapshots__/ic-checkbox-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-checkbox-group/__snapshots__/ic-checkbox-group.spec.ts.snap
@@ -43,10 +43,7 @@ exports[`ic-checkbox-group should remove disabled attribute from static addition
           <ic-input-label for="ic-text-field-input-3" helpertext="" label="Test label"></ic-input-label>
           <ic-input-component-container validationstatus="">
             <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-3" inputmode="text" name="ic-text-field-input-3" placeholder="Placeholder" type="text" value="">
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         </ic-input-container>
       </mock:shadow-root>
       <input class="ic-input" name="ic-text-field-input-3" type="hidden" value="">
@@ -267,10 +264,7 @@ exports[`ic-checkbox-group should render with disabled static additional field: 
           <ic-input-label disabled="" for="ic-text-field-input-2" helpertext="" label="Test label"></ic-input-label>
           <ic-input-component-container disabled="" validationstatus="">
             <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-text-field-input-2" inputmode="text" name="ic-text-field-input-2" placeholder="" type="text" value="">
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         </ic-input-container>
       </mock:shadow-root>
       <input class="ic-input" disabled="" name="ic-text-field-input-2" type="hidden" value="">
@@ -328,10 +322,7 @@ exports[`ic-checkbox-group should render with dynamic additional field when chec
           <ic-input-label for="ic-text-field-input-1" helpertext="" label="Test label"></ic-input-label>
           <ic-input-component-container validationstatus="">
             <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-1" inputmode="text" name="ic-text-field-input-1" placeholder="Placeholder" type="text" value="">
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         </ic-input-container>
       </mock:shadow-root>
       <input class="ic-input" name="ic-text-field-input-1" type="hidden" value="">
@@ -384,10 +375,7 @@ exports[`ic-checkbox-group should render with hidden dynamic additional field: r
           <ic-input-label for="ic-text-field-input-0" helpertext="" label="Test label"></ic-input-label>
           <ic-input-component-container validationstatus="">
             <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-0" inputmode="text" name="ic-text-field-input-0" placeholder="Placeholder" type="text" value="">
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         </ic-input-container>
       </mock:shadow-root>
       <input class="ic-input" name="ic-text-field-input-0" type="hidden" value="">

--- a/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
+++ b/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
@@ -12,7 +12,6 @@ ic-input-component-container {
   padding: 1px;
   background-color: var(--ic-architectural-white);
   box-sizing: border-box;
-  position: relative;
   fill: var(--ic-architectural-400);
   outline: none;
 }

--- a/packages/web-components/src/components/ic-input-container/ic-input-container.css
+++ b/packages/web-components/src/components/ic-input-container/ic-input-container.css
@@ -1,5 +1,4 @@
 ic-input-container .component-container {
   display: flex;
   flex-direction: column;
-  position: relative;
 }

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
@@ -67,8 +67,6 @@
   background-color: var(--ic-focus-blue) !important;
   box-shadow: inset 0 0 0 2px var(--ic-focus-glow) !important;
   border-radius: var(--ic-space-xxs);
-  height: var(--ic-space-xl);
-  margin-top: var(--ic-space-xxxs);
 }
 
 .search-submit-button:focus * {

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -289,8 +289,8 @@ export class SearchBar {
         this.filteredOptions =
           rawFilteredOptions.length > 0 ? rawFilteredOptions : noOptions;
       }
-    } 
-    
+    }
+
     if (!this.showClearButton) {
       this.handleShowClearButton(true);
     }

--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -5,6 +5,10 @@
 */
 
 :host {
+  position: relative;
+}
+
+:host([full-width]) {
   width: 100%;
 }
 
@@ -78,6 +82,7 @@ select:not([disabled]) {
   width: 100%;
   display: flex;
   align-items: center;
+  position: relative;
 }
 
 .select-input {
@@ -112,6 +117,7 @@ select:not([disabled]) {
   align-items: center;
   display: flex;
   width: 100%;
+  position: relative;
 }
 
 .expand-icon {

--- a/packages/web-components/src/components/ic-text-field/__snapshots__/ic-text-field.input.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-text-field/__snapshots__/ic-text-field.input.spec.tsx.snap
@@ -7,10 +7,7 @@ exports[`ic-text-field should render disabled: renders-disabled 1`] = `
       <ic-input-label disabled="" for="ic-text-field-input-7" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container disabled="" validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-text-field-input-7" inputmode="text" name="ic-text-field-input-7" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" disabled="" name="ic-text-field-input-7" type="hidden" value="test value">
@@ -24,10 +21,7 @@ exports[`ic-text-field should render readonly: renders-readonly 1`] = `
       <ic-input-label for="ic-text-field-input-8" helpertext="" label="Test label" readonly=""></ic-input-label>
       <ic-input-component-container disabled="" readonly="" validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" class="no-left-pad readonly" disabled="" id="ic-text-field-input-8" inputmode="text" name="ic-text-field-input-8" placeholder="" readonly="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" disabled="" name="ic-text-field-input-8" type="hidden" value="test value">
@@ -41,10 +35,7 @@ exports[`ic-text-field should render with autoprops: renders-with-autoprops 1`] 
       <ic-input-label for="ic-text-field-input-4" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="on" autocomplete="on" id="ic-text-field-input-4" inputmode="text" name="ic-text-field-input-4" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-text-field-input-4" type="hidden" value="test value">
@@ -58,10 +49,7 @@ exports[`ic-text-field should render with error validation: renders-with-error-v
       <ic-input-label for="ic-text-field-input-13" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="error">
         <input aria-describedby="ic-text-field-input-13-validation-text" aria-invalid="true" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-13" inputmode="text" name="ic-text-field-input-13" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
       <ic-input-validation arialivemode="assertive" for="ic-text-field-input-13" message="error text" status="error"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -76,10 +64,7 @@ exports[`ic-text-field should render with helperText, required and small: render
       <ic-input-label for="ic-text-field-input-3" helpertext="helper text value" label="Test label" required=""></ic-input-label>
       <ic-input-component-container small="" validationstatus="">
         <input aria-describedby="ic-text-field-input-3-helper-text" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-3" inputmode="text" name="ic-text-field-input-3" placeholder="" required="" type="text" value="">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-text-field-input-3" type="hidden" value="">
@@ -92,10 +77,7 @@ exports[`ic-text-field should render with hidden label: renders-with-hiden-label
     <ic-input-container>
       <ic-input-component-container validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-5" inputmode="text" name="ic-text-field-input-5" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-text-field-input-5" type="hidden" value="test value">
@@ -112,10 +94,7 @@ exports[`ic-text-field should render with icon: renders-with-icon 1`] = `
           <slot name="icon"></slot>
         </span>
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-6" inputmode="text" name="ic-text-field-input-6" placeholder="" type="text" value="">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <svg fill="#000000" height="24px" slot="icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
@@ -133,10 +112,7 @@ exports[`ic-text-field should render with inline success validation: renders-wit
       <ic-input-label for="ic-text-field-input-14" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationinline="" validationstatus="success">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-14" inputmode="text" name="ic-text-field-input-14" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-14" message="" status=""></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -151,10 +127,7 @@ exports[`ic-text-field should render with max length: renders-with-maxlength 1`]
       <ic-input-label for="ic-text-field-input-9" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="error">
         <input aria-describedby="ic-text-field-input-9-charcount-desc ic-text-field-input-9-validation-text" aria-invalid="true" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-9" inputmode="text" name="ic-text-field-input-9" placeholder="" type="text" value="a long test value to exceed limit">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
       <ic-input-validation arialivemode="assertive" for="ic-text-field-input-9" message="Maximum length exceeded" status="error">
         <div slot="validation-message-adornment">
           <ic-typography class="exceeded maxlengthtext" variant="caption">
@@ -180,10 +153,7 @@ exports[`ic-text-field should render with name & full width: renders-with-name-f
       <ic-input-label for="ic-text-field-input-10" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container fullwidth="" validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-10" inputmode="text" name="mycontolname" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="mycontolname" type="hidden" value="test value">
@@ -197,10 +167,7 @@ exports[`ic-text-field should render with placeholder: renders-with-placeholder 
       <ic-input-label for="ic-text-field-input-1" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-1" inputmode="text" name="ic-text-field-input-1" placeholder="placeholder" type="text" value="">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-text-field-input-1" type="hidden" value="">
@@ -214,10 +181,7 @@ exports[`ic-text-field should render with success validation: renders-with-succe
       <ic-input-label for="ic-text-field-input-11" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="success">
         <input aria-describedby="ic-text-field-input-11-validation-text" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-11" inputmode="text" name="ic-text-field-input-11" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-11" message="Good choice!" status="success"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -232,10 +196,7 @@ exports[`ic-text-field should render with value: renders-with-value 1`] = `
       <ic-input-label for="ic-text-field-input-2" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-2" inputmode="text" name="ic-text-field-input-2" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-text-field-input-2" type="hidden" value="test value">
@@ -249,10 +210,7 @@ exports[`ic-text-field should render with warning validation: renders-with-warni
       <ic-input-label for="ic-text-field-input-12" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="warning">
         <input aria-describedby="ic-text-field-input-12-validation-text" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-12" inputmode="text" name="ic-text-field-input-12" placeholder="" type="text" value="test value">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-12" message="warning text" status="warning"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -267,10 +225,7 @@ exports[`ic-text-field should render: renders 1`] = `
       <ic-input-label for="ic-text-field-input-0" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container validationstatus="">
         <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-0" inputmode="text" name="ic-text-field-input-0" placeholder="" type="text" value="">
-        <slot name="clear-button"></slot>
-        <slot name="search-submit-button"></slot>
       </ic-input-component-container>
-      <slot name="menu"></slot>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-text-field-input-0" type="hidden" value="">

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.css
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.css
@@ -2,9 +2,13 @@
 
 :host {
   /**
-   * @prop --input-width: Width of the input field 
+   * @prop --input-width: Width of the input field
    */
   display: block;
+}
+
+:host([full-width]),
+.fullwidth {
   width: 100%;
 }
 
@@ -45,11 +49,6 @@ textarea:disabled {
 input.readonly,
 textarea.readonly {
   color: var(--ic-color-primary-text);
-}
-
-.fullwidth {
-  position: relative;
-  width: 100%;
 }
 
 /* Chrome, Safari, Edge */

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.textarea.spec.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.textarea.spec.tsx
@@ -14,10 +14,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-0" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-0" inputmode="text" name="ic-text-field-input-0" placeholder="" rows="6" value=""></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-0" type="hidden" value="">
@@ -37,10 +34,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-1" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-1" inputmode="text" name="ic-text-field-input-1" placeholder="placeholder" rows="6" value=""></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-1" type="hidden" value="">
@@ -60,10 +54,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-2" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-2" inputmode="text" name="ic-text-field-input-2" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-2" type="hidden" value="test value">
@@ -83,10 +74,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-3" helpertext="helper text value" label="Test label" required=""></ic-input-label>
             <ic-input-component-container small="" multiline="" validationstatus=""><textarea aria-describedby="ic-text-field-input-3-helper-text" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-3" inputmode="text" name="ic-text-field-input-3" placeholder="" required="" rows="6" value=""></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-3" type="hidden" value="">
@@ -106,10 +94,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-4" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="on" class="no-resize" id="ic-text-field-input-4" inputmode="text" name="ic-text-field-input-4" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-4" type="hidden" value="test value">
@@ -128,10 +113,7 @@ describe("ic-text-field", () => {
         <mock:shadow-root>
           <ic-input-container>
             <ic-input-component-container multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-5" inputmode="text" name="ic-text-field-input-5" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-5" type="hidden" value="test value">
@@ -168,10 +150,7 @@ describe("ic-text-field", () => {
               <span slot="left-icon">
                 <slot name="icon"></slot>
               </span><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-6" inputmode="text" name="ic-text-field-input-6" placeholder="" rows="6" value=""></textarea>
-              <slot name="clear-button"></slot>
-              <slot name="search-submit-button"></slot>
             </ic-input-component-container>
-            <slot name="menu"></slot>
         </ic-input-container>
         </mock:shadow-root>
         <svg fill="#000000" height="24px" slot="icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
@@ -195,10 +174,7 @@ describe("ic-text-field", () => {
           <ic-input-container disabled="">
             <ic-input-label disabled="" for="ic-text-field-input-7" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container disabled="" multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" disabled="" id="ic-text-field-input-7" inputmode="text" name="ic-text-field-input-7" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" disabled="" name="ic-text-field-input-7" type="hidden" value="test value">
@@ -218,10 +194,7 @@ describe("ic-text-field", () => {
           <ic-input-container disabled="" readonly="">
             <ic-input-label for="ic-text-field-input-8" helpertext="" label="Test label" readonly=""></ic-input-label>
             <ic-input-component-container disabled="" multiline="" readonly="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-left-pad no-resize readonly" disabled="" id="ic-text-field-input-8" inputmode="text" name="ic-text-field-input-8" placeholder="" readonly="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" disabled="" name="ic-text-field-input-8" type="hidden" value="test value">
@@ -241,10 +214,7 @@ describe("ic-text-field", () => {
         <ic-input-container>
           <ic-input-label for="ic-text-field-input-9" helpertext="" label="Test label"></ic-input-label>
           <ic-input-component-container multiline="" validationstatus="error"><textarea aria-describedby="ic-text-field-input-9-charcount-desc ic-text-field-input-9-validation-text" aria-invalid="true" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-9" inputmode="text" name="ic-text-field-input-9" placeholder="" rows="6" value="a long test value to exceed limit"></textarea>
-          <slot name="clear-button"></slot>
-          <slot name="search-submit-button"></slot>
         </ic-input-component-container>
-        <slot name="menu"></slot>
     <ic-input-validation arialivemode="assertive" for="ic-text-field-input-9" message="Maximum length exceeded" status="error">
             <div slot="validation-message-adornment">
               <ic-typography class="exceeded maxlengthtext" variant="caption">
@@ -276,10 +246,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-10" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container fullwidth="" multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-10" inputmode="text" name="mycontolname" placeholder="" rows="2" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="mycontolname" type="hidden" value="test value">
@@ -299,10 +266,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-11" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus="success"><textarea aria-describedby="ic-text-field-input-11-validation-text" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-11" inputmode="text" name="ic-text-field-input-11" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         <ic-input-validation arialivemode="polite" for="ic-text-field-input-11" message="Good choice!" status="success"></ic-input-validation>
           </ic-input-container>
         </mock:shadow-root>
@@ -323,10 +287,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-12" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus="warning"><textarea aria-describedby="ic-text-field-input-12-validation-text" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-12" inputmode="text" name="ic-text-field-input-12" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         <ic-input-validation arialivemode="polite" for="ic-text-field-input-12" message="warning text" status="warning"></ic-input-validation>
           </ic-input-container>
         </mock:shadow-root>
@@ -347,10 +308,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-13" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus="error"><textarea aria-describedby="ic-text-field-input-13-validation-text" aria-invalid="true" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-13" inputmode="text" name="ic-text-field-input-13" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
         <ic-input-validation arialivemode="assertive" for="ic-text-field-input-13" message="error text" status="error"></ic-input-validation>
           </ic-input-container>
         </mock:shadow-root>
@@ -371,10 +329,7 @@ describe("ic-text-field", () => {
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-14" helpertext="" label="Test label"></ic-input-label>
             <ic-input-component-container multiline="" validationstatus=""><textarea aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" id="ic-text-field-input-14" inputmode="text" name="ic-text-field-input-14" placeholder="" rows="6" value="test value"></textarea>
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
           </ic-input-component-container>
-          <slot name="menu"></slot>
       </ic-input-container>
         </mock:shadow-root>
         <input class="ic-input" name="ic-text-field-input-14" type="hidden" value="test value">

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -28,6 +28,7 @@ import {
   onComponentRequiredPropUndefined,
   addFormResetListener,
   removeFormResetListener,
+  isSlotUsed,
 } from "../../utils/helpers";
 import { IC_INHERITED_ARIA } from "../../utils/constants";
 import {
@@ -538,10 +539,10 @@ export class TextField {
                 {...this.inheritedAttributes}
               ></textarea>
             )}
-            <slot name="clear-button"></slot>
-            <slot name="search-submit-button"></slot>
+            {isSlotUsed(this.el, 'clear-button') && <slot name="clear-button"></slot>}
+            {isSlotUsed(this.el, 'search-submit-button') && <slot name="search-submit-button"></slot>}
           </ic-input-component-container>
-          <slot name="menu"></slot>
+          {isSlotUsed(this.el, 'menu') && <slot name="menu"></slot>}
           {(!isEmptyString(validationStatus) ||
             !isEmptyString(validationText) ||
             maxNumChars > 0) && (


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updates styling for ic-input-* to fix tooltip positioning
Added `isSlotUsed` on text field to prevent unused slots appearing in the DOM and updated tests
Fixed styling for submit button on search-bar small variant

## Related issue
#318 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 