### PR TITLE
fix(web-components): moved scroll bar calculations to componentDidRender

### DIFF
--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -506,6 +506,17 @@ export class Menu {
     this.ungroupedOptions = this.getSortedOptions(this.ungroupedOptions);
   };
 
+  private setMenuScrollbar = () => {
+    let optionsHeight = 0;
+    this.host.shadowRoot
+      .querySelectorAll(".option")
+      .forEach((option) => (optionsHeight += option.clientHeight));
+
+    if (optionsHeight >= 320) {
+      this.menu.classList.add("menu-scroll");
+    }
+  };
+
   connectedCallback(): void {
     if (this.parentEl?.tagName === "IC-SEARCH-BAR") {
       this.setHighlightedOption(0);
@@ -526,13 +537,6 @@ export class Menu {
       (this.parentEl as HTMLIcSearchBarElement).disableFilter
     ) {
       this.focusFromSearchKeypress = true;
-    }
-    let optionsHeight = 0;
-    this.host.shadowRoot
-      .querySelectorAll(".option")
-      .forEach((option) => (optionsHeight += option.clientHeight));
-    if (optionsHeight >= 320) {
-      this.menu.classList.add("menu-scroll");
     }
 
     onComponentRequiredPropUndefined(
@@ -567,6 +571,10 @@ export class Menu {
           },
         ],
       });
+    }
+
+    if (this.open && !!this.options.length) {
+      this.setMenuScrollbar();
     }
   }
 

--- a/packages/web-components/src/components/ic-select/ic-select.e2e.ts
+++ b/packages/web-components/src/components/ic-select/ic-select.e2e.ts
@@ -7,6 +7,19 @@ const options = `[
   { label: 'Test label 3', value: 'Test value 3' },
 ]`;
 
+const largeOptions = `[
+  { label: 'Test label 1', value: 'Test value 1' },
+  { label: 'Test label 2', value: 'Test value 2' },
+  { label: 'Test label 3', value: 'Test value 3' },
+  { label: 'Test label 4', value: 'Test value 4' },
+  { label: 'Test label 5', value: 'Test value 5' },
+  { label: 'Test label 6', value: 'Test value 6' },
+  { label: 'Test label 7', value: 'Test value 7' },
+  { label: 'Test label 8', value: 'Test value 8' },
+  { label: 'Test label 9', value: 'Test value 9' },
+  { label: 'Test label 10', value: 'Test value 10' },
+]`;
+
 const searchableOptions = `[
   { label: "Cappuccino", value: "Cap" },
   { label: "Latte", value: "Lat" },
@@ -79,6 +92,16 @@ const getTestSearchableSelectAsync = () =>
         select.options = []
       }, 800)
     </script>`;
+
+const getTestSelectAsync = (firstDataset: string, secondDataset: string) =>
+  `<ic-select label="IC Select Test" value="Test value"></ic-select>
+      <script>
+        var select = document.querySelector('ic-select');
+        select.options = ${firstDataset};
+        window.setTimeout(() => {
+          select.options = ${secondDataset}
+        }, 1500)
+      </script>`;
 
 const getMenuVisibility = async (page: E2EPage) => {
   const menuVisibility = await page.evaluate(() => {
@@ -1870,6 +1893,58 @@ describe("ic-select", () => {
       );
 
       expect(selectClassName).toBe("select-option-selected");
+    });
+
+    it("should add .menu-scroll to menu components when options height is over 320", async () => {
+      const page = await newE2EPage();
+      await page.setContent(getTestSelect(largeOptions));
+      await page.waitForChanges();
+
+      const select = await page.find("ic-select >>> button.select-input");
+      await select.click();
+      await page.waitForChanges();
+
+      const menuClasses = await page.evaluate(() => {
+        const menu = document
+          .querySelector("ic-select")
+          .shadowRoot.querySelector("ic-menu")
+          .shadowRoot.querySelector(".menu");
+        return menu.classList;
+      });
+
+      expect(Object.values(menuClasses).includes("menu-scroll")).toBeTruthy();
+    });
+
+    it("should add .menu-scroll to menu components when options are initially set and then populated with large data set", async () => {
+      const page = await newE2EPage();
+      await page.setContent(getTestSelectAsync(options, largeOptions));
+      await page.waitForChanges();
+
+      const select = await page.find("ic-select >>> button.select-input");
+      await select.click();
+      await page.waitForChanges();
+
+      let menuClasses = await page.evaluate(() => {
+        const menu = document
+          .querySelector("ic-select")
+          .shadowRoot.querySelector("ic-menu")
+          .shadowRoot.querySelector(".menu");
+        return menu.classList;
+      });
+
+      expect(Object.values(menuClasses).includes("menu-scroll")).toBeFalsy();
+
+      await page.waitForTimeout(1200);
+
+      menuClasses = await page.evaluate(() => {
+        const menu = document
+          .querySelector("ic-select")
+          .shadowRoot.querySelector("ic-menu")
+          .shadowRoot.querySelector(".menu");
+        return menu.classList;
+      });
+
+      expect(Object.values(menuClasses).includes("menu-scroll")).toBeTruthy();
     });
   });
 });

--- a/packages/web-components/src/components/ic-select/ic-select.stories.mdx
+++ b/packages/web-components/src/components/ic-select/ic-select.stories.mdx
@@ -35,6 +35,40 @@ import readme from "./readme.md";
   </Story>
 </Canvas>
 
+### Async select default
+
+<Canvas>
+  <Story name="Async select default" parameters={{ loki: { skip: true } }}>
+    {(args) =>
+      html`<ic-select label="What is your favourite coffee?"></ic-select>
+        <script>
+          var select = document.querySelector("ic-select");
+          var option = "Cappuccino";
+          select.options = [];
+          select.addEventListener("icChange", function (event) {
+            option = event.detail.value;
+            select.value = option;
+          });
+          setTimeout(() => {
+            select.options = [
+              { label: "Cappuccino", value: "Cap" },
+              { label: "Latte", value: "Lat" },
+              { label: "Americano", value: "Ame" },
+              { label: "Filter", value: "Fil" },
+              { label: "Flat white", value: "Fla" },
+              { label: "Mocha", value: "Moc" },
+              { label: "Macchiato", value: "Mac" },
+              { label: "Café au lait", value: "Caf" },
+              { label: "Espresso", value: "Esp" },
+              { label: "Cortado", value: "Cor" },
+              { label: "Ristretto", value: "Ris" },
+            ];
+          }, 2000);
+        </script>`
+    }
+  </Story>
+</Canvas>
+
 ### Default value
 
 <Canvas>
@@ -564,6 +598,43 @@ import readme from "./readme.md";
             option = event.detail.value;
             select.value = option;
           });
+        </script>`
+    }
+  </Story>
+</Canvas>
+
+### Async searchable default
+
+<Canvas>
+  <Story name="Async searchable default" parameters={{ loki: { skip: true } }}>
+    {(args) =>
+      html`<ic-select
+          label="What is your favourite coffee?"
+          searchable
+        ></ic-select>
+        <script>
+          var select = document.querySelector("ic-select");
+          var option = "Cappuccino";
+          select.options = [];
+          select.addEventListener("icChange", function (event) {
+            option = event.detail.value;
+            select.value = option;
+          });
+          setTimeout(() => {
+            select.options = [
+              { label: "Cappuccino", value: "Cap" },
+              { label: "Latte", value: "Lat" },
+              { label: "Americano", value: "Ame" },
+              { label: "Filter", value: "Fil" },
+              { label: "Flat white", value: "Fla" },
+              { label: "Mocha", value: "Moc" },
+              { label: "Macchiato", value: "Mac" },
+              { label: "Café au lait", value: "Caf" },
+              { label: "Espresso", value: "Esp" },
+              { label: "Cortado", value: "Cor" },
+              { label: "Ristretto", value: "Ris" },
+            ];
+          }, 2000);
         </script>`
     }
   </Story>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Moved the calculations which were setting the scroll bars from componentDidLoad to componentDidRender because a re-calculation was required if the options where initially `[]`. compontnDidLoad was only triggered once so any data which populated options after a request or update was not re-calculated for the scroll bar

## Related issue
#501

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 