### PR TITLE
fix(web-components): return out of onBlur for select if scrollbar/group title is clicked

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.spec.tsx
@@ -698,12 +698,7 @@ describe("ic-select", () => {
 
   it("should test blur on searchable input", async () => {
     const page = await newSpecPage({
-      components: [
-        Select,
-        Menu,
-        InputComponentContainer,
-        InputComponentContainer,
-      ],
+      components: [Select, Menu, InputComponentContainer],
       html: `<ic-select label="IC Select Test" searchable="true"></ic-select>`,
     });
 
@@ -717,6 +712,32 @@ describe("ic-select", () => {
     input.blur();
     await page.waitForChanges();
     expect(eventSpy).toHaveBeenCalled();
+  });
+
+  it("should test blur on searchable input where target is an element of the menu but not a menu option", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      html: `<ic-select label="IC Select Test" searchable="true"></ic-select>`,
+    });
+
+    page.root.options = menuOptions;
+    await page.waitForChanges();
+
+    const target = page.root.shadowRoot.querySelector("ul.menu");
+
+    const event = new FocusEvent("blur", {
+      bubbles: true,
+      cancelable: true,
+      relatedTarget: target,
+    });
+
+    const eventSpy = jest.fn();
+    page.win.addEventListener("icBlur", eventSpy);
+
+    await page.rootInstance.onBlur(event);
+
+    await page.waitForChanges();
+    expect(eventSpy).not.toHaveBeenCalled();
   });
 
   it("should test searchable input", async () => {

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -754,6 +754,15 @@ export class Select {
   };
 
   private onBlur = (event: FocusEvent): void => {
+    const target = event.relatedTarget as HTMLElement;
+    if (
+      target !== null &&
+      target.tagName === "UL" &&
+      target.className.includes("menu")
+    ) {
+      return;
+    }
+
     const retryButton = this.menu?.querySelector("#retry-button");
     const isSearchableAndNoFocusedInternalElements =
       this.searchable &&


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Return out of onBlur for select if scrollbar/group title is clicked to ensure the menu stays open

## Related issue
#596 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 