### PR TITLE
chore(root): updated branch CI workflow to run tests on contributor code

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -7,13 +7,27 @@ on:
       - develop
       - gh-pages
       - 'dependabot/**'
+  pull_request:
+    types: [opened, reopened, edited]
 
 concurrency:  
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
+jobs:  
+  ci-check:
+    name: 'CI Check'
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'same_content_newer'
   ic-ui-kit-static-analysis-tests:
+    needs: ci-check
+    if: needs.ci-check.outputs.should_skip != 'true'
     name: 'Static Analysis Tests'
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +63,8 @@ jobs:
         run: npm run test:coverage-ci
 
   ic-ui-kit-e2e-tests:
+    needs: ci-check
+    if: needs.ci-check.outputs.should_skip != 'true'
     name: 'E2E Tests'
     runs-on: ubuntu-latest
     steps:
@@ -66,6 +82,8 @@ jobs:
         run: npm run test-e2e
 
   ic-ui-kit-visual-tests:
+    needs: ci-check
+    if: needs.ci-check.outputs.should_skip != 'true'
     name: 'Visual Regression Tests'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added additional trigger events on CI build so tests can be run on forked repos which are contributing to base develop branch. Hopefully this change will enable the 'Approve and run' functionality (https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks). 
The update includes adding a build trigger when a PR has been:
- Opened
- Reopened
- Edited

This update should work in unison with the default 'push' to branch trigger. There is a particular instance where 'skipped' will appear within the checks:
- If a 'push' tagged build in ongoing and a PR is created.

Also, if a 'push' tagged build is run and complete and a PR is created afterwards, the build will run again tagged as 'pull_request'. 

## Related issue
N/A

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 