### PR TITLE
Bug/213 clear button disappearing in safari

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
@@ -28,9 +28,7 @@
 
 .clear-button-container {
   align-items: center;
-  margin-right: 0.063rem;
-  display: none;
-  visibility: hidden;
+  display: flex;
 }
 
 .clear-button {
@@ -47,11 +45,6 @@
 
 .clear-button:focus * {
   fill: white;
-}
-
-.clear-button-visible {
-  visibility: visible;
-  display: flex;
 }
 
 .search-submit-button-container {

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -359,6 +359,10 @@ export class SearchBar {
     }
   };
 
+  private handleClearMouseDown = (ev: Event) => {
+    ev.preventDefault();
+  };
+
   /**
    * Emitted when the search value has been submitted
    */
@@ -716,34 +720,35 @@ export class SearchBar {
           inputmode="search"
           debounce={this.debounce}
         >
-          <div
-            class={{
-              "clear-button-container": true,
-              "clear-button-visible":
-                value && !disabledMode && this.showClearButton,
-            }}
-            slot="clear-button"
-          >
-            <ic-button
-              id="clear-button"
-              class="clear-button"
-              aria-label="Clear"
-              innerHTML={clearIcon}
-              onClick={this.handleClear}
-              size={small ? "small" : "default"}
-              onFocus={this.handleFocusClearButton}
-              onBlur={this.handleClearBlur}
-              onKeyDown={this.handleClear}
-              type="submit"
-              variant="icon"
-              appearance={
-                this.clearButtonFocused
-                  ? IcThemeForegroundEnum.Light
-                  : IcThemeForegroundEnum.Dark
-              }
-            ></ic-button>
-            <div class="divider"></div>
-          </div>
+          {value && this.showClearButton && (
+            <div
+              class={{
+                "clear-button-container": true,
+              }}
+              slot="clear-button"
+            >
+              <ic-button
+                id="clear-button"
+                class="clear-button"
+                aria-label="Clear"
+                innerHTML={clearIcon}
+                onClick={this.handleClear}
+                onMouseDown={this.handleClearMouseDown}
+                size={small ? "small" : "default"}
+                onFocus={this.handleFocusClearButton}
+                onBlur={this.handleClearBlur}
+                onKeyDown={this.handleClear}
+                type="submit"
+                variant="icon"
+                appearance={
+                  this.clearButtonFocused
+                    ? IcThemeForegroundEnum.Light
+                    : IcThemeForegroundEnum.Dark
+                }
+              ></ic-button>
+              <div class="divider"></div>
+            </div>
+          )}
           <div
             class={{
               "search-submit-button-container": true,


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Restyle the clear button container class, remove the clear button visible class, add logic to clear the search bar, add handleClearMouseDown to handle event.
This fixes the bug, which is only in safari. 

## Related issue
#213

## Checklist
- [X] I have added relevant unit and visual regression tests.
- [X] I have manually accessibility tested any changes, if relevant.
- [X] I have ensured any changes match the Figma component library. 