### PR TITLE
fix(web-components): add extra check to search isSubmitDisabled

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -558,7 +558,10 @@ export class SearchBar {
   private isSubmitDisabled = (): boolean => {
     const valueNotSet =
       this.value === undefined || this.value === null || this.value === "";
-    return valueNotSet || this.disabled || this.hadNoOptions();
+    const valueLengthLess = this.value.length < this.charactersUntilSuggestion;
+    return (
+      valueNotSet || valueLengthLess || this.disabled || this.hadNoOptions()
+    );
   };
 
   private highlightFirstOptionAfterNoResults = () => {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add check to search isSubmitDisabled for if the value length is too low (less than charactersUntilSuggestion), so that the submit button isn't enabled on initial value

## Related issue
#363

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 