### PR TITLE
fix(root): updated github action to check event name

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -103,7 +103,7 @@ jobs:
 
   ic-ui-kit-deploy:
     needs: [ic-ui-kit-static-analysis-tests, ic-ui-kit-e2e-tests, ic-ui-kit-visual-tests]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
     name: 'Deploy'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Additional check on deploy step to run if event name is push. This should not be possible for external contrributors. Their build trigger is invoked from the pull_request trigger. Push event should be triggered from internal PRs

## Related issue
#629 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 