### PR TITLE
fix(web-components): updated top-navigation e2e test

### DIFF
--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.e2e.ts
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.e2e.ts
@@ -31,9 +31,10 @@ describe("ic-top-navigation", () => {
       height: pageHeight,
     });
 
-    const navGroup = await page.find(
-      "ic-top-navigation >>> ic-horizontal-scroll >>> ic-navigation-group"
-    );
+    await page.waitForChanges();
+
+    const navGroup = await page.find("ic-top-navigation ic-navigation-group");
+
     await navGroup.hover();
 
     await page.waitForChanges();


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updated top nav e2e flaky test. The `ic-navigation-group` selector needed updating as it was appearing outside of the ShadowDOM. This PR fixes this test: https://github.com/mi6/ic-ui-kit/actions/runs/4374871463/jobs/7654841381#step:5:694

## Related issue
N/A

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 