### PR TITLE
[github-action]: fix(root): updated concurrency step for qa deployments

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -8,6 +8,10 @@ on:
       - gh-pages
       - 'dependabot/**'
 
+concurrency:  
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ic-ui-kit-static-analysis-tests:
     name: 'Static Analysis Tests'
@@ -77,7 +81,6 @@ jobs:
 
   ic-ui-kit-deploy:
     needs: [ic-ui-kit-static-analysis-tests, ic-ui-kit-e2e-tests, ic-ui-kit-visual-tests]
-    concurrency: ci-${{ github.ref }}
     name: 'Deploy'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ic-ui-kit-develop.yml
+++ b/.github/workflows/ic-ui-kit-develop.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+concurrency:  
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ic-ui-kit-static-analysis-tests:
     name: 'Static Analysis Tests'
@@ -74,7 +78,6 @@ jobs:
 
   ic-ui-kit-deploy:
     needs: [ic-ui-kit-static-analysis-tests, ic-ui-kit-e2e-tests, ic-ui-kit-visual-tests]
-    concurrency: ci-${{ github.ref }}
     name: 'Deploy QA Storybook'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Concurrency action has been moved from the deployment step to the overall action. This will make sure the latest codebase of the branch is being built. Updated concurrency for QA and develop due to the high volume of builds.  As part of the investigation, there was a requirement to update the concurrency property on `pages-build-deployment` action provided by GitHub Pages by default but it is not accessible.

## Related issue
https://github.com/mi6/ic-design-system/issues/6

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 