### PR TITLE
fix(web-components): add overlay to pages when top navigation pop out menu is open

### DIFF
--- a/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.css
+++ b/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.css
@@ -4,6 +4,13 @@
 
 :host {
   display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  min-height: 100% !important;
+  background: rgb(0 0 0 / 60%);
+  z-index: var(--ic-z-index-navigation-menu);
 }
 
 .popout-modal {
@@ -25,7 +32,6 @@
   box-shadow: var(--ic-elevation-overlay);
   overflow-y: auto;
   overflow-x: hidden;
-  z-index: var(--ic-z-index-navigation-menu);
 }
 
 :host(.inline) .popout-menu {

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -193,8 +193,12 @@ export class TopNavigation {
     this.navMenuVisible = show;
     if (show) {
       this.icNavigationMenuOpened.emit();
+      document.body.style.height = "100%";
+      document.body.style.overflow = "hidden";
     } else {
       this.icNavigationMenuClosed.emit();
+      document.body.style.height = "auto";
+      document.body.style.overflow = "auto";
     }
   }
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add overlay to pages when top navigation pop out menu is open to ensure the rest of the page is not responsive

## Related issue
#621 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 