### PR TITLE
Group nav changes

### DIFF
--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.e2e.ts
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.e2e.ts
@@ -35,7 +35,7 @@ describe("ic-top-navigation", () => {
 
     const navGroup = await page.find("ic-top-navigation ic-navigation-group");
 
-    await navGroup.hover();
+    await navGroup.press("Enter");
 
     await page.waitForChanges();
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Group-navigation has been changed to apply new WCAG features;

.5 second delay when hovering a grouped-nav-item (when mouse is idle) before dropdown.
delay not applied when mouse enters sibling grouped-nav-item.
dropdown can be cancelled with escape, space or enter (without focus).
.5 second delay after mouse leaves grouped-nav-item before dropdown is closed

## Related issue
#674 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 