### PR TITLE
fix(web-components): added wrap to interaction-container to stack buttons/links zoomed in

### DIFF
--- a/packages/web-components/src/components/ic-hero/ic-hero.css
+++ b/packages/web-components/src/components/ic-hero/ic-hero.css
@@ -55,6 +55,7 @@ ic-typography.heading-bottom-spacing {
   display: flex;
   gap: var(--ic-space-md);
   margin-top: var(--ic-space-lg);
+  flex-wrap: wrap;
 }
 
 .secondary-container {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added flex-wrap: wrap to stack buttons if IcHero is zoomed in 200%+

Screenshots can be found in #594 

## Related issue
#594 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 