### PR TITLE
fix(web-components): fix static side navigation falling off screen

### DIFF
--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -361,13 +361,6 @@ slot[name="app-icon"]::slotted(a) {
     bottom: 0;
   }
 
-  :host(.static) {
-    position: relative;
-    left: auto;
-    top: auto;
-    bottom: auto;
-  }
-
   .app-icon-container {
     padding: var(--ic-space-xxs) 0;
   }

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -433,6 +433,14 @@ export class SideNavigation {
         });
       }
 
+      let paddingLeft;
+
+      if (this.collapsedIconLabels) {
+        paddingLeft = "calc(var(--ic-space-xxl) * 2)";
+      } else {
+        paddingLeft = "calc(var(--ic-space-xxl) + var(--ic-space-xs))";
+      }
+
       if (currSize > DEVICE_SIZES.L) {
         if (!this.disableAutoParentStyling) {
           this.setParentPaddingTop("0");
@@ -440,16 +448,20 @@ export class SideNavigation {
         }
       } else if (
         currSize > DEVICE_SIZES.S &&
-        currSize <= DEVICE_SIZES.L &&
-        !this.static &&
+        currSize <= DEVICE_SIZES.M &&
+        this.static &&
         !this.disableAutoParentStyling
       ) {
-        if (this.collapsedIconLabels) {
-          this.setParentPaddingLeft("calc(var(--ic-space-xxl) * 2)");
+        this.setParentPaddingLeft(paddingLeft);
+      } else if (
+        currSize > DEVICE_SIZES.S &&
+        currSize <= DEVICE_SIZES.L &&
+        !this.disableAutoParentStyling
+      ) {
+        if (this.static) {
+          this.setParentPaddingLeft("calc(var(--ic-space-xl) * 10)");
         } else {
-          this.setParentPaddingLeft(
-            "calc(var(--ic-space-xxl) + var(--ic-space-xs))"
-          );
+          this.setParentPaddingLeft(paddingLeft);
         }
       }
     }
@@ -652,7 +664,6 @@ export class SideNavigation {
             foregroundColor === IcThemeForegroundEnum.Dark,
           ["collapsed-labels"]:
             !isSDevice && !menuExpanded && collapsedIconLabels,
-          ["static"]: this.static,
           ["inline"]: inline,
         }}
       >


### PR DESCRIPTION
## Summary of the changes
Fixed static side navigation falling off screen. Adjusted padding for static variant.

To test this, add a lot of text / a large div to the page in the static variant story so that the page is scrollable and then scroll down.

Other issues mentioned in the [comment on the ticket](https://github.com/mi6/ic-ui-kit/issues/700#issuecomment-1571584355) are being made into tickets.

## Related issue
#700 

## Checklist
- [x] I have ensured any changes match the Figma component library. 