### PR TITLE
fix(web-components): added stopimmediatepropagation on icTabSelect

### DIFF
--- a/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
@@ -66,12 +66,12 @@ export class TabContext {
   /**
    * @deprecated This event should not be used anymore. Use icTabSelect instead.
    */
-  @Event() tabSelect: EventEmitter<IcTabSelectEventDetail>;
+  @Event({ bubbles: false }) tabSelect: EventEmitter<IcTabSelectEventDetail>;
 
   /**
    * Emitted when a user selects a tab.
    */
-  @Event() icTabSelect: EventEmitter<IcTabSelectEventDetail>;
+  @Event({ bubbles: false }) icTabSelect: EventEmitter<IcTabSelectEventDetail>;
 
   @Listen("tabClick")
   tabClickHandler(event: CustomEvent<IcTabClickEventDetail>): void {
@@ -87,6 +87,7 @@ export class TabContext {
     this.tabSelect.emit({
       tabIndex: event.detail.position,
     });
+    event.stopImmediatePropagation();
   }
 
   @Listen("tabCreated")

--- a/packages/web-components/src/components/ic-tab-context/ic-tabs.stories.mdx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tabs.stories.mdx
@@ -252,26 +252,32 @@ import TabPanelReadme from "../ic-tab-panel/readme.md";
 
 <Canvas>
   <Story name="Nested tabs">
-    {html`<ic-tab-context>
-      <ic-tab-group label="Example tab group">
-        <ic-tab>Outer One</ic-tab>
-        <ic-tab>Outer Two</ic-tab>
-        <ic-tab>Outer Three</ic-tab>
-      </ic-tab-group>
-      <ic-tab-panel>
-        <ic-tab-context context-id="context-nested">
-          <ic-tab-group label="Example tab group">
-            <ic-tab>Nested One</ic-tab>
-            <ic-tab>Nested Two</ic-tab>
-            <ic-tab>Nested Three</ic-tab>
-          </ic-tab-group>
-          <ic-tab-panel>Nested Tab One</ic-tab-panel>
-          <ic-tab-panel>Nested Tab Two</ic-tab-panel>
-          <ic-tab-panel>Nested Tab Three</ic-tab-panel>
-        </ic-tab-context>
-      </ic-tab-panel>
-      <ic-tab-panel>Outer Tab Two</ic-tab-panel>
-      <ic-tab-panel>Outer Tab Three</ic-tab-panel>
-    </ic-tab-context>`}
+    {html`<ic-tab-context id="main">
+        <ic-tab-group label="Example tab group">
+          <ic-tab>Outer One</ic-tab>
+          <ic-tab>Outer Two</ic-tab>
+          <ic-tab>Outer Three</ic-tab>
+        </ic-tab-group>
+        <ic-tab-panel>
+          <ic-tab-context context-id="context-nested" id="nested">
+            <ic-tab-group label="Example tab group">
+              <ic-tab>Nested One</ic-tab>
+              <ic-tab>Nested Two</ic-tab>
+              <ic-tab>Nested Three</ic-tab>
+            </ic-tab-group>
+            <ic-tab-panel>Nested Tab One</ic-tab-panel>
+            <ic-tab-panel>Nested Tab Two</ic-tab-panel>
+            <ic-tab-panel>Nested Tab Three</ic-tab-panel>
+          </ic-tab-context>
+        </ic-tab-panel>
+        <ic-tab-panel>Outer Tab Two</ic-tab-panel>
+        <ic-tab-panel>Outer Tab Three</ic-tab-panel>
+      </ic-tab-context>
+      <script>
+        const main = document.querySelector("#main");
+        const nested = document.querySelector("#nested");
+        main.addEventListener("icTabSelect", () => console.log("MAIN"));
+        nested.addEventListener("icTabSelect", () => console.log("NESTED"));
+      </script> `}
   </Story>
 </Canvas>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added stopImmediatePropagation to prevent events from bubbling up. This is fixes nested tab event bubbling up to the parent tab component

## Related issue
N/A

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 