### PR TITLE
fix(web-components): update navigation buttons to have 100% height

### DIFF
--- a/packages/web-components/src/components/ic-navigation-button/ic-navigation-button.css
+++ b/packages/web-components/src/components/ic-navigation-button/ic-navigation-button.css
@@ -9,3 +9,7 @@
 :host(.in-side-menu) {
   margin-right: 0;
 }
+
+:host::part(button) {
+  height: 100%;
+}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update navigation buttons to have 100% height so that focus doesn't appear cut off on small breakpoints

## Related issue
#598 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 