### PR TITLE
Fixes select IcChange debounce when using arrow keys

### DIFF
--- a/packages/react/src/stories/ic-select.stories.mdx
+++ b/packages/react/src/stories/ic-select.stories.mdx
@@ -157,13 +157,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Default">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -175,13 +173,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Default value">
     {() => {
-      const [value, setValue] = useState("Cap");
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -193,14 +189,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="With clear button">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           showClearButton
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -212,13 +206,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="With description">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={optionsWithDescriptions}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -230,14 +222,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Helper text">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           helperText="Some helper text"
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -249,14 +239,13 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Custom placeholder">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           placeholder="Placeholder goes here"
           options={options}
           value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -268,14 +257,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Small">
     {() => {
-      const [value, setValue] = useState(null);
-      return (
+       return (
         <IcSelect
           label="What is your favourite coffee?"
           small
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -287,14 +274,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Disabled">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           disabled
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -306,13 +291,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Disabled options">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={optionsWithDisabled}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -324,14 +307,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Full width">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           fullWidth
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -343,14 +324,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Hidden label">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           hideLabel
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -362,14 +341,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Required">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           required
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -381,14 +358,13 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Read-only">
     {() => {
-      const [value, setValue] = useState("Cap");
       return (
         <IcSelect
           label="What is your favourite coffee?"
           readonly
           options={options}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          value="Cap"
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -400,13 +376,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Groups">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={groupedOptions}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -418,13 +392,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Recommended">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={optionsWithRecommended}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -436,9 +408,6 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Validation">
     {() => {
-      const [value1, setValue1] = useState(null);
-      const [value2, setValue2] = useState(null);
-      const [value3, setValue3] = useState(null);
       return (
         <div>
           <IcSelect
@@ -446,7 +415,6 @@ export const searchableOptionsWithRecommended = [
             validationStatus="success"
             validationText="Success message"
             options={options}
-            value={value1}
             onIcChange={(event) => setValue1(event.detail.value)}
           ></IcSelect>
           <IcSelect
@@ -454,7 +422,6 @@ export const searchableOptionsWithRecommended = [
             validationStatus="warning"
             validationText="Warning message"
             options={options}
-            value={value2}
             onIcChange={(event) => setValue2(event.detail.value)}
           ></IcSelect>
           <IcSelect
@@ -462,7 +429,6 @@ export const searchableOptionsWithRecommended = [
             validationStatus="error"
             validationText="Error message"
             options={options}
-            value={value3}
             onIcChange={(event) => setValue3(event.detail.value)}
           ></IcSelect>
         </div>
@@ -476,13 +442,11 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Scroll behaviour">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={manyOptions}
-          value={value}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -494,14 +458,12 @@ export const searchableOptionsWithRecommended = [
 <Canvas>
   <Story name="Searchable default">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -509,14 +471,13 @@ export const searchableOptionsWithRecommended = [
 </Canvas>
 
 export const SearchableDefaultValue = () => {
-  const [value, setValue] = useState('Cap'); 
   return (
     <IcSelect
       label="What is your favourite coffee?"
       required
-      value={value}
+      value="Cap"
       options={searchableOptions}
-      onIcChange={e => setValue(e.detail.value || '')}
+      onIcChange={e => console.log(e.detail.value)}
       searchable
       showClearButton
     />
@@ -535,15 +496,14 @@ export const SearchableDefaultValue = () => {
 </Canvas>
 
 export const SearchableFormDefaultValue = () => {
-  const [value, setValue] = useState('Cap'); 
   return (
     <form>
       <IcSelect
         label="What is your favourite coffee?"
         required
-        value={value}
+        value="Cap"
         options={searchableOptions}
-        onIcChange={e => setValue(e.detail.value || '')}
+        onIcChange={e => console.log(e.detail.value)}
         searchable
         showClearButton
       />
@@ -568,15 +528,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable filter by start of options">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           filterMatchPosition="start"
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -588,15 +546,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable characters until suggestions">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           charactersUntilSuggestions={3}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -608,14 +564,12 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable with description">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptionsWithDescriptions}
-          value={value}
           searchable
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -627,15 +581,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable with description (included in search)">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptionsWithDescriptions}
-          value={value}
           searchable
           includeDescriptionsInSearch
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -647,15 +599,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable helper text">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           helperText="Some helper text"
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -667,15 +617,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable small">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           small
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -687,15 +635,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable disabled">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           disabled
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -707,14 +653,12 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable disabled options">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptionsWithDisabled}
-          value={value}
           searchable
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -726,15 +670,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable hidden label">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           hideLabel
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -746,15 +688,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable required">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptions}
-          value={value}
           searchable
           required
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -766,14 +706,12 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable groups">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={groupedOptions}
-          value={value}
           searchable
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -785,15 +723,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable groups (group titles included in search)">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={groupedOptions}
-          value={value}
           searchable
           includeGroupTitlesInSearch
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -805,15 +741,13 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable groups characters until suggestions">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={groupedOptions}
-          value={value}
           searchable
           charactersUntilSuggestions={3}
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -825,14 +759,12 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable recommended">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={searchableOptionsWithRecommended}
-          value={value}
           searchable
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -844,9 +776,6 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable validation">
     {() => {
-      const [value1, setValue1] = useState(null);
-      const [value2, setValue2] = useState(null);
-      const [value3, setValue3] = useState(null);
       return (
         <div>
           <IcSelect
@@ -854,7 +783,6 @@ export const SearchableFormDefaultValue = () => {
             validationStatus="success"
             validationText="Success message"
             options={options}
-            value={value1}
             searchable
             onIcChange={(event) => setValue1(event.detail.value)}
           ></IcSelect>
@@ -863,7 +791,6 @@ export const SearchableFormDefaultValue = () => {
             validationStatus="warning"
             validationText="Warning message"
             options={options}
-            value={value2}
             searchable
             onIcChange={(event) => setValue2(event.detail.value)}
           ></IcSelect>
@@ -872,7 +799,6 @@ export const SearchableFormDefaultValue = () => {
             validationStatus="error"
             validationText="Error message"
             options={options}
-            value={value3}
             searchable
             onIcChange={(event) => setValue3(event.detail.value)}
           ></IcSelect>
@@ -887,14 +813,12 @@ export const SearchableFormDefaultValue = () => {
 <Canvas>
   <Story name="Searchable many options">
     {() => {
-      const [value, setValue] = useState(null);
       return (
         <IcSelect
           label="What is your favourite coffee?"
           options={manyOptions}
-          value={value}
           searchable
-          onIcChange={(event) => setValue(event.detail.value)}
+          onIcChange={(event) => console.log(event.detail.value)}
         ></IcSelect>
       );
     }}
@@ -916,7 +840,6 @@ export const ExternalFiltering = () => {
     { label: "Macchiato", value: "Mac" },
   ];
   const [query, setQuery] = useState('');
-  const [value, setValue] = useState(null);
   const [selectedValue, setSelectedValue] = useState(null);
   const [results, setResults] = useState([]);
   useEffect(() => {
@@ -933,7 +856,7 @@ export const ExternalFiltering = () => {
     }
   },[query])
   const handleChange = (event) => {
-    setValue(event.detail.value);
+    console.log(event.detail.value);
     setQuery(event.detail.value);
   }
   const handleOptionSelect = (event) =>{
@@ -943,7 +866,7 @@ export const ExternalFiltering = () => {
     setResults([]);
   }
   return (
-    <IcSelect debounce={300} label="What is your favourite coffee?" searchable disableFilter charactersUntilSuggestions="2" options={results} onIcOptionSelect={handleOptionSelect} onIcChange={handleChange} onIcClear={handleClear} value={value}/>
+    <IcSelect debounce={300} label="What is your favourite coffee?" searchable disableFilter charactersUntilSuggestions="2" options={results} onIcOptionSelect={handleOptionSelect} onIcChange={handleChange} onIcClear={handleClear}/>
   );
 };
 

--- a/packages/web-components/src/components/ic-select/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.spec.tsx
@@ -1170,18 +1170,6 @@ describe("ic-select", () => {
 
     page.root.options = menuOptions;
     await page.waitForChanges();
-
-    //test debounce changes to 0 when menu opened
-    input.focus();
-    await page.waitForChanges();
-    await page.rootInstance.handleKeyDown({
-      key: "ArrowDown",
-      preventDefault: (): void => null,
-    });
-    await page.waitForChanges();
-
-    expect(page.rootInstance.open).toBe(true);
-    expect(page.rootInstance.currDebounce).toBe(0);
   });
 
   it("should test menus opens and closes when enter pressed - external filtering", async () => {

--- a/packages/web-components/src/components/ic-select/ic-select.stories.mdx
+++ b/packages/web-components/src/components/ic-select/ic-select.stories.mdx
@@ -27,8 +27,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -46,8 +45,7 @@ import readme from "./readme.md";
           var option = "Cappuccino";
           select.options = [];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
           setTimeout(() => {
             select.options = [
@@ -84,8 +82,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -110,8 +107,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -145,8 +141,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -171,8 +166,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -197,8 +191,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -220,8 +213,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -246,8 +238,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -269,8 +260,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -295,8 +285,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -321,8 +310,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -347,8 +335,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -374,8 +361,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -408,8 +394,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -433,8 +418,7 @@ import readme from "./readme.md";
             { label: "Filter", value: "Fil" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -461,8 +445,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select1.addEventListener("icChange", function (event) {
-            option1 = event.detail.value;
-            select1.value = option1;
+            console.log(event.detail.value);
           });
         </script>
         <ic-select
@@ -480,8 +463,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select2.addEventListener("icChange", function (event) {
-            option2 = event.detail.value;
-            select2.value = option2;
+            console.log(event.detail.value);
           });
         </script>
         <ic-select
@@ -499,8 +481,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select3.addEventListener("icChange", function (event) {
-            option3 = event.detail.value;
-            select3.value = option3;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -531,8 +512,7 @@ import readme from "./readme.md";
             { label: "Latte macchiato", value: "Lam" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -561,8 +541,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
           document.querySelector("form").addEventListener("submit", (ev) => {
             ev.preventDefault();
@@ -596,8 +575,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -618,8 +596,7 @@ import readme from "./readme.md";
           var option = "Cappuccino";
           select.options = [];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
           setTimeout(() => {
             select.options = [
@@ -663,8 +640,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -694,8 +670,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -725,8 +700,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -784,8 +758,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -844,8 +817,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -875,8 +847,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -906,8 +877,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -937,8 +907,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -967,8 +936,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac", disabled: true },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -998,8 +966,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1029,8 +996,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1066,8 +1032,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1104,8 +1069,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1142,8 +1106,7 @@ import readme from "./readme.md";
             },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1172,8 +1135,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1205,8 +1167,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select1.addEventListener("icChange", function (event) {
-            option1 = event.detail.value;
-            select1.value = option1;
+            console.log(event.detail.value);
           });
         </script>
         <ic-select
@@ -1229,8 +1190,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select2.addEventListener("icChange", function (event) {
-            option2 = event.detail.value;
-            select2.value = option2;
+            console.log(event.detail.value);
           });
         </script>
         <ic-select
@@ -1253,8 +1213,7 @@ import readme from "./readme.md";
             { label: "Macchiato", value: "Mac" },
           ];
           select3.addEventListener("icChange", function (event) {
-            option3 = event.detail.value;
-            select3.value = option3;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1287,8 +1246,7 @@ import readme from "./readme.md";
             { label: "Ristretto", value: "Ris" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
         </script>`
     }
@@ -1343,7 +1301,7 @@ import readme from "./readme.md";
           });
           select.addEventListener("icChange", function (event) {
             var option = event.detail.value;
-            select.value = option;
+            console.log(option);
             if (option !== selectedValue) {
               if (option && option.length > 1) {
                 mockAPI = (query) => {
@@ -1393,8 +1351,7 @@ import readme from "./readme.md";
             { label: "Americano", value: "Ame" },
           ];
           select.addEventListener("icChange", function (event) {
-            option = event.detail.value;
-            select.value = option;
+            console.log(event.detail.value);
           });
           document.querySelector("form").addEventListener("submit", (ev) => {
             ev.preventDefault();


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes issue where `IcChange` event was not emitting on a delay when `debounce` prop set and using the arrow keys to navigate the items in the dropdown.

This change means that it is no longer necessary to set the `value` prop in an IcChange handler. it can still be done, but will not have any effect as the value will match the internal state in the component

## Related issue
#461

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 