### PR TITLE
fix(root): updating github actions for external contributions

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -8,7 +8,7 @@ on:
       - gh-pages
       - 'dependabot/**'
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 concurrency:  
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -103,7 +103,7 @@ jobs:
 
   ic-ui-kit-deploy:
     needs: [ic-ui-kit-static-analysis-tests, ic-ui-kit-e2e-tests, ic-ui-kit-visual-tests]
-    if: github.repository_owner == 'mi6'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: 'Deploy'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added `synchronize` to the action trigger so updated PRs will require 'approve and run' to continuiously run checks. Also added ternary to deploy step so it is not run during check for external contributors

## Related issue
#627 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 