### PR TITLE
Bug/213 clear button disappearing in safari

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
@@ -39,13 +39,15 @@
     border-radius var(--ic-easing-transition);
 }
 
-.clear-button:focus {
+.clear-button:focus,
+.clear-button:active {
   background-color: var(--ic-focus-blue);
   box-shadow: inset 0 0 0 0.125rem var(--ic-focus-glow);
   border-radius: 0.25rem;
 }
 
-.clear-button:focus * {
+.clear-button:focus,
+.clear-button:active * {
   fill: white;
 }
 
@@ -63,13 +65,15 @@
   display: none !important;
 }
 
-.search-submit-button:focus {
+.search-submit-button:focus,
+.search-submit-button:active {
   background-color: var(--ic-focus-blue) !important;
   box-shadow: inset 0 0 0 0.125rem var(--ic-focus-glow) !important;
   border-radius: var(--ic-space-xxs);
 }
 
-.search-submit-button:focus * {
+.search-submit-button:focus,
+.search-submit-button:active * {
   fill: white;
 }
 

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.spec.ts
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.spec.ts
@@ -557,4 +557,26 @@ describe("ic-search-bar search", () => {
       "No results found"
     );
   });
+
+  it("should test mousedown handler", async () => {
+    const page = await newSpecPage({
+      components: [
+        SearchBar,
+        Button,
+        TextField,
+        Menu,
+        InputContainer,
+        InputLabel,
+      ],
+      html: '<ic-search-bar label="Test label" value="test"></ic-search-bar>',
+    });
+
+    await page.rootInstance.handleMouseDown({
+      preventDefault: (): void => null,
+    });
+
+    await page.waitForChanges();
+
+    expect(page.root.value).toBe("test");
+  });
 });

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -359,6 +359,10 @@ export class SearchBar {
     }
   };
 
+  private handleMouseDown = (ev: Event) => {
+    ev.preventDefault();
+  };
+
   /**
    * Emitted when the search value has been submitted
    */
@@ -730,6 +734,7 @@ export class SearchBar {
               aria-label="Clear"
               innerHTML={clearIcon}
               onClick={this.handleClear}
+              onMouseDown={this.handleMouseDown}
               size={small ? "small" : "default"}
               onFocus={this.handleFocusClearButton}
               onBlur={this.handleClearBlur}
@@ -763,6 +768,7 @@ export class SearchBar {
               innerHTML={searchIcon}
               size={small ? "small" : "default"}
               onClick={this.handleSubmitSearch}
+              onMouseDown={this.handleMouseDown}
               onBlur={this.handleSubmitSearchBlur}
               onFocus={this.handleSubmitSearchFocus}
               onKeyDown={this.handleSubmitSearchKeyDown}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add handleMouseDown to handle the event via preventDefault. Add css active selector to clear and
select button focus states. Add spec test for handleMouseDown.

## Related issue
.#213

## Checklist
- [X] I have added relevant unit and visual regression tests.
- [X] I have manually accessibility tested any changes, if relevant.
- [X] I have ensured any changes match the Figma component library. 