### PR TITLE
fix(web-components): updated aria-hidden on mobile menu button

### DIFF
--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -153,6 +153,15 @@ slot[name="toggle-icon"] svg {
   margin-left: var(--ic-space-md);
 }
 
+.menu-button-container .navigation-landmark-button-text {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 .search-actions-container {
   display: flex;
 }

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -405,13 +405,16 @@ export class TopNavigation {
                       )}
                       {hasMenuContent && this.deviceSize <= DEVICE_SIZES.L && (
                         <div class="menu-button-container">
+                          <span
+                            id="navigation-landmark-button-text"
+                            class="navigation-landmark-button-text"
+                            aria-hidden="true"
+                          >
+                            Main navigation button
+                          </span>
                           <nav
-                            aria-labelledby="navigation-landmark-text"
-                            aria-hidden={
-                              !this.hasNavigation || this.navMenuVisible
-                                ? "true"
-                                : "false"
-                            }
+                            aria-labelledby="navigation-landmark-button-text"
+                            aria-hidden={this.navMenuVisible ? "true" : "false"}
                           >
                             <ic-button
                               id="menu-button"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updated aria-hidden to false due to interactive close button inside menu. Error appearing within Lighthouse Accessibility report should now be fixed.

## Related issue
N/A

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 