### PR TITLE
fix(web-components): add condition to menu item aria label so it doesn't read undefined menu group

### DIFF
--- a/packages/web-components/src/components/ic-menu-group/__snapshots__/ic-menu-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-menu-group/__snapshots__/ic-menu-group.spec.ts.snap
@@ -93,7 +93,7 @@ exports[`menu group should render a menu group without a label 1`] = `
   <ic-menu-item label="Button" variant="default">
     <mock:shadow-root>
       <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, undefined menu group" disabletooltip="" fullwidth="" variant="tertiary">
+        <ic-button aria-disabled="false" aria-label="Button" disabletooltip="" fullwidth="" variant="tertiary">
           <div class="focus-border">
             <span class="icon">
               <slot name="icon"></slot>
@@ -117,7 +117,7 @@ exports[`menu group should render a menu group without a label 1`] = `
   <ic-menu-item label="Button" variant="default">
     <mock:shadow-root>
       <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, undefined menu group" disabletooltip="" fullwidth="" variant="tertiary">
+        <ic-button aria-disabled="false" aria-label="Button" disabletooltip="" fullwidth="" variant="tertiary">
           <div class="focus-border">
             <span class="icon">
               <slot name="icon"></slot>
@@ -141,7 +141,7 @@ exports[`menu group should render a menu group without a label 1`] = `
   <ic-menu-item description="This button has a href and so it behaves like a link" href="#" label="Button" variant="default">
     <mock:shadow-root>
       <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, This button has a href and so it behaves like a link, undefined menu group" disabletooltip="" fullwidth="" href="#" variant="tertiary">
+        <ic-button aria-disabled="false" aria-label="Button, This button has a href and so it behaves like a link" disabletooltip="" fullwidth="" href="#" variant="tertiary">
           <div class="focus-border">
             <div class="menu-item-info">
               <div class="menu-labels">

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -155,7 +155,10 @@ export class MenuItem {
     }
     const parentEl = getParentElement(this.el);
 
-    if (parentEl.tagName === "IC-MENU-GROUP") {
+    if (
+      parentEl.tagName === "IC-MENU-GROUP" &&
+      (parentEl as HTMLIcMenuGroupElement).label
+    ) {
       return `${ariaLabel}, ${
         (parentEl as HTMLIcMenuGroupElement).label
       } menu group`;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add condition to menu item aria label so it doesn't read undefined menu group when menu group has no label

## Related issue
#656

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 