### PR TITLE
fix(web-components): removed shadow DOM from ic-menu for a11y fixes

### DIFF
--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -24,7 +24,7 @@ import {
 @Component({
   tag: "ic-menu",
   styleUrl: "ic-menu.css",
-  shadow: true,
+  scoped: true,
 })
 export class Menu {
   @Element() host: HTMLIcMenuElement;
@@ -281,7 +281,7 @@ export class Menu {
     );
 
     const getOptionId = (index: number): string =>
-      Array.from(this.host.shadowRoot.querySelectorAll("li"))[index].id;
+      Array.from(this.host.querySelectorAll("li"))[index].id;
 
     switch (event.key) {
       case "ArrowDown":
@@ -520,7 +520,7 @@ export class Menu {
 
   private setMenuScrollbar = () => {
     let optionsHeight = 0;
-    this.host.shadowRoot
+    this.host
       .querySelectorAll(".option")
       .forEach((option) => (optionsHeight += option.clientHeight));
 
@@ -618,7 +618,7 @@ export class Menu {
         !this.focusFromSearchKeypress &&
         !this.preventIncorrectTabOrder
       ) {
-        const highlightedEl = this.host.shadowRoot.querySelector(
+        const highlightedEl = this.host.querySelector(
           `li[data-value="${this.optionHighlighted}"]`
         ) as HTMLElement;
 

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.e2e.ts
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.e2e.ts
@@ -144,9 +144,9 @@ describe("ic-search-bar", () => {
 
     await page.waitForTimeout(500);
 
-    const menuItems = menu.shadowRoot.querySelectorAll("li");
+    const menuItems = menu.findAll("li");
 
-    expect(await menuItems.length).toBe(2);
+    expect((await menuItems).length).toBe(2);
     expect(await menu.isVisible()).toBeTruthy();
   });
 
@@ -250,8 +250,7 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     const activeElId = await page.$eval("ic-search-bar", (el) => {
-      const textfield = el.shadowRoot.querySelector("ic-text-field");
-      return textfield.querySelector("ic-menu").shadowRoot.activeElement.id;
+      return el.shadowRoot.activeElement.id;
     });
 
     expect(activeElId).toBe("ic-search-bar-input-0-menu-qux");
@@ -277,8 +276,7 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     const activeElId = await page.$eval("ic-search-bar", (el) => {
-      const textfield = el.shadowRoot.querySelector("ic-text-field");
-      return textfield.querySelector("ic-menu").shadowRoot.activeElement.id;
+      return el.shadowRoot.activeElement.id;
     });
 
     expect(activeElId).toBe("ic-search-bar-input-0-menu-qux");
@@ -476,17 +474,17 @@ describe("ic-search-bar", () => {
 
     await page.waitForChanges();
 
-    let menuItems = menu.shadowRoot.querySelectorAll("li");
+    let menuItems = menu.findAll("li");
 
-    expect(await menuItems.length).toBe(2);
+    expect(await (await menuItems).length).toBe(2);
 
     await page.keyboard.press("r");
 
     await page.waitForChanges();
 
-    menuItems = menu.shadowRoot.querySelectorAll("li");
+    menuItems = menu.findAll("li");
 
-    expect(await menuItems.length).toBe(1);
+    expect(await (await menuItems).length).toBe(1);
   });
 
   it("should prevent form submit event when clear is invoked using Enter", async () => {
@@ -578,10 +576,8 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     const focusedElement = await page.evaluate(() => {
-      const el = document
-        .querySelector("ic-search-bar")
-        .shadowRoot.querySelector("ic-menu");
-      return el.shadowRoot.activeElement.id;
+      const el = document.querySelector("ic-search-bar").shadowRoot;
+      return el.activeElement.id;
     });
 
     expect(focusedElement).toBe("ic-search-bar-input-0-menu-qux");
@@ -654,7 +650,7 @@ describe("ic-search-bar", () => {
       const menuEl = document
         .querySelector("ic-search-bar")
         .shadowRoot.querySelector("ic-menu");
-      const noOptionsItem = menuEl.shadowRoot.querySelectorAll("li")[0];
+      const noOptionsItem = menuEl.querySelectorAll("li")[0];
 
       return noOptionsItem.innerText;
     });
@@ -683,7 +679,7 @@ describe("ic-search-bar", () => {
       const menuEl = document
         .querySelector("ic-search-bar")
         .shadowRoot.querySelector("ic-menu");
-      const noOptionsItem = menuEl.shadowRoot.querySelectorAll("li")[0];
+      const noOptionsItem = menuEl.querySelectorAll("li")[0];
 
       return noOptionsItem.innerText;
     });
@@ -732,7 +728,7 @@ describe("ic-search-bar", () => {
       const menuEl = document
         .querySelector("ic-search-bar")
         .shadowRoot.querySelector("ic-menu");
-      const firstMenuItem = menuEl.shadowRoot.querySelectorAll("li")[0];
+      const firstMenuItem = menuEl.querySelectorAll("li")[0];
 
       return firstMenuItem.classList.contains("focused-option");
     });
@@ -762,7 +758,7 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     let menu = await page.find("ic-search-bar >>> ic-text-field ic-menu");
-    let firstOption = menu.shadowRoot.querySelectorAll("li")[0];
+    let firstOption = (await menu.findAll("li"))[0];
     expect(firstOption).toHaveClass("focused-option");
 
     await searchBar.press("Enter");
@@ -784,8 +780,8 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     menu = await page.find("ic-search-bar >>> ic-text-field ic-menu");
-    firstOption = menu.shadowRoot.querySelectorAll("li")[0];
-    const lastOption = menu.shadowRoot.querySelectorAll("li")[1];
+    firstOption = (await menu.findAll("li"))[0];
+    const lastOption = (await menu.findAll("li"))[1];
 
     expect(firstOption).not.toHaveClass("focused-option");
     expect(lastOption).toHaveClass("focused-option");
@@ -847,10 +843,8 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     focusedElement = await page.evaluate(() => {
-      const el = document
-        .querySelector("ic-search-bar")
-        .shadowRoot.querySelector("ic-menu");
-      return el.shadowRoot.activeElement.id;
+      const el = document.querySelector("ic-search-bar").shadowRoot;
+      return el.activeElement.id;
     });
 
     expect(focusedElement).toBe("ic-search-bar-input-0-menu-bar");
@@ -894,10 +888,8 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     let focusedElement = await page.evaluate(() => {
-      const el = document
-        .querySelector("ic-search-bar")
-        .shadowRoot.querySelector("ic-menu");
-      return el.shadowRoot.activeElement.id;
+      const el = document.querySelector("ic-search-bar").shadowRoot;
+      return el.activeElement.id;
     });
 
     expect(focusedElement).toBe("ic-search-bar-input-0-menu-bar");
@@ -995,7 +987,7 @@ describe("ic-search-bar", () => {
       const menuEl = document
         .querySelector("ic-search-bar")
         .shadowRoot.querySelector("ic-menu");
-      const noOptionsItem = menuEl.shadowRoot.querySelectorAll("li")[0];
+      const noOptionsItem = menuEl.querySelectorAll("li")[0];
 
       return noOptionsItem.innerText;
     });
@@ -1012,7 +1004,7 @@ describe("ic-search-bar", () => {
       const menuEl = document
         .querySelector("ic-search-bar")
         .shadowRoot.querySelector("ic-menu");
-      const firstOptionItem = menuEl.shadowRoot.querySelectorAll("li")[0];
+      const firstOptionItem = menuEl.querySelectorAll("li")[0];
 
       return firstOptionItem.classList.contains("focused-option");
     });
@@ -1040,10 +1032,8 @@ describe("ic-search-bar", () => {
     await page.waitForChanges();
 
     let focusedElement = await page.evaluate(() => {
-      const el = document
-        .querySelector("ic-search-bar")
-        .shadowRoot.querySelector("ic-menu");
-      return el.shadowRoot.activeElement.id;
+      const el = document.querySelector("ic-search-bar").shadowRoot;
+      return el.activeElement.id;
     });
 
     expect(focusedElement).toBe("ic-search-bar-input-0-menu-qux");

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.spec.ts
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.spec.ts
@@ -338,11 +338,9 @@ describe("ic-search-bar search", () => {
     page.rootInstance.open = true;
     await page.waitForChanges();
 
-    let items = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelectorAll("li");
+    let items = Array.from(page.root.shadowRoot.querySelectorAll("ic-menu li"));
 
-    items[2].click();
+    (items[2] as HTMLElement).click();
     await page.waitForChanges();
 
     expect(page.rootInstance.value).toBe("flatwhite");
@@ -350,10 +348,9 @@ describe("ic-search-bar search", () => {
     page.rootInstance.open = true;
     await page.waitForChanges();
 
-    items = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelectorAll("li");
-    items[2].blur();
+    items = Array.from(page.root.shadowRoot.querySelectorAll("ic-menu li"));
+
+    (items[2] as HTMLElement).blur();
     expect(page.rootInstance.open).toBe(false);
   });
 

--- a/packages/web-components/src/components/ic-select/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/__snapshots__/ic-select.spec.tsx.snap
@@ -24,9 +24,7 @@ exports[`ic-select should have correct validation status: with-validation-status
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
       <ic-input-validation arialivemode="polite" for="ic-select-input-2" message="" status="error"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -58,9 +56,7 @@ exports[`ic-select should not have a validation status if disabled: no-validatio
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" disabled="" name="ic-select-input-3" type="hidden" value="">
@@ -90,9 +86,7 @@ exports[`ic-select should not render a label when the 'hide-label' prop is suppl
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-0" type="hidden" value="">
@@ -123,9 +117,7 @@ exports[`ic-select should not render validation text if disabled: no-validation-
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-6" type="hidden" value="">
@@ -156,9 +148,7 @@ exports[`ic-select should not render validation text if no validation status has
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-5" type="hidden" value="">
@@ -182,9 +172,7 @@ exports[`ic-select should render as required: required-searchable 1`] = `
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-7" type="hidden" value="">
@@ -215,9 +203,7 @@ exports[`ic-select should render correct validation text: with-validation-text 1
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
       <ic-input-validation arialivemode="polite" for="ic-select-input-4" message="Test validation text" status="error"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -238,9 +224,7 @@ exports[`ic-select should render readonly: readonly 1`] = `
           </ic-typography>
         </div>
       </ic-input-component-container>
-      <ic-menu>
-        <mock:shadow-root></mock:shadow-root>
-      </ic-menu>
+      <ic-menu></ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-1" type="hidden" value="">
@@ -344,37 +328,35 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
         </div>
       </ic-input-component-container>
       <ic-menu>
-        <mock:shadow-root>
-          <ul aria-activedescendant="ic-select-input-8-menu-test-value" aria-label="IC Select Test" class="menu" id="ic-select-input-8-menu" role="listbox" tabindex="0">
-            <li aria-disabled="false" aria-label="Test label 1" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-8-menu-Test value 1" role="option" tabindex="-1">
-              <div class="option-text-container">
-                <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    Test label 1
-                  </p>
-                </ic-typography>
-              </div>
-            </li>
-            <li aria-disabled="false" aria-label="Test label 2" class="option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-8-menu-Test value 2" role="option" tabindex="-1">
-              <div class="option-text-container">
-                <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    Test label 2
-                  </p>
-                </ic-typography>
-              </div>
-            </li>
-            <li aria-disabled="false" aria-label="Test label 3" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-8-menu-Test value 3" role="option" tabindex="-1">
-              <div class="option-text-container">
-                <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    Test label 3
-                  </p>
-                </ic-typography>
-              </div>
-            </li>
-          </ul>
-        </mock:shadow-root>
+        <ul aria-activedescendant="ic-select-input-8-menu-test-value" aria-label="IC Select Test" class="menu" id="ic-select-input-8-menu" role="listbox" tabindex="0">
+          <li aria-disabled="false" aria-label="Test label 1" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-8-menu-Test value 1" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <ic-typography aria-hidden="true" variant="body">
+                <p>
+                  Test label 1
+                </p>
+              </ic-typography>
+            </div>
+          </li>
+          <li aria-disabled="false" aria-label="Test label 2" class="option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-8-menu-Test value 2" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <ic-typography aria-hidden="true" variant="body">
+                <p>
+                  Test label 2
+                </p>
+              </ic-typography>
+            </div>
+          </li>
+          <li aria-disabled="false" aria-label="Test label 3" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-8-menu-Test value 3" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <ic-typography aria-hidden="true" variant="body">
+                <p>
+                  Test label 3
+                </p>
+              </ic-typography>
+            </div>
+          </li>
+        </ul>
       </ic-menu>
     </ic-input-container>
   </mock:shadow-root>

--- a/packages/web-components/src/components/ic-select/ic-select.e2e.ts
+++ b/packages/web-components/src/components/ic-select/ic-select.e2e.ts
@@ -107,8 +107,7 @@ const getMenuVisibility = async (page: E2EPage) => {
   const menuVisibility = await page.evaluate(() => {
     const menu = document
       .querySelector("ic-select")
-      .shadowRoot.querySelector("ic-menu")
-      .shadowRoot.querySelector("#ic-select-input-0-menu");
+      .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
     return window.getComputedStyle(menu).visibility;
   });
   return menuVisibility;
@@ -183,42 +182,7 @@ describe("ic-select", () => {
 
       const select = await page.find("ic-select");
 
-      expect(select.shadowRoot)
-        .toEqualHtml(`<ic-input-container class="hydrated">
-      <!---->
-      <div class="component-container">
-        <ic-input-label class="hydrated">
-          <ic-typography class="hydrated ic-typography-label">
-            <label for="ic-select-input-0">
-              IC Select Test
-            </label>
-          </ic-typography>
-        </ic-input-label>
-        <ic-input-component-container class="hydrated">
-          <!---->
-          <div class="focus-indicator">
-            <div class="select-container">
-              <button aria-controls="ic-select-input-0-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-0-menu" class="select-input" id="ic-select-input-0">
-                <ic-typography class="hydrated ic-typography-body placeholder value-text">
-                  <p>
-                    Select an option
-                  </p>
-                </ic-typography>
-                <div class="select-input-end">
-                  <span aria-hidden="true" class="expand-icon">
-                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M7 9.5L12 14.5L17 9.5H7Z" fill="currentColor"></path>
-                    </svg>
-                  </span>
-                </div>
-              </button>
-            </div>
-          </div>
-        </ic-input-component-container>
-        <ic-menu class="hydrated"></ic-menu>
-      </div>
-    </ic-input-container>
-      `);
+      expect(select.shadowRoot).toMatchSnapshot();
     });
 
     it("should render when no options are provided", async () => {
@@ -228,42 +192,7 @@ describe("ic-select", () => {
 
       const select = await page.find("ic-select");
 
-      expect(select.shadowRoot).toEqualHtml(`
-        <ic-input-container class="hydrated">
-      <!---->
-      <div class="component-container">
-        <ic-input-label class="hydrated">
-          <ic-typography class="hydrated ic-typography-label">
-            <label for="ic-select-input-0">
-              IC Select Test
-            </label>
-          </ic-typography>
-        </ic-input-label>
-        <ic-input-component-container class="hydrated">
-          <!---->
-          <div class="focus-indicator">
-            <div class="select-container">
-              <button aria-controls="ic-select-input-0-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-0-menu" class="select-input" id="ic-select-input-0">
-                <ic-typography class="hydrated ic-typography-body placeholder value-text">
-                  <p>
-                    Select an option
-                  </p>
-                </ic-typography>
-                <div class="select-input-end">
-                  <span aria-hidden="true" class="expand-icon">
-                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M7 9.5L12 14.5L17 9.5H7Z" fill="currentColor"></path>
-                    </svg>
-                  </span>
-                </div>
-              </button>
-            </div>
-          </div>
-        </ic-input-component-container>
-        <ic-menu class="hydrated"></ic-menu>
-      </div>
-    </ic-input-container>
-      `);
+      expect(select.shadowRoot).toMatchSnapshot();
     });
 
     it("should open, set focus on menu and set aria-expanded to 'true' when input clicked", async () => {
@@ -274,8 +203,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -287,8 +215,7 @@ describe("ic-select", () => {
       const newMenuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(newMenuVisibility).toBe("visible");
@@ -296,8 +223,7 @@ describe("ic-select", () => {
 
       const activeElId = await page.$eval(
         "ic-select",
-        (el) =>
-          el.shadowRoot.querySelector("ic-menu").shadowRoot.activeElement.id
+        (el) => el.shadowRoot.activeElement.id
       );
       expect(activeElId).toBe("ic-select-input-0-menu");
     });
@@ -311,10 +237,8 @@ describe("ic-select", () => {
       await select.click();
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(3);
       expect(menuOptions[0]).toEqualText("Test label 1");
       expect(menuOptions[1]).toEqualText("Test label 2");
@@ -347,13 +271,11 @@ describe("ic-select", () => {
         await select.press("ArrowDown");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
         expect(await getMenuVisibility(page)).toBe("visible");
 
-        const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-        expect(firstOption).toHaveClass("focused-option");
+        const firstOption = await menu.findAll("li");
+        expect(firstOption[0]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 1");
       });
 
@@ -391,13 +313,11 @@ describe("ic-select", () => {
         await select.press("ArrowUp");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
         expect(await getMenuVisibility(page)).toBe("visible");
 
-        const lastOption = await menu.shadowRoot.querySelectorAll("li")[2];
-        expect(lastOption).toHaveClass("focused-option");
+        const lastOption = await menu.findAll("li");
+        expect(lastOption[2]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 3");
       });
     });
@@ -413,11 +333,9 @@ describe("ic-select", () => {
         await select.press("ArrowDown");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const secondOption = await menu.shadowRoot.querySelectorAll("li")[1];
-        expect(secondOption).toHaveClass("focused-option");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const secondOption = await menu.findAll("li");
+        expect(secondOption[1]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 2");
       });
 
@@ -431,11 +349,9 @@ describe("ic-select", () => {
         await select.press("ArrowDown");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-        expect(firstOption).toHaveClass("focused-option");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const firstOption = await menu.findAll("li");
+        expect(firstOption[0]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 1");
       });
 
@@ -449,11 +365,9 @@ describe("ic-select", () => {
         await select.press("ArrowUp");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const secondOption = await menu.shadowRoot.querySelectorAll("li")[1];
-        expect(secondOption).toHaveClass("focused-option");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const secondOption = await menu.findAll("li");
+        expect(secondOption[1]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 2");
       });
 
@@ -467,11 +381,9 @@ describe("ic-select", () => {
         await select.press("ArrowUp");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const lastOption = await menu.shadowRoot.querySelectorAll("li")[2];
-        expect(lastOption).toHaveClass("focused-option");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const lastOption = await menu.findAll("li");
+        expect(lastOption[2]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 3");
       });
 
@@ -485,11 +397,9 @@ describe("ic-select", () => {
         await page.keyboard.press("Home");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-        expect(firstOption).toHaveClass("focused-option");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const firstOption = await menu.findAll("li");
+        expect(firstOption[0]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 1");
       });
 
@@ -503,11 +413,9 @@ describe("ic-select", () => {
         await page.keyboard.press("End");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const lastOption = await menu.shadowRoot.querySelectorAll("li")[2];
-        expect(lastOption).toHaveClass("focused-option");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const lastOption = await menu.findAll("li");
+        expect(lastOption[2]).toHaveClass("focused-option");
         expect(select).toEqualText("Test label 3");
       });
 
@@ -520,14 +428,10 @@ describe("ic-select", () => {
         await select.press("ArrowDown");
         await page.waitForChanges();
 
-        const menu = await page.find(
-          "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-        );
-        const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-        const checkIcon = await menu.shadowRoot
-          .querySelectorAll("li")[0]
-          .querySelector(".check-icon");
-        expect(firstOption).toHaveAttribute("aria-selected");
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const firstOption = await menu.findAll("li");
+        const checkIcon = await menu.find("li .check-icon");
+        expect(firstOption[0]).toHaveAttribute("aria-selected");
         expect(checkIcon).not.toBeNull();
       });
 
@@ -601,8 +505,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -624,9 +527,7 @@ describe("ic-select", () => {
       await page.waitForChanges();
 
       const icChange = await page.spyOnEvent("icChange");
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
       await menu.click();
       await page.waitForChanges();
 
@@ -634,8 +535,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -667,8 +567,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -690,8 +589,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -713,8 +611,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -739,8 +636,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -764,8 +660,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -792,8 +687,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -830,12 +724,8 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const firstOptionDescription = await menu.shadowRoot
-        .querySelectorAll("li")[0]
-        .querySelector(".option-description");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const firstOptionDescription = await menu.find("li .option-description");
       expect(firstOptionDescription).toEqualText("Test description 1");
     });
 
@@ -866,8 +756,7 @@ describe("ic-select", () => {
       const menuVisibility = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector("#ic-select-input-0-menu");
+          .shadowRoot.querySelector("ic-menu #ic-select-input-0-menu");
         return window.getComputedStyle(menu).visibility;
       });
       expect(menuVisibility).toBe("hidden");
@@ -887,9 +776,7 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
       await menu.click();
       await page.waitForChanges();
 
@@ -910,10 +797,8 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions[0]).toHaveAttribute("aria-disabled");
       expect(menuOptions[1]).toHaveClass("focused-option");
     });
@@ -984,9 +869,8 @@ describe("ic-select", () => {
         Array.from(
           document
             .querySelector("ic-select")
-            .shadowRoot.querySelector("ic-menu")
-            .shadowRoot.querySelectorAll("ic-typography"),
-          (typography) => typography.innerText
+            .shadowRoot.querySelectorAll("ic-menu ic-typography"),
+          (typography) => (typography as HTMLElement).innerText
         )
       );
       expect(optionsText[0]).toBe("Test group");
@@ -1011,10 +895,8 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const childOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const childOptions = await menu.findAll("li");
       expect(childOptions).toHaveLength(3);
       expect(childOptions[0]).toEqualText("Test label 1");
       expect(childOptions[1]).toEqualText("Test label 2");
@@ -1036,11 +918,9 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-      expect(firstOption).toEqualText("Test label 2");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const firstOption = await menu.findAll("li");
+      expect(firstOption[0]).toEqualText("Test label 2");
     });
 
     it("should set aria-invalid if validation status is 'error'", async () => {
@@ -1068,11 +948,9 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-      expect(firstOption.getAttribute("aria-label")).toBe(
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const firstOption = await menu.findAll("li");
+      expect(firstOption[0].getAttribute("aria-label")).toBe(
         "Test label 1, Test description 1"
       );
     });
@@ -1096,11 +974,9 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-      expect(firstOption.getAttribute("aria-label")).toBe(
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const firstOption = await menu.findAll("li");
+      expect(firstOption[0].getAttribute("aria-label")).toBe(
         "Test label 1, Test group group"
       );
     });
@@ -1124,11 +1000,9 @@ describe("ic-select", () => {
       await select.press("ArrowDown");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const firstOption = await menu.shadowRoot.querySelectorAll("li")[0];
-      expect(firstOption.getAttribute("aria-label")).toBe(
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const firstOption = await menu.findAll("li");
+      expect(firstOption[0].getAttribute("aria-label")).toBe(
         "Test label 1, Test description 1, Test group group"
       );
     });
@@ -1178,10 +1052,8 @@ describe("ic-select", () => {
 
       expect(await getMenuVisibility(page)).toBe("visible");
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(4);
       expect(menuOptions[0]).toEqualText("Cappuccino");
       expect(menuOptions[1]).toEqualText("Americano");
@@ -1198,10 +1070,8 @@ describe("ic-select", () => {
       await select.press("z");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(1);
       expect(menuOptions[0]).toEqualText("No results found");
     });
@@ -1219,10 +1089,8 @@ describe("ic-select", () => {
       await select.press("Backspace");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(2);
       expect(menuOptions[0]).toEqualText("Filter");
       expect(menuOptions[1]).toEqualText("Flat white");
@@ -1239,10 +1107,8 @@ describe("ic-select", () => {
       await select.press("l");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(1);
       expect(menuOptions[0]).toEqualText("Latte");
     });
@@ -1269,10 +1135,8 @@ describe("ic-select", () => {
       await select.press("i");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(1);
       expect(menuOptions[0].textContent.substring(0, 5)).toEqualText("Latte");
     });
@@ -1302,10 +1166,8 @@ describe("ic-select", () => {
       await select.press("b");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(1);
       expect(menuOptions[0]).toEqualText("No results found");
     });
@@ -1337,10 +1199,8 @@ describe("ic-select", () => {
       await select.press("b");
       await page.waitForChanges();
 
-      const menu = await page.find(
-        "ic-select >>> ic-menu >>> #ic-select-input-0-menu"
-      );
-      const menuOptions = await menu.shadowRoot.querySelectorAll("li");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      const menuOptions = await menu.findAll("li");
       expect(menuOptions).toHaveLength(2);
       expect(menuOptions[0]).toEqualText("Filter");
       expect(menuOptions[1]).toEqualText("Latte");
@@ -1907,8 +1767,7 @@ describe("ic-select", () => {
       const menuClasses = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector(".menu");
+          .shadowRoot.querySelector("ic-menu .menu");
         return menu.classList;
       });
 
@@ -1927,8 +1786,7 @@ describe("ic-select", () => {
       let menuClasses = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector(".menu");
+          .shadowRoot.querySelector("ic-menu .menu");
         return menu.classList;
       });
 
@@ -1939,8 +1797,7 @@ describe("ic-select", () => {
       menuClasses = await page.evaluate(() => {
         const menu = document
           .querySelector("ic-select")
-          .shadowRoot.querySelector("ic-menu")
-          .shadowRoot.querySelector(".menu");
+          .shadowRoot.querySelector("ic-menu .menu");
         return menu.classList;
       });
 

--- a/packages/web-components/src/components/ic-select/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.spec.tsx
@@ -476,9 +476,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 2";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -506,9 +504,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 1";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -536,9 +532,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 1";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -566,9 +560,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 3";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -596,9 +588,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 3";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -621,9 +611,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 1";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -651,9 +639,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 3";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -681,9 +667,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 3";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -709,9 +693,7 @@ describe("ic-select", () => {
     page.rootInstance.open = true;
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -738,9 +720,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 2";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -768,9 +748,7 @@ describe("ic-select", () => {
     page.root.value = "Test value 2";
     await page.waitForChanges();
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keyup", {
@@ -1320,9 +1298,7 @@ describe("ic-select", () => {
 
     page.win.addEventListener("icChange", eventSpy);
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {
@@ -1417,9 +1393,7 @@ describe("ic-select", () => {
 
     page.win.addEventListener("icChange", eventSpy);
 
-    const list = page.root.shadowRoot
-      .querySelector("ic-menu")
-      .shadowRoot.querySelector("ul");
+    const list = page.root.shadowRoot.querySelector("ic-menu ul");
 
     list.dispatchEvent(
       new window.window.KeyboardEvent("keydown", {

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -674,11 +674,15 @@ export class Select {
   };
 
   private onBlur = (event: FocusEvent): void => {
-    if (
+    const isSearchableAndNoFocusedInternalElements =
       this.searchable &&
       event.relatedTarget !== this.menu &&
-      !(this.clearButton && event.relatedTarget === this.clearButton)
-    ) {
+      !Array.from(this.menu.querySelectorAll("[role='option']")).includes(
+        event.relatedTarget as Element
+      ) &&
+      !(this.clearButton && event.relatedTarget === this.clearButton);
+
+    if (isSearchableAndNoFocusedInternalElements) {
       this.setMenuChange(false);
       this.handleFocusIndicatorDisplay();
     }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
aria-owns and aria-controls was unable to link to the UL element within ic-menu due to shadow DOM encapsulation. Instead of restructuring the component, scoped worked.

Checked against accessibility scanner 'Equal Access Accessibility Checker' chrome plugin

## Related issue
#484 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 