### PR TITLE
fix(web-components): fixes changing disabled prop

### DIFF
--- a/packages/web-components/src/components/ic-select/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/__snapshots__/ic-select.spec.tsx.snap
@@ -35,7 +35,7 @@ exports[`ic-select should have correct validation status: with-validation-status
 `;
 
 exports[`ic-select should not have a validation status if disabled: no-validation-status-if-disabled 1`] = `
-<ic-select disabled="" label="IC Select Test" validation-status="error">
+<ic-select class="disabled" disabled="" label="IC Select Test" validation-status="error">
   <mock:shadow-root>
     <ic-input-container>
       <ic-input-label disabled="" for="ic-select-input-3" helpertext="" label="IC Select Test"></ic-input-label>
@@ -166,7 +166,7 @@ exports[`ic-select should not render validation text if no validation status has
 `;
 
 exports[`ic-select should render as required: required-searchable 1`] = `
-<ic-select label="IC Select Test" required="true" searchable="true">
+<ic-select class="searchable" label="IC Select Test" required="true" searchable="true">
   <mock:shadow-root>
     <ic-input-container>
       <ic-input-label for="ic-select-input-7" helpertext="" label="IC Select Test" required=""></ic-input-label>

--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -9,7 +9,7 @@
   position: relative;
 }
 
-:host([full-width]) {
+:host(.full-width) {
   width: 100%;
 }
 
@@ -102,15 +102,15 @@ select:not([disabled]) {
   outline: var(--ic-hc-focus-outline);
 }
 
-:host(:not([disabled])) ic-input-component-container:hover .select-input {
+:host(:not(.disabled)) ic-input-component-container:hover .select-input {
   background-color: var(--ic-architectural-white);
 }
 
-:host([disabled]) .select-input {
+.select-input[disabled] {
   pointer-events: none;
 }
 
-:host([searchable]) .select-input {
+:host(.searchable) .select-input {
   cursor: auto;
 }
 
@@ -133,22 +133,22 @@ select:not([disabled]) {
   height: var(--ic-space-lg);
 }
 
-:host([disabled]) .expand-icon,
-:host([disabled]) .expand-icon > svg > path {
+:host(.disabled) .expand-icon,
+:host(.disabled) .expand-icon > svg > path {
   color: var(--ic-architectural-200);
 }
 
-:host([searchable]) .expand-icon {
+:host(.searchable) .expand-icon {
   padding-left: var(--ic-space-xxs);
   height: 2.25rem;
 }
 
-:host([searchable]) .expand-icon > svg {
+:host(.searchable) .expand-icon > svg {
   height: 2.25rem;
   padding: 0 0.375rem;
 }
 
-:host([searchable]:not([disabled])) .expand-icon > svg {
+:host(.searchable:not(.disabled)) .expand-icon > svg {
   cursor: pointer;
 }
 
@@ -161,11 +161,11 @@ select:not([disabled]) {
 }
 
 .expand-icon-open,
-:host([searchable]) .expand-icon-open {
+:host(.searchable) .expand-icon-open {
   transform: rotateX(180deg);
 }
 
-:host([disabled]) .value-text,
+:host(.disabled) .value-text,
 .placeholder {
   color: var(--ic-color-tertiary-text);
 }
@@ -181,7 +181,7 @@ select:not([disabled]) {
   padding-left: 2.375rem;
 }
 
-:host([small]) .clear-button-container {
+:host(.small) .clear-button-container {
   padding-left: 1.875rem;
 }
 
@@ -193,7 +193,7 @@ select:not([disabled]) {
   height: var(--ic-space-lg);
 }
 
-:host([small]) .divider {
+:host(.small) .divider {
   height: var(--ic-space-md);
 }
 

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -767,7 +767,14 @@ export class Select {
     ).trim();
 
     return (
-      <Host>
+      <Host
+        class={{
+          disabled: disabled,
+          searchable: searchable,
+          small: small,
+          "full-width": fullWidth,
+        }}
+      >
         <ic-input-container readonly={readonly}>
           {!hideLabel && (
             <ic-input-label
@@ -897,7 +904,6 @@ export class Select {
                     "expand-icon-filled": !(
                       currValue == null || currValue === ""
                     ),
-                    "expand-icon-disabled": !this.isMenuEnabled(),
                   }}
                   innerHTML={Expand}
                   aria-hidden="true"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes styling & interaction after removing disabled prop. Styles are now applied based on classes being applied to the host rather than relying on the prop\attribute.

## Related issue
#548 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 