### PR TITLE
fix(web-components): fixes tooltips on side navigation items

### DIFF
--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -91,7 +91,6 @@
 
 .bottom-wrapper {
   border-top: var(--ic-keyline-lighten);
-  position: sticky;
   bottom: 0;
   left: 0;
   z-index: 2;
@@ -100,6 +99,10 @@
   display: flex;
   flex-direction: column;
   visibility: hidden;
+}
+
+:host(.inline) .bottom-wrapper {
+  position: sticky;
 }
 
 :host(.dark) .bottom-wrapper {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes tooltips not displaying for secondary nav items. 

## Related issue
#463 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 