### PR TITLE
fix(web-components): fix suggestions after typing

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -3132,6 +3132,7 @@ declare namespace LocalJSX {
         "onMenuOptionId"?: (event: IcMenuCustomEvent<IcMenuOptionIdEventDetail>) => void;
         "onMenuOptionSelect"?: (event: IcMenuCustomEvent<IcOptionSelectEventDetail>) => void;
         "onMenuStateChange"?: (event: IcMenuCustomEvent<IcMenuChangeEventDetail>) => void;
+        "onMenuValueChange"?: (event: IcMenuCustomEvent<IcValueEventDetail>) => void;
         "onRetryButtonClicked"?: (event: IcMenuCustomEvent<IcValueEventDetail>) => void;
         "onTimeoutBlur"?: (event: IcMenuCustomEvent<{ ev: FocusEvent }>) => void;
         "onUngroupedOptionsSet"?: (event: IcMenuCustomEvent<{ options: IcMenuOption[] }>) => void;

--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -70,7 +70,7 @@ export class Menu {
   /**
    * The value of the currently selected option.
    */
-  @Prop() value!: string;
+  @Prop({ mutable: true }) value!: string;
 
   /**
    * Determines whether options manually set as values (by pressing 'Enter') when they receive focus using keyboard navigation.
@@ -121,6 +121,11 @@ export class Menu {
     this.loadUngroupedOptions();
   }
 
+  @Watch("value")
+  watchValueHandler(): void {
+    this.menuValueChange.emit({ value: this.value });
+  }
+
   /**
    * @internal Emitted when an option is selected.
    */
@@ -140,6 +145,11 @@ export class Menu {
    * @internal Emitted when key is pressed while menu is open
    */
   @Event() menuKeyPress: EventEmitter<{ isNavKey: boolean; key: string }>;
+
+  /**
+   * @internal Emitted when menu value changes.
+   */
+  @Event() menuValueChange: EventEmitter<IcValueEventDetail>;
 
   /**
    * @internal Emitted when the ungrouped options have been set.

--- a/packages/web-components/src/components/ic-select/ic-select.e2e.ts
+++ b/packages/web-components/src/components/ic-select/ic-select.e2e.ts
@@ -1133,32 +1133,31 @@ describe("ic-select", () => {
       expect(menuOptions[3]).toEqualText("Macchiato");
     });
 
-    //TODO: Uncomment when bug is fixed
-    // it("should keep the same options when characters are entered and the menu is reopened", async () => {
-    //   const page = await newE2EPage();
-    //   await page.setContent(getTestSearchableSelect(searchableOptions));
-    //   await page.waitForChanges();
+    it("should keep the same options when characters are entered and the menu is reopened", async () => {
+      const page = await newE2EPage();
+      await page.setContent(getTestSearchableSelect(searchableOptions));
+      await page.waitForChanges();
 
-    //   await focusAndTypeIntoInput("foo", page);
-    //   await page.waitForChanges();
+      await focusAndTypeIntoInput("foo", page);
+      await page.waitForChanges();
 
-    //   const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
-    //   let menuOptions = await menu.findAll("li");
-    //   expect(menuOptions).toHaveLength(1);
-    //   expect(menuOptions[0]).toEqualText("No results found");
+      const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+      let menuOptions = await menu.findAll("li");
+      expect(menuOptions).toHaveLength(1);
+      expect(menuOptions[0]).toEqualText("No results found");
 
-    //   const select = await page.find("ic-select >>> #ic-select-input-0");
-    //   select.click();
-    //   await page.waitForChanges();
-    //   expect(await getMenuVisibility(page)).toBe("hidden");
+      const select = await page.find("ic-select >>> #ic-select-input-0");
+      select.click();
+      await page.waitForChanges();
+      expect(await getMenuVisibility(page)).toBe("hidden");
 
-    //   select.click();
-    //   await page.waitForChanges();
-    //   expect(await getMenuVisibility(page)).toBe("visible");
-    //   menuOptions = await menu.findAll("li");
-    //   expect(menuOptions).toHaveLength(1);
-    //   expect(menuOptions[0]).toEqualText("No results found");
-    // });
+      select.click();
+      await page.waitForChanges();
+      expect(await getMenuVisibility(page)).toBe("visible");
+      menuOptions = await menu.findAll("li");
+      expect(menuOptions).toHaveLength(1);
+      expect(menuOptions[0]).toEqualText("No results found");
+    });
 
     it("should display no results state when search term matches none of the options", async () => {
       const page = await newE2EPage();

--- a/packages/web-components/src/components/ic-select/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.spec.tsx
@@ -968,6 +968,11 @@ describe("ic-select searchable", () => {
 
     const input = page.root.shadowRoot.querySelector("input");
     expect(input.value).toBe(label1);
+
+    input.click();
+    await page.waitForChanges();
+
+    expect(page.rootInstance.filteredOptions).toHaveLength(3);
   });
 
   it("should test keydown on menu - space key", async () => {
@@ -1056,6 +1061,21 @@ describe("ic-select searchable", () => {
     const page = await newSpecPage({
       components: [Select, Menu, InputComponentContainer],
       html: `<ic-select label="IC Select Test" searchable="true"></ic-select>`,
+    });
+
+    page.root.options = menuOptions;
+    await page.waitForChanges();
+
+    const input = page.root.shadowRoot.querySelector("input");
+    input.click();
+    await page.waitForChanges();
+    expect(page.rootInstance.open).toBe(true);
+  });
+
+  it("should test click on input with external filtering", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      html: `<ic-select label="IC Select Test" searchable="true" disable-filter="true"></ic-select>`,
     });
 
     page.root.options = menuOptions;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Searchable IcSelect now keeps suggestions after typing and then closing\reopening menu

## Related issue
#704 

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 