### PR TITLE
Feature/158 add keyboard character navigation to select

### DIFF
--- a/packages/react/src/stories/ic-select.stories.mdx
+++ b/packages/react/src/stories/ic-select.stories.mdx
@@ -80,6 +80,7 @@ export const manyOptions = [
   { label: "Espresso", value: "Esp" },
   { label: "Cortado", value: "Cor" },
   { label: "Ristretto", value: "Ris" },
+  { label: "Latte macchiato", value: "Lam" },
 ];
 
 export const searchableOptions = [

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2593,10 +2593,11 @@ declare namespace LocalJSX {
           * The ID of the menu.
          */
         "menuId": string;
-        "onMenuKeyPress"?: (event: IcMenuCustomEvent<{ isNavKey: boolean }>) => void;
+        "onMenuKeyPress"?: (event: IcMenuCustomEvent<{ isNavKey: boolean; key: string }>) => void;
         "onMenuOptionId"?: (event: IcMenuCustomEvent<IcMenuOptionIdEventDetail>) => void;
         "onMenuOptionSelect"?: (event: IcMenuCustomEvent<IcOptionSelectEventDetail>) => void;
         "onMenuStateChange"?: (event: IcMenuCustomEvent<IcMenuChangeEventDetail>) => void;
+        "onUngroupedOptionsSet"?: (event: IcMenuCustomEvent<{ options: IcMenuOption[] }>) => void;
         /**
           * If `true`, the menu will be displayed open.
          */

--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -119,7 +119,12 @@ export class Menu {
   /**
    * @internal Emitted when key is pressed while menu is open
    */
-  @Event() menuKeyPress: EventEmitter<{ isNavKey: boolean }>;
+  @Event() menuKeyPress: EventEmitter<{ isNavKey: boolean; key: string }>;
+
+  /**
+   * @internal Emitted when the ungrouped options have been set.
+   */
+  @Event() ungroupedOptionsSet: EventEmitter<{ options: IcMenuOption[] }>;
 
   private handleClearListener = (): void => {
     this.optionHighlighted = "";
@@ -381,8 +386,8 @@ export class Menu {
     }
   };
 
-  private emitMenuKeyPress = (isNavKey: boolean) => {
-    this.menuKeyPress.emit({ isNavKey: isNavKey });
+  private emitMenuKeyPress = (isNavKey: boolean, key: string) => {
+    this.menuKeyPress.emit({ isNavKey: isNavKey, key: key });
   };
 
   private autoSetValueOnMenuKeyDown = (event: KeyboardEvent): void => {
@@ -418,7 +423,6 @@ export class Menu {
         });
         this.keyboardNav = true;
         break;
-      case " ":
       case "Enter":
       case "Escape":
         this.handleMenuChange(false);
@@ -434,9 +438,12 @@ export class Menu {
         if (isSearchableSelect && event.key !== "Tab") {
           this.inputEl.focus();
         }
+        if (event.key.length === 1) {
+          this.keyboardNav = true;
+        }
         break;
     }
-    this.emitMenuKeyPress(this.keyboardNav);
+    this.emitMenuKeyPress(this.keyboardNav, event.key);
   };
 
   private handleMenuKeyUp = (event: KeyboardEvent): void => {
@@ -504,6 +511,7 @@ export class Menu {
       });
     }
     this.ungroupedOptions = this.getSortedOptions(this.ungroupedOptions);
+    this.ungroupedOptionsSet.emit({ options: this.ungroupedOptions });
   };
 
   connectedCallback(): void {

--- a/packages/web-components/src/components/ic-select/ic-select.stories.mdx
+++ b/packages/web-components/src/components/ic-select/ic-select.stories.mdx
@@ -494,6 +494,7 @@ import readme from "./readme.md";
             { label: "Espresso", value: "Esp" },
             { label: "Cortado", value: "Cor" },
             { label: "Ristretto", value: "Ris" },
+            { label: "Latte macchiato", value: "Lam" },
           ];
           select.addEventListener("icChange", function (event) {
             option = event.detail.value;


### PR DESCRIPTION
## Summary of the changes
Added functionality which allows user to select options that match the pressed character keys 
- Reflects behaviour of native select
- Works both when the select is focussed and not opened and also when the menu is open
- Selects option where the pressed keys match the start of the option label
- Multiple character key presses is supported
- Space key only opens / closes menu if not being used alongside character keys (e.g. if the user is trying to select an option which has a space in it - can test using new "Latte macchiato" option)

## Related issue
#158 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 