### PR TITLE
674 ic top navigation update to grouped navigation behaviour

### DIFF
--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.spec.ts
@@ -6,6 +6,7 @@ import { TopNavigation } from "../ic-top-navigation/ic-top-navigation";
 import { DEVICE_SIZES } from "../../utils/helpers";
 import { NavigationGroup } from "./ic-navigation-group";
 import * as helpers from "../../utils/helpers";
+import { waitForTimeout } from "../../testspec.setup";
 
 describe("ic-navigation-group", () => {
   it("should render with label", async () => {
@@ -23,11 +24,30 @@ describe("ic-navigation-group", () => {
       html: `<ic-navigation-group label="Group label"></ic-navigation-group>`,
     });
     await waitForNavGroupLoad();
-
+    const ev = {
+      relatedTarget: {
+        nodeName: "IC-NAVIGATION-GROUP",
+      },
+    };
     expect(page.rootInstance.dropdownOpen).toBe(false);
-    await page.rootInstance.triggerShowDropdown();
+    await page.rootInstance.triggerShowDropdown(ev);
     await page.waitForChanges();
     expect(page.rootInstance.dropdownOpen).toBe(true);
+    await page.rootInstance.hideDropdown();
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+
+    ev.relatedTarget.nodeName = "ANOTHER-NAME";
+
+    jest.spyOn(document, "addEventListener");
+
+    await page.rootInstance.triggerShowDropdown(ev);
+    await page.waitForChanges();
+
+    expect(document.addEventListener).toHaveBeenCalledTimes(2);
+
+    await page.rootInstance.showDropdown();
+    await page.waitForChanges();
 
     await page.rootInstance.childBlurHandler();
     await page.waitForChanges();
@@ -101,6 +121,83 @@ describe("ic-navigation-group", () => {
     await page.waitForChanges();
     expect(page.rootInstance.dropdownOpen).toBe(true);
   });
+  it("should test handleBlur function", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup, NavigationItem],
+      html: `<ic-navigation-group label="Group label">
+        <ic-navigation-item href="/" label="Home"></ic-navigation-item>
+        <ic-navigation-item href="/" label="andAway"></ic-navigation-item>
+        <ic-navigation-item href="/" label="closerEachDay"></ic-navigation-item>
+      </ic-navigation-group>`,
+    });
+    await waitForNavGroupLoad();
+    const ev = {
+      relatedTarget: {
+        nodeName: "IC-NAVIGATION-GROUP",
+      },
+    };
+
+    await page.rootInstance.showDropdown();
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(true);
+    await page.rootInstance.handleBlur(ev);
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+  });
+  it("should test isMouseIdle function", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup, NavigationItem],
+      html: `<ic-navigation-group label="Group label">
+        <ic-navigation-item href="/" label="Home"></ic-navigation-item>
+      </ic-navigation-group>`,
+    });
+    await waitForNavGroupLoad();
+
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+    await page.rootInstance.isMouseIdle();
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+    await waitForTimeout(600);
+    expect(page.rootInstance.dropdownOpen).toBe(true);
+  });
+
+  it("should test handleMouseLeave function", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup, NavigationItem],
+      html: `<ic-navigation-group label="Group label">
+        <ic-navigation-item href="/" label="Home"></ic-navigation-item>
+        <ic-navigation-item href="/" label="andAway"></ic-navigation-item>
+      </ic-navigation-group>`,
+    });
+    await waitForNavGroupLoad();
+    const ev = {
+      relatedTarget: {
+        nodeName: "IC-NAVIGATION-GROUP",
+      },
+    };
+
+    await page.rootInstance.showDropdown();
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(true);
+    await page.rootInstance.handleMouseLeave(ev);
+    await waitForTimeout(600);
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+    // check other branch of 'if'
+    ev.relatedTarget.nodeName = "IC-NOT-NAV-GROUP";
+    await page.rootInstance.showDropdown();
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(true);
+    await page.rootInstance.handleMouseLeave(ev);
+    await waitForTimeout(600);
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+    // check if null value called
+    await page.rootInstance.handleMouseLeave(ev);
+    await waitForTimeout(600);
+    await page.waitForChanges();
+    expect(page.rootInstance.dropdownOpen).toBe(false);
+  });
 
   it("should test key down handler", async () => {
     const page = await newSpecPage({
@@ -118,14 +215,16 @@ describe("ic-navigation-group", () => {
 
     page.rootInstance.navigationType = "side";
     await page.rootInstance.handleKeydown({
-      key: "Space",
+      key: " ",
       preventDefault: (): void => null,
     });
     await page.waitForChanges();
+    await waitForTimeout(600);
     expect(page.rootInstance.expanded).toBe(true);
 
     expect(page.rootInstance.dropdownOpen).toBe(false);
     page.rootInstance.navigationType = "top";
+    await page.waitForChanges();
     await page.rootInstance.handleKeydown({ key: "Enter" });
     await page.waitForChanges();
     expect(page.rootInstance.dropdownOpen).toBe(true);

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -144,12 +144,14 @@ export class NavigationGroup {
   };
 
   private showDropdown() {
+    document.removeEventListener("mousemove", this.isMouseIdle);
     if (!this.dropdownOpen) {
       this.toggleDropdown();
     }
   }
 
   private hideDropdown() {
+    document.removeEventListener("keydown", this.handleKeydown);
     if (this.dropdownOpen) {
       this.toggleDropdown();
     }
@@ -171,16 +173,16 @@ export class NavigationGroup {
   };
 
   private handleTopNavKeydown = (ev: KeyboardEvent) => {
-    if (!this.inTopNavSideMenu && ev.key === "Escape") {
-      this.hideDropdown();
-      this.el.blur();
-    } else if (ev.key === " " || ev.key === "Enter") {
+    if (ev.key === "Space" || ev.key === "Enter") {
       this.toggleDropdown();
+    } else if (!this.inTopNavSideMenu && ev.key === "Escape") {
+      document.removeEventListener("mousemove", this.isMouseIdle);
+      this.hideDropdown();
     }
   };
 
   private handleKeydown = (ev: KeyboardEvent) => {
-    if (ev.key === "Enter" || ev.key === "Space") {
+    if (ev.key === "Enter" || ev.key === "Space" || ev.key === "Escape") {
       switch (this.navigationType) {
         case "top":
           this.handleTopNavKeydown(ev as KeyboardEvent);
@@ -204,12 +206,41 @@ export class NavigationGroup {
       document.activeElement !== this.el &&
       !this.el.contains(document.activeElement)
     ) {
-      this.hideDropdown();
+      if (target.nodeName === "IC-NAVIGATION-GROUP") {
+        this.hideDropdown();
+      } else {
+        setTimeout(() => {
+          this.dropdownOpen ? this.hideDropdown() : null;
+        }, 500);
+      }
     }
   };
 
-  private triggerShowDropdown = () => {
-    this.showDropdown();
+  private triggerShowDropdown = (ev: MouseEvent) => {
+    const target = ev.relatedTarget as HTMLElement;
+    document.addEventListener("keydown", this.handleKeydown);
+    if (this.dropdownOpen === false) {
+      if (
+        target.nodeName === "IC-NAVIGATION-GROUP" &&
+        !this.el.contains(target) &&
+        target !== this.dropdown &&
+        document.activeElement !== this.el &&
+        !this.el.contains(document.activeElement)
+      ) {
+        this.showDropdown();
+      } else {
+        document.addEventListener("mousemove", this.isMouseIdle);
+      }
+    }
+  };
+
+  private time: any;
+
+  private isMouseIdle = () => {
+    clearTimeout(this.time);
+    this.time = setTimeout(() => {
+      this.showDropdown();
+    }, 500);
   };
 
   private renderDropdownGroupedLinks = (): HTMLDivElement => (
@@ -353,7 +384,7 @@ export class NavigationGroup {
       >
         <NavigationGroupElement
           tabindex={inTopNavSideMenu && !expandable ? "-1" : "0"}
-          onMouseOver={
+          onMouseEnter={
             !inTopNavSideMenu && this.navigationType === "top"
               ? this.triggerShowDropdown
               : null

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -173,7 +173,7 @@ export class NavigationGroup {
   };
 
   private handleTopNavKeydown = (ev: KeyboardEvent) => {
-    if (ev.key === "Space" || ev.key === "Enter") {
+    if (ev.key === " " || ev.key === "Enter") {
       this.toggleDropdown();
     } else if (!this.inTopNavSideMenu && ev.key === "Escape") {
       document.removeEventListener("mousemove", this.isMouseIdle);
@@ -182,7 +182,7 @@ export class NavigationGroup {
   };
 
   private handleKeydown = (ev: KeyboardEvent) => {
-    if (ev.key === "Enter" || ev.key === "Space" || ev.key === "Escape") {
+    if (ev.key === "Enter" || ev.key === " " || ev.key === "Escape") {
       switch (this.navigationType) {
         case "top":
           this.handleTopNavKeydown(ev as KeyboardEvent);
@@ -235,7 +235,6 @@ export class NavigationGroup {
   };
 
   private time: any;
-
   private isMouseIdle = () => {
     clearTimeout(this.time);
     this.time = setTimeout(() => {

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.e2e.ts
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.e2e.ts
@@ -35,7 +35,7 @@ describe("ic-top-navigation", () => {
 
     const navGroup = await page.find("ic-top-navigation ic-navigation-group");
 
-    await navGroup.hover();
+    await navGroup.press("Enter");
 
     await page.waitForChanges();
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Group-navigation has been changed to apply new WCAG features;
- .5 second delay when hovering a grouped-nav-item (when mouse is idle) before dropdown.
- delay not applied when mouse enters sibling grouped-nav-item.
- dropdown can be cancelled with escape, space or enter (without focus).
- .5 second delay after mouse leaves grouped-nav-item before dropdown is closed
- 

## Related issue
#674 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 