### PR TITLE
fix(web-components): fixes page header z-index issue

### DIFF
--- a/packages/web-components/src/components/ic-page-header/ic-page-header.css
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.css
@@ -1,18 +1,18 @@
 @import "../../global/normalize.css";
 
 /**
- * @prop --ic-z-index-page-header: z-index of page-header in sticky mode
+ * @prop --ic-z-index-page-header: z-index of page-header
  */
 
 :host {
   display: block;
+  z-index: var(--ic-z-index-page-header);
 }
 
 :host(.sticky) {
   position: sticky;
   top: 0;
   box-shadow: var(--ic-elevation-overlay);
-  z-index: var(--ic-z-index-page-header);
 }
 
 header {

--- a/packages/web-components/src/components/ic-page-header/readme.md
+++ b/packages/web-components/src/components/ic-page-header/readme.md
@@ -35,9 +35,9 @@
 
 ## CSS Custom Properties
 
-| Name                       | Description                           |
-| -------------------------- | ------------------------------------- |
-| `--ic-z-index-page-header` | z-index of page-header in sticky mode |
+| Name                       | Description            |
+| -------------------------- | ---------------------- |
+| `--ic-z-index-page-header` | z-index of page-header |
 
 
 ## Dependencies


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes an issue with previous changes to z-index of page header. It only worked for sticky prop and not stickyDesktopOnly

## Related issue
#391

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 