### PR TITLE
fix(web-components): updated default value functionality

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.spec.tsx
@@ -1454,4 +1454,48 @@ describe("ic-select", () => {
     expect(page.rootInstance.pressedCharacters).toBe("C ");
     expect(page.rootInstance.open).toBe(true);
   });
+
+  it("should set the default value of searchable as option label when options initially set to [] then populated", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      template: () => (
+        <ic-select
+          label="select test"
+          searchable
+          options={[]}
+          value="Test value 1"
+        ></ic-select>
+      ),
+    });
+
+    page.root.options = menuOptions;
+    await page.waitForChanges();
+
+    expect(page.rootInstance.searchableSelectInputValue).toBe("Test label 1");
+
+    const input = page.root.shadowRoot.querySelector("input");
+    expect(input.value).toBe("Test label 1");
+  });
+
+  it("should set the default value to custom value when options initially set to [] then set to [] again", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      template: () => (
+        <ic-select
+          label="select test"
+          searchable
+          options={[]}
+          value="Test value 1"
+        ></ic-select>
+      ),
+    });
+
+    page.root.options = [];
+    await page.waitForChanges();
+
+    expect(page.rootInstance.searchableSelectInputValue).toBe("Test value 1");
+
+    const input = page.root.shadowRoot.querySelector("input");
+    expect(input.value).toBe("Test value 1");
+  });
 });

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -61,7 +61,10 @@ export class Select {
   private inheritedAttributes: { [k: string]: unknown } = {};
 
   private debounceAria: number;
-  private hasSetSearchableDefaultValue = false;
+  private hasSetDefaultValue = false;
+
+  private initialRender = false;
+  private initialOptionsEmpty = false;
 
   private characterKeyPressTimer: number;
 
@@ -200,8 +203,6 @@ export class Select {
 
   @State() pressedCharacters: string = "";
 
-  private initialRender = false;
-
   @Watch("options")
   watchOptionsHandler(): void {
     if (this.isExternalFiltering()) {
@@ -220,10 +221,15 @@ export class Select {
       }
 
       this.updateSearchableSelectResultAriaLive();
-      this.setSearchableDefaultValue();
+      this.setDefaultValue();
     } else {
       this.setOptionsValuesFromLabels();
       this.filteredOptions = this.options;
+
+      if (this.initialOptionsEmpty) {
+        this.setDefaultValue();
+        this.initialOptionsEmpty = false;
+      }
     }
   }
 
@@ -649,11 +655,11 @@ export class Select {
   private getDefaultValue = (value: string): string | null =>
     this.getLabelFromValue(value) || value || null;
 
-  private setSearchableDefaultValue() {
-    if (!this.hasSetSearchableDefaultValue && this.value && this.searchable) {
+  private setDefaultValue() {
+    if (!this.hasSetDefaultValue && this.value) {
       this.searchableSelectInputValue = this.getDefaultValue(this.value);
       this.initialValue = this.value;
-      this.hasSetSearchableDefaultValue = true;
+      this.hasSetDefaultValue = true;
     }
   }
 
@@ -697,8 +703,10 @@ export class Select {
 
     this.initialRender = true;
 
-    if (!this.disableFilter) {
-      this.setSearchableDefaultValue();
+    if (!this.options.length) {
+      this.initialOptionsEmpty = true;
+    } else if (!this.disableFilter) {
+      this.setDefaultValue();
     }
   }
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updated default value functionality as there are use cases where the options are initially set to [] and then populated after a useEffect or setTimeout. By moving the method to componentWillRender, the scroll bar calculations will happen more frequently and when the menu is open. It was initially running within componentWillLoad which only runs on initial load.

## Related issue
#456 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 