### PR TITLE
feat(web-components): adds method to set current page to pagination

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -927,6 +927,10 @@ export namespace Components {
          */
         "boundaryCount": number;
         /**
+          * The current page displayed by the pagination.
+         */
+        "currentPage": number;
+        /**
           * The default page to display.
          */
         "defaultPage": number;
@@ -950,6 +954,7 @@ export namespace Components {
           * The total number of pages.
          */
         "pages": number;
+        "setCurrentPage": (page: number) => Promise<void>;
         /**
           * The type of pagination to be used.
          */
@@ -3182,6 +3187,10 @@ declare namespace LocalJSX {
           * The number of pages displayed as boundary items to the current page when using 'complex' type pagination. Accepted values are 0, 1 & 2.
          */
         "boundaryCount"?: number;
+        /**
+          * The current page displayed by the pagination.
+         */
+        "currentPage"?: number;
         /**
           * The default page to display.
          */

--- a/packages/web-components/src/components/ic-pagination/ic-pagination.spec.ts
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.spec.ts
@@ -398,7 +398,7 @@ describe("ic-pagination complex type", () => {
     await page.rootInstance.paginationItemClickHandler({ detail: { page: 1 } });
     await page.waitForChanges();
 
-    expect(page.root.currentPage).toBe(undefined);
+    expect(page.root.currentPage).toBe(1);
   });
 });
 describe("ic-pagination appearance tests", () => {
@@ -433,5 +433,19 @@ describe("ic-pagination appearance tests", () => {
     });
 
     expect(page.root).toMatchSnapshot("render light complex pagination");
+  });
+
+  it("should change page when current page set with public method", async () => {
+    const page = await newSpecPage({
+      components: [Pagination, Button, PaginationItem],
+      html: `<ic-pagination pages="15" type="complex"></ic-pagination>
+      `,
+    });
+    expect(page.rootInstance.currentPage).toBe(1);
+
+    await page.root.setCurrentPage(3);
+    await page.waitForChanges();
+
+    expect(page.rootInstance.currentPage).toBe(3);
   });
 });

--- a/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
@@ -9,6 +9,7 @@ import {
   Watch,
   Event,
   EventEmitter,
+  Method,
 } from "@stencil/core";
 import paginationNextPrevious from "../../assets/pagination-next-previous.svg";
 import paginationFirstLast from "../../assets/pagination-first-last.svg";
@@ -64,8 +65,11 @@ export class Pagination {
    * The label for the pagination item (applicable when simple pagination is being used).
    */
   @Prop() label: string = "Page";
+  /**
+   * The current page displayed by the pagination.
+   */
+  @Prop({ mutable: true }) currentPage: number = this.defaultPage;
 
-  @State() currentPage: number = this.defaultPage;
   @State() startEllipsis: boolean = false;
   @State() endEllipsis: boolean = false;
   @State() startItems: number[] = [];
@@ -82,6 +86,20 @@ export class Pagination {
     const page = ev.detail.page;
     this.currentPage = page;
     this.icPageChange.emit({ value: this.currentPage });
+  }
+
+  /**
+   * Sets the currently displayed page.
+   */
+  @Method()
+  async setCurrentPage(page: number) {
+    if (typeof page === "number" && page > 0 && page <= this.pages) {
+      this.currentPage = page;
+    } else {
+      console.error(
+        "Current page must be a number greater than zero but less than or equal to the total number of pages"
+      );
+    }
   }
 
   @Watch("currentPage")

--- a/packages/web-components/src/components/ic-pagination/readme.md
+++ b/packages/web-components/src/components/ic-pagination/readme.md
@@ -7,18 +7,19 @@
 
 ## Properties
 
-| Property                     | Attribute                         | Description                                                                                                                             | Type                             | Default     |
-| ---------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
-| `adjacentCount`              | `adjacent-count`                  | The number of pages displayed adjacent to the current page when using 'complex' type pagination. Accepted values are 0, 1 & 2.          | `number`                         | `1`         |
-| `appearance`                 | `appearance`                      | The appearance of the pagination, e.g. dark, light or the default.                                                                      | `"dark" \| "default" \| "light"` | `"default"` |
-| `boundaryCount`              | `boundary-count`                  | The number of pages displayed as boundary items to the current page when using 'complex' type pagination. Accepted values are 0, 1 & 2. | `number`                         | `1`         |
-| `defaultPage`                | `default-page`                    | The default page to display.                                                                                                            | `number`                         | `1`         |
-| `disabled`                   | `disabled`                        | If `true`, the pagination will not allow interaction.                                                                                   | `boolean`                        | `false`     |
-| `hideCurrentPage`            | `hide-current-page`               | If `true`, the current page of the simple pagination will not be displayed.                                                             | `boolean`                        | `false`     |
-| `hideFirstAndLastPageButton` | `hide-first-and-last-page-button` | If `true`, the first and last page buttons will not be displayed.                                                                       | `boolean`                        | `false`     |
-| `label`                      | `label`                           | The label for the pagination item (applicable when simple pagination is being used).                                                    | `string`                         | `"Page"`    |
-| `pages` _(required)_         | `pages`                           | The total number of pages.                                                                                                              | `number`                         | `undefined` |
-| `type`                       | `type`                            | The type of pagination to be used.                                                                                                      | `"complex" \| "simple"`          | `"simple"`  |
+| Property                     | Attribute                         | Description                                                                                                                             | Type                             | Default            |
+| ---------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
+| `adjacentCount`              | `adjacent-count`                  | The number of pages displayed adjacent to the current page when using 'complex' type pagination. Accepted values are 0, 1 & 2.          | `number`                         | `1`                |
+| `appearance`                 | `appearance`                      | The appearance of the pagination, e.g. dark, light or the default.                                                                      | `"dark" \| "default" \| "light"` | `"default"`        |
+| `boundaryCount`              | `boundary-count`                  | The number of pages displayed as boundary items to the current page when using 'complex' type pagination. Accepted values are 0, 1 & 2. | `number`                         | `1`                |
+| `currentPage`                | `current-page`                    | The current page displayed by the pagination.                                                                                           | `number`                         | `this.defaultPage` |
+| `defaultPage`                | `default-page`                    | The default page to display.                                                                                                            | `number`                         | `1`                |
+| `disabled`                   | `disabled`                        | If `true`, the pagination will not allow interaction.                                                                                   | `boolean`                        | `false`            |
+| `hideCurrentPage`            | `hide-current-page`               | If `true`, the current page of the simple pagination will not be displayed.                                                             | `boolean`                        | `false`            |
+| `hideFirstAndLastPageButton` | `hide-first-and-last-page-button` | If `true`, the first and last page buttons will not be displayed.                                                                       | `boolean`                        | `false`            |
+| `label`                      | `label`                           | The label for the pagination item (applicable when simple pagination is being used).                                                    | `string`                         | `"Page"`           |
+| `pages` _(required)_         | `pages`                           | The total number of pages.                                                                                                              | `number`                         | `undefined`        |
+| `type`                       | `type`                            | The type of pagination to be used.                                                                                                      | `"complex" \| "simple"`          | `"simple"`         |
 
 
 ## Events
@@ -26,6 +27,19 @@
 | Event          | Description                      | Type                               |
 | -------------- | -------------------------------- | ---------------------------------- |
 | `icPageChange` | Emitted when a page is selected. | `CustomEvent<IcChangeEventDetail>` |
+
+
+## Methods
+
+### `setCurrentPage(page: number) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
 
 
 ## Dependencies


### PR DESCRIPTION
## Summary of the changes
Adds a public method to the pagination component to allow current page to be set.

## Related issue
#707 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 