### PR TITLE
fix(web-components): fixes memory leak in ic-button\ic-tooltip

### DIFF
--- a/packages/web-components/src/components/ic-button/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/__snapshots__/ic-button.spec.ts.snap
@@ -36,11 +36,9 @@ exports[`button component should correctly render with text 1`] = `
 exports[`button component should disable tooltip when prop set 1`] = `
 <ic-button class="button-size-default button-variant-icon" disable-tooltip="" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip class="tooltip-disabled" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-label="Tooltip text" class="button" id="ic-button-with-tooltip-test-button" part="button" type="button">
-        <slot></slot>
-      </button>
-    </ic-tooltip>
+    <button aria-label="Tooltip text" class="button" part="button" type="button">
+      <slot></slot>
+    </button>
   </mock:shadow-root>
   Button
 </ic-button>

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -225,7 +225,7 @@ export class Button {
 
     const id = this.el.id;
     this.id = id !== undefined ? id : null;
-    this.hasTooltip = this.variant === "icon";
+    this.hasTooltip = this.variant === "icon" && this.disableTooltip === false;
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -173,6 +173,10 @@ export class Tooltip {
             element: this.arrow,
           },
         },
+        {
+          name: "eventListeners",
+          options: { scroll: false, resize: false },
+        },
       ],
     });
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes issue with events being created by popperjs for tooltip
ic-tooltip is no longer added to DOM for icon buttons if `disableTooltip ` is `true`
resize & scroll event listeners are no longer added to tooltips

## Related issue
#788 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 