### PR TITLE
fix(web-components): prevents space bar causing page to scroll in ic-select

### DIFF
--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -401,6 +401,9 @@ export class Menu {
     this.keyboardNav = false;
 
     switch (event.key) {
+      case " ":
+        event.preventDefault();
+        break;
       case "ArrowUp":
         event.preventDefault();
         this.setPreviousOptionValue(selectedOptionIndex);


### PR DESCRIPTION


## Summary of the changes
space bar now causes menu to close rather than causing page to scroll to the bottom

## Related issue
https://github.com/mi6/ic-ui-kit/issues/541

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 