### PR TITLE
fix(web-components): fixed closing of popover menu

### DIFF
--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.spec.ts
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.spec.ts
@@ -312,6 +312,10 @@ describe("ic-popover-menu", () => {
 
     jest.spyOn(page.rootInstance, "closeMenu").mockImplementation();
 
+    // Menu should be open before it can be closed
+    page.doc.querySelector("ic-popover-menu").open = true;
+    await page.waitForChanges();
+
     await page.rootInstance.handleKeyDown({
       key: "Escape",
       preventDefault: (): void => null,
@@ -331,6 +335,10 @@ describe("ic-popover-menu", () => {
     });
 
     jest.spyOn(page.rootInstance, "closeMenu").mockImplementation();
+
+    // Menu should be open before it can be closed
+    page.doc.querySelector("ic-popover-menu").open = true;
+    await page.waitForChanges();
 
     await page.rootInstance.handleKeyDown({
       key: "Tab",

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
@@ -318,3 +318,135 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
     }
   </Story>
 </Canvas>
+
+### Multiple popovers on page
+
+<Canvas>
+  <Story name="Multiple popovers on page" parameters={{ loki: { skip: true } }}>
+    {(args) =>
+      html` <ic-link href="/">Link1</ic-link>
+        <ic-button id="button-1" onclick="buttonClick(1)"
+          >Show popover</ic-button
+        >
+        <ic-link href="/">Link2</ic-link>
+        <ic-button id="button-2" onclick="buttonClick(2)"
+          >Show popover 2</ic-button
+        >
+        <ic-link href="/">Link3</ic-link>
+        <script>
+          function buttonClick(pos) {
+            var icPopover = document.querySelector("#popover" + pos);
+            icPopover.open = true;
+          }
+        </script>
+        <div>
+          <ic-popover-menu anchor="button-1" aria-label="popover" id="popover1">
+            <ic-menu-item label="Copy code" disabled="true"></ic-menu-item>
+            <ic-menu-group label="View">
+              <ic-menu-item
+                label="Zoom in"
+                keyboard-shortcut="Cmd+"
+              ></ic-menu-item>
+              <ic-menu-item
+                label="Zoom out"
+                keyboard-shortcut="Cmd-"
+              ></ic-menu-item>
+            </ic-menu-group>
+            <ic-menu-item
+              label="Actions"
+              submenu-trigger-for="abc"
+            ></ic-menu-item>
+            <ic-menu-item
+              label="Logout"
+              variant="destructive"
+              disabled="true"
+            ></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu submenu-id="abc">
+            <ic-menu-item label="Edit"></ic-menu-item>
+            <ic-menu-item
+              label="Find"
+              submenu-trigger-for="abc123"
+            ></ic-menu-item>
+            <ic-menu-item label="Delete" variant="destructive"></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu submenu-id="abc123">
+            <ic-menu-item
+              disabled="true"
+              label="Search the web"
+              description="This will search the web to find the thing you are looking for."
+            ></ic-menu-item>
+            <ic-menu-item label="Find..."></ic-menu-item>
+            <ic-menu-item label="Find icons">
+              <svg
+                slot="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </ic-menu-item>
+            <ic-menu-item
+              label="Show found results"
+              variant="toggle"
+            ></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu anchor="button-2" aria-label="popover" id="popover2">
+            <ic-menu-item label="Copy code" disabled="true"></ic-menu-item>
+            <ic-menu-group label="View">
+              <ic-menu-item
+                label="Zoom in"
+                keyboard-shortcut="Cmd+"
+              ></ic-menu-item>
+              <ic-menu-item
+                label="Zoom out"
+                keyboard-shortcut="Cmd-"
+              ></ic-menu-item>
+            </ic-menu-group>
+            <ic-menu-item
+              label="Actions"
+              submenu-trigger-for="def"
+            ></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu submenu-id="def">
+            <ic-menu-item label="Edit"></ic-menu-item>
+            <ic-menu-item
+              label="Find"
+              submenu-trigger-for="def123"
+            ></ic-menu-item>
+            <ic-menu-item label="Delete" variant="destructive"></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu submenu-id="def123">
+            <ic-menu-item
+              label="Search the web"
+              description="This will search the web to find the thing you are looking for."
+            ></ic-menu-item>
+            <ic-menu-item label="Find..."></ic-menu-item>
+            <ic-menu-item label="Find icons">
+              <svg
+                slot="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </ic-menu-item>
+            <ic-menu-item
+              label="Show found results"
+              variant="toggle"
+            ></ic-menu-item>
+          </ic-popover-menu>
+        </div>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
@@ -169,7 +169,7 @@ export class PopoverMenu {
 
   private closeMenu = () => {
     this.open = false;
-    this.anchorEl.focus();
+    this.anchorEl?.focus();
   };
 
   private getNextItemToSelect = (
@@ -220,8 +220,10 @@ export class PopoverMenu {
         break;
       case "Escape":
       case "Tab":
-        this.closeMenu();
-        this.host.blur();
+        if (this.open) {
+          this.closeMenu();
+          this.host.blur();
+        }
         break;
     }
   }


### PR DESCRIPTION
## Summary of the changes
fixed keyboard closing of popover menu when other elements feature on a page

## Related issue
#564 