### PR TITLE
fix(web-components): fix gap appearing under slotted nav items

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -39,6 +39,7 @@ ic-typography {
 }
 
 :host(.navigation-item) ::slotted(a) {
+  height: 100%;
   font: var(--ic-font-label) !important;
   letter-spacing: var(--ic-font-letter-spacing-0pt025) !important;
   padding: 0 var(--ic-space-md) !important;


### PR DESCRIPTION
## Summary of the changes
Fixed gap appearing under nav items with slotted `<a>`s (e.g. in React router story) - caused by changes made during horizontal scroll work.

<img src="https://user-images.githubusercontent.com/111882109/223192857-43edf83a-eed4-401f-a6fd-6803ab5b6609.png" width="300">
