### PR TITLE
fix(web-components): added stopImmediatePropagation to icTabSelect

### DIFF
--- a/packages/web-components/src/components/ic-tab-context/ic-tab-context.spec.ts
+++ b/packages/web-components/src/components/ic-tab-context/ic-tab-context.spec.ts
@@ -84,7 +84,7 @@ describe("ic-tab-context component", () => {
     expect(page.rootInstance.selectedTab).toBe(2);
 
     const eventSpy = jest.fn();
-    page.win.addEventListener("icTabSelect", eventSpy);
+    page.root.addEventListener("icTabSelect", eventSpy);
 
     const tabGroup = page.root.querySelector("ic-tab-group");
 
@@ -180,9 +180,10 @@ describe("ic-tab-context component", () => {
     expect(page.rootInstance.selectedTabIndex).toBe(undefined);
 
     const eventSpy = jest.fn();
-    page.win.addEventListener("icTabSelect", eventSpy);
+    page.root.addEventListener("icTabSelect", eventSpy);
 
     await page.rootInstance.tabClickHandler({
+      stopImmediatePropagation: jest.fn(),
       detail: {
         contextId: "default",
         position: 1,

--- a/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
@@ -66,12 +66,12 @@ export class TabContext {
   /**
    * @deprecated This event should not be used anymore. Use icTabSelect instead.
    */
-  @Event() tabSelect: EventEmitter<IcTabSelectEventDetail>;
+  @Event({ bubbles: false }) tabSelect: EventEmitter<IcTabSelectEventDetail>;
 
   /**
    * Emitted when a user selects a tab.
    */
-  @Event() icTabSelect: EventEmitter<IcTabSelectEventDetail>;
+  @Event({ bubbles: false }) icTabSelect: EventEmitter<IcTabSelectEventDetail>;
 
   @Listen("tabClick")
   tabClickHandler(event: CustomEvent<IcTabClickEventDetail>): void {
@@ -87,6 +87,7 @@ export class TabContext {
     this.tabSelect.emit({
       tabIndex: event.detail.position,
     });
+    event.stopImmediatePropagation();
   }
 
   @Listen("tabCreated")

--- a/packages/web-components/src/components/ic-tab-context/ic-tabs.stories.mdx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tabs.stories.mdx
@@ -252,26 +252,32 @@ import TabPanelReadme from "../ic-tab-panel/readme.md";
 
 <Canvas>
   <Story name="Nested tabs">
-    {html`<ic-tab-context>
-      <ic-tab-group label="Example tab group">
-        <ic-tab>Outer One</ic-tab>
-        <ic-tab>Outer Two</ic-tab>
-        <ic-tab>Outer Three</ic-tab>
-      </ic-tab-group>
-      <ic-tab-panel>
-        <ic-tab-context context-id="context-nested">
-          <ic-tab-group label="Example tab group">
-            <ic-tab>Nested One</ic-tab>
-            <ic-tab>Nested Two</ic-tab>
-            <ic-tab>Nested Three</ic-tab>
-          </ic-tab-group>
-          <ic-tab-panel>Nested Tab One</ic-tab-panel>
-          <ic-tab-panel>Nested Tab Two</ic-tab-panel>
-          <ic-tab-panel>Nested Tab Three</ic-tab-panel>
-        </ic-tab-context>
-      </ic-tab-panel>
-      <ic-tab-panel>Outer Tab Two</ic-tab-panel>
-      <ic-tab-panel>Outer Tab Three</ic-tab-panel>
-    </ic-tab-context>`}
+    {html`<ic-tab-context id="main">
+        <ic-tab-group label="Example tab group">
+          <ic-tab>Outer One</ic-tab>
+          <ic-tab>Outer Two</ic-tab>
+          <ic-tab>Outer Three</ic-tab>
+        </ic-tab-group>
+        <ic-tab-panel>
+          <ic-tab-context context-id="context-nested" id="nested">
+            <ic-tab-group label="Example tab group">
+              <ic-tab>Nested One</ic-tab>
+              <ic-tab>Nested Two</ic-tab>
+              <ic-tab>Nested Three</ic-tab>
+            </ic-tab-group>
+            <ic-tab-panel>Nested Tab One</ic-tab-panel>
+            <ic-tab-panel>Nested Tab Two</ic-tab-panel>
+            <ic-tab-panel>Nested Tab Three</ic-tab-panel>
+          </ic-tab-context>
+        </ic-tab-panel>
+        <ic-tab-panel>Outer Tab Two</ic-tab-panel>
+        <ic-tab-panel>Outer Tab Three</ic-tab-panel>
+      </ic-tab-context>
+      <script>
+        const main = document.querySelector("#main");
+        const nested = document.querySelector("#nested");
+        main.addEventListener("icTabSelect", () => console.log("main"));
+        nested.addEventListener("icTabSelect", () => console.log("nested"));
+      </script> `}
   </Story>
 </Canvas>

--- a/packages/web-components/src/components/ic-tab-panel/ic-tab-panel.tsx
+++ b/packages/web-components/src/components/ic-tab-panel/ic-tab-panel.tsx
@@ -64,7 +64,9 @@ export class TabPanel {
     const tabContext = document.querySelector(
       `ic-tab-context[context-id=${this.contextId}]`
     ) as HTMLIcTabContextElement;
-    tabContext.tabRemovedHandler();
+    if (tabContext) {
+      tabContext.tabRemovedHandler();
+    }
   }
 
   render() {

--- a/packages/web-components/src/components/ic-tab/ic-tab.tsx
+++ b/packages/web-components/src/components/ic-tab/ic-tab.tsx
@@ -126,7 +126,9 @@ export class Tab {
     const tabContext = document.querySelector(
       `ic-tab-context[context-id=${this.contextId}]`
     ) as HTMLIcTabContextElement;
-    tabContext.tabRemovedHandler(!!this.focusTabId);
+    if (tabContext) {
+      tabContext.tabRemovedHandler(!!this.focusTabId);
+    }
   }
 
   render() {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added stopImmediatePropagate method to prevent icTabSelect event bubbling up outside of its own context. For example, nested tab event should not trigger events within the parent tab component

## Related issue
#684 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 