### PR TITLE
fix(web-components): replace underline thickness and offset for some components

### DIFF
--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
@@ -38,7 +38,7 @@
 }
 
 ic-link {
-  --breadcrumb-link-display: flex;
+  --breadcrumb-link-display: inline-flex;
   --breadcrumb-link-align-items: center;
   --breadcrumb-link-gap: var(--ic-space-xs);
 }
@@ -68,9 +68,9 @@ ic-link {
 :host(.collapsed-breadcrumb-wrapper) ::slotted(.collapsed-breadcrumb:hover),
 :host(.collapsed-breadcrumb-wrapper) ::slotted(.collapsed-breadcrumb:focus) {
   outline: var(--ic-hc-focus-outline);
-  text-decoration-line: underline;
-  text-decoration-thickness: 25%;
-  text-underline-offset: 25%;
+  border-bottom: 0.25rem solid !important;
+  margin-bottom: -0.25rem !important;
+  text-decoration: none;
 }
 
 .hide,
@@ -81,5 +81,20 @@ ic-link {
 @media (forced-colors: active) {
   .back-icon svg {
     color: currentcolor;
+  }
+}
+
+@supports (text-decoration-thickness: 25%) {
+  ic-link {
+    --breadcrumb-link-display: flex;
+  }
+
+  :host(.collapsed-breadcrumb-wrapper) ::slotted(.collapsed-breadcrumb:hover),
+  :host(.collapsed-breadcrumb-wrapper) ::slotted(.collapsed-breadcrumb:focus) {
+    text-decoration-line: underline;
+    text-decoration-thickness: 25%;
+    text-underline-offset: 25%;
+    border-bottom: 0 !important;
+    margin-bottom: 0 !important;
   }
 }

--- a/packages/web-components/src/components/ic-card/ic-card.css
+++ b/packages/web-components/src/components/ic-card/ic-card.css
@@ -82,8 +82,22 @@ button {
 .card.clickable:hover .card-title,
 .card.clickable:focus .card-title,
 .card.clickable.focussed .card-title {
-  text-decoration-thickness: 25%;
-  text-underline-offset: 25%;
+  display: inline-block;
+  border-bottom: 0.25rem solid !important;
+  margin-bottom: -0.25rem !important;
+  text-decoration: none;
+}
+
+@supports (text-decoration-thickness: 25%) {
+  .card.clickable:hover .card-title,
+  .card.clickable:focus .card-title,
+  .card.clickable.focussed .card-title {
+    text-decoration-line: underline;
+    text-decoration-thickness: 25%;
+    text-underline-offset: 25%;
+    border-bottom: 0 !important;
+    margin-bottom: 0 !important;
+  }
 }
 
 .card.clickable:active .card-title {

--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -80,9 +80,22 @@ a:link:visited > ::slotted(svg) {
 :host(.footer-link) a:link:focus,
 :host(.footer-link) a ::slotted(a:link:hover),
 :host(.footer-link) a ::slotted(a:link:focus) {
-  text-decoration-line: underline;
-  text-decoration-thickness: 25%;
-  text-underline-offset: 25%;
+  border-bottom: 0.25rem solid !important;
+  margin-bottom: -0.25rem !important;
+  text-decoration: none;
+}
+
+@supports (text-decoration-thickness: 25%) {
+  :host(.footer-link) a:link:hover,
+  :host(.footer-link) a:link:focus,
+  :host(.footer-link) a ::slotted(a:link:hover),
+  :host(.footer-link) a ::slotted(a:link:focus) {
+    text-decoration-line: underline;
+    text-decoration-thickness: 25%;
+    text-underline-offset: 25%;
+    border-bottom: 0 !important;
+    margin-bottom: 0 !important;
+  }
 }
 
 :host(.footer-link) a:link:hover,

--- a/packages/web-components/src/components/ic-link/ic-link.css
+++ b/packages/web-components/src/components/ic-link/ic-link.css
@@ -27,10 +27,23 @@
 :host(.link) .ic-link:focus,
 :host(.link) ::slotted(a:hover),
 :host(.link) ::slotted(a:focus) {
-  text-decoration-line: underline;
-  text-decoration-thickness: 25%;
-  text-underline-offset: 25%;
   outline: none;
+  border-bottom: 0.25rem solid !important;
+  margin-bottom: -0.25rem !important;
+  text-decoration: none;
+}
+
+@supports (text-decoration-thickness: 25%) {
+  :host(.link) .ic-link:hover,
+  :host(.link) .ic-link:focus,
+  :host(.link) ::slotted(a:hover),
+  :host(.link) ::slotted(a:focus) {
+    text-decoration-line: underline;
+    text-decoration-thickness: 25%;
+    text-underline-offset: 25%;
+    border-bottom: 0 !important;
+    margin-bottom: 0 !important;
+  }
 }
 
 :host(.link) .ic-link:active,


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Replace text-decoration-thickness and text-underline-offset with border-bottom for breadcrumb, card, footer link, and links so that all browsers provide the correct hover state

## Related issue
#508 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 