### PR TITLE
fix(web-components): add aria-hidden to see more/see less typography

### DIFF
--- a/packages/web-components/src/components/ic-typography/__snapshots__/ic-typography.spec.ts.snap
+++ b/packages/web-components/src/components/ic-typography/__snapshots__/ic-typography.spec.ts.snap
@@ -164,7 +164,7 @@ exports[`ic-typography component should render the typography with truncation 2`
     <div class="trunc-wrapper">
       <slot></slot>
     </div>
-    <button class="trunc-btn">
+    <button aria-hidden="true" class="trunc-btn">
       See more
     </button>
   </mock:shadow-root>

--- a/packages/web-components/src/components/ic-typography/ic-typography.tsx
+++ b/packages/web-components/src/components/ic-typography/ic-typography.tsx
@@ -161,6 +161,7 @@ export class Typography {
             onBlur={this.truncButtonBlur}
             onMouseDown={this.truncButtonFocusFromMouse}
             onClick={this.toggleExpanded}
+            aria-hidden="true"
           >
             {expanded ? "See less" : "See more"}
           </button>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add aria-hidden to see more/see less typography as the screen reader reads out the whole text.

## Related issue
#712

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 