### PR TITLE
fix(web-components): fixes z-index on top nav dropdown

### DIFF
--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
@@ -130,6 +130,7 @@
   right: 0;
   padding: var(--ic-space-xs) var(--ic-space-md);
   box-shadow: 0 0.375rem 0.5rem -0.375rem rgba(0 0 0 / 20%);
+  z-index: var(--ic-z-index-overlay);
 }
 
 :host .navigation-group-dropdown-items-list {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes z-index issue when top nav contains navigation groups

## Related issue
#375 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 