### PR TITLE
fix(web-components): replaced box-shadow for page-header selected nav item

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -495,9 +495,15 @@ svg {
   box-shadow: rgba(23 89 188 / 0%) !important;
 }
 
-:host(.navigation-item-page-header.navigation-item-selected) .link,
-:host(.navigation-item-page-header) ::slotted(a.active) {
-  box-shadow: inset 0 calc(-1 * var(--ic-space-xxs)) 0 var(--ic-action-default);
+:host(.navigation-item-page-header.navigation-item-selected) .link::after,
+:host(.navigation-item-page-header) ::slotted(a.active)::after {
+  content: " " !important;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: var(--ic-space-xxs);
+  background-color: var(--ic-action-default) !important;
 }
 
 :host(.navigation-item-page-header) .link:hover,
@@ -518,10 +524,10 @@ svg {
   background-color: var(--ic-action-default-bg-active) !important;
 }
 
-:host(.navigation-item-page-header.navigation-item-selected) .link:focus,
-:host(.navigation-item-page-header) ::slotted(a.active:focus) {
-  box-shadow: var(--ic-border-focus),
-    inset 0 calc(-1 * var(--ic-space-xxs)) 0 var(--ic-action-default);
+:host(.navigation-item-page-header.navigation-item-selected) .link:focus::after,
+:host(.navigation-item-page-header) ::slotted(a.active:focus)::after {
+  border-bottom-left-radius: var(--ic-border-radius);
+  border-bottom-right-radius: var(--ic-border-radius);
 }
 
 :host(.navigation-item-page-header.navigation-item-selected.with-transition)


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Replaced box-shadow with ::after to style selected state. This removes the curved underline when navigation item has focus state. Tested with React Router (slotted) example

## Related issue
#537 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 