### PR TITLE
fix(web-components): updated side navigation z-index

### DIFF
--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
@@ -6,7 +6,7 @@
   bottom: 0;
   width: 100%;
   height: var(--ic-space-lg);
-  z-index: var(--ic-z-index-overlay);
+  z-index: var(--ic-z-index-classification-banner);
 }
 
 :host(.inline) {

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -1,6 +1,5 @@
 :host {
   display: block;
-
   --side-navigation-position: fixed;
   --side-navigation-position-left: 0;
   --side-navigation-position-top: var(--ic-space-xxl);
@@ -11,6 +10,7 @@
     --ic-transition-duration-slow
   );
   --side-navigation-width: 20rem;
+  z-index: var(--ic-z-index-nav-menu);
 }
 
 :host > * {
@@ -27,6 +27,7 @@
   left: calc(var(--side-navigation-width) * -1);
   bottom: 0;
   background-color: var(--ic-theme-primary);
+  z-index: var(--ic-z-index-nav-menu);
 }
 
 :host(.inline) .side-navigation {

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -279,6 +279,8 @@
   --ic-space-xxl: 3rem;
 
   /* z-index */
+  --ic-z-index-classification-banner: 1400;
+  --ic-z-index-nav-menu: 1200;
   --ic-z-index-overlay: 1000;
   --ic-z-index-popup-menu: calc(var(--ic-z-index-overlay) + 1);
 }


### PR DESCRIPTION
## Summary of the changes
Items and components from other DS were appearing above the expanded drawer of ic-side-nav, a new Z-index has been applied which stops this behaviour. Also z-index variable added.

## Related issue
#322 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 