### PR TITLE
fix(web-components): remove disabled attribute from components when disabled is false

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -6,6 +6,7 @@
     "GHSA-pfrx-2q88-qq97",
     "GHSA-9c47-m6qq-7p4h",
     "GHSA-hc6q-2mpp-qw7j",
-    "GHSA-776f-qx25-q3cc"
+    "GHSA-776f-qx25-q3cc",
+    "GHSA-c2qf-rxjj-qqgw"
   ]
 }

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -10,7 +10,11 @@ import {
   h,
 } from "@stencil/core";
 
-import { getThemeFromContext, inheritAttributes } from "../../utils/helpers";
+import {
+  getThemeFromContext,
+  inheritAttributes,
+  removeDisabledFalse,
+} from "../../utils/helpers";
 import { IC_INHERITED_ARIA } from "../../utils/constants";
 import {
   IcButtonSizes,
@@ -220,6 +224,8 @@ export class Button {
       "aria-expanded",
       "title",
     ]);
+
+    removeDisabledFalse(this.disabled, this.el);
 
     this.el.setAttribute("exportparts", "button");
 

--- a/packages/web-components/src/components/ic-card/ic-card.tsx
+++ b/packages/web-components/src/components/ic-card/ic-card.tsx
@@ -11,6 +11,7 @@ import {
   onComponentRequiredPropUndefined,
   isSlotUsed,
   getThemeFromContext,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import {
   IcTheme,
@@ -153,6 +154,8 @@ export class Card {
       this.parentEl.addEventListener("focus", this.parentFocussed);
       this.parentEl.addEventListener("blur", this.parentBlurred);
     }
+
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   disconnectedCallback(): void {

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.tsx
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.tsx
@@ -12,6 +12,7 @@ import {
   getInputDescribedByText,
   hasValidationStatus,
   onComponentRequiredPropUndefined,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IcInformationStatusOrEmpty } from "../../utils/types";
 import { IcChangeEventDetail } from "./ic-checkbox-group.types";
@@ -86,6 +87,10 @@ export class CheckboxGroup {
       })),
       selectedOption: ev.target as HTMLIcCheckboxElement,
     });
+  }
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.host);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -17,6 +17,7 @@ import {
   removeHiddenInput,
   addFormResetListener,
   removeFormResetListener,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 
 @Component({
@@ -129,6 +130,8 @@ export class Checkbox {
   }
 
   componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.host);
+
     addFormResetListener(this.host, this.handleFormReset);
     this.host
       .querySelector(this.IC_TEXT_FIELD)

--- a/packages/web-components/src/components/ic-chip/ic-chip.tsx
+++ b/packages/web-components/src/components/ic-chip/ic-chip.tsx
@@ -12,6 +12,7 @@ import {
 import {
   onComponentRequiredPropUndefined,
   isSlotUsed,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IcChipAppearance, IcChipSizes } from "./ic-chip.types";
 import dismissIcon from "../../assets/dismiss-icon.svg";
@@ -90,6 +91,10 @@ export class Chip {
     if (this.el.shadowRoot.querySelector("button")) {
       this.el.shadowRoot.querySelector("button").focus();
     }
+  }
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -13,6 +13,7 @@ import {
   getParentElement,
   isSlotUsed,
   onComponentRequiredPropUndefined,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IcMenuItemVariants } from "./ic-menu-item.types";
 import Check from "../../assets/check-icon.svg";
@@ -122,6 +123,8 @@ export class MenuItem {
     if (this.submenuTriggerFor !== undefined && this.variant !== "default") {
       this.variant = "default";
     }
+
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-pagination-item/ic-pagination-item.tsx
+++ b/packages/web-components/src/components/ic-pagination-item/ic-pagination-item.tsx
@@ -8,6 +8,7 @@ import {
 } from "@stencil/core";
 import { IcPaginationItemType } from "./ic-pagination-item.types";
 import { IcThemeForeground } from "../../utils/types";
+import { removeDisabledFalse } from "../../utils/helpers";
 
 @Component({
   tag: "ic-pagination-item",
@@ -58,6 +59,10 @@ export class PaginationItem {
   private handleClick = () => {
     this.paginationItemClick.emit({ page: this.page });
   };
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   render() {
     const {

--- a/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
@@ -15,7 +15,10 @@ import paginationNextPrevious from "../../assets/pagination-next-previous.svg";
 import paginationFirstLast from "../../assets/pagination-first-last.svg";
 import { IcThemeForeground } from "../../utils/types";
 import { IcPaginationTypes, IcChangeEventDetail } from "./ic-pagination.types";
-import { onComponentRequiredPropUndefined } from "../../utils/helpers";
+import {
+  onComponentRequiredPropUndefined,
+  removeDisabledFalse,
+} from "../../utils/helpers";
 
 @Component({
   tag: "ic-pagination",
@@ -365,6 +368,8 @@ export class Pagination {
     if (this.adjacentCount > 2) {
       this.adjacentCount = 2;
     }
+
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   render() {

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -13,6 +13,7 @@ import {
   hasValidationStatus,
   isSlotUsed,
   onComponentRequiredPropUndefined,
+  removeDisabledFalse,
   renderHiddenInput,
 } from "../../utils/helpers";
 import {
@@ -159,6 +160,10 @@ export class RadioGroup {
 
     return nextItem;
   };
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.host);
+  }
 
   componentDidLoad(): void {
     this.radioOptions = Array.from(

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
@@ -16,6 +16,7 @@ import {
   onComponentRequiredPropUndefined,
   addFormResetListener,
   removeFormResetListener,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 @Component({
   tag: "ic-radio-option",
@@ -131,6 +132,8 @@ export class RadioOption {
     this.defaultRadioValue = this.value;
 
     addFormResetListener(this.host, this.handleFormReset);
+
+    removeDisabledFalse(this.disabled, this.host);
   }
 
   private handleFormReset = (): void => {

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -25,6 +25,7 @@ import {
   getLabelFromValue,
   onComponentRequiredPropUndefined,
   getFilteredMenuOptions,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IcSearchBarBlurEventDetail } from "./ic-search-bar.types";
 import { IcValueEventDetail, IcBlurEventDetail } from "../../utils/types";
@@ -681,6 +682,8 @@ export class SearchBar {
 
   componentWillLoad(): void {
     this.watchValueHandler(this.value);
+
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-switch/ic-switch.tsx
+++ b/packages/web-components/src/components/ic-switch/ic-switch.tsx
@@ -15,6 +15,7 @@ import {
   renderHiddenInput,
   addFormResetListener,
   removeFormResetListener,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IcSwitchChangeEventDetail } from "./ic-switch.types";
 
@@ -129,6 +130,8 @@ export class Switch {
   componentWillLoad(): void {
     this.checkedState = this.checked;
     addFormResetListener(this.el, this.handleFormReset);
+
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-tab-context/__snapshots__/ic-tab-context.spec.ts.snap
+++ b/packages/web-components/src/components/ic-tab-context/__snapshots__/ic-tab-context.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`ic-tab-context component should render tab context with custom contextI
         </div>
       </ic-horizontal-scroll>
     </mock:shadow-root>
-    <ic-tab aria-controls="ic-tab-panel-0-context-custom-context" aria-disabled="false" aria-selected="false" context-id="custom-context" id="ic-tab-0-context-custom-context" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-0-context-custom-context" aria-disabled="false" aria-selected="true" class="selected" context-id="custom-context" id="ic-tab-0-context-custom-context" role="tab" selected="" tab-id="ic-tab--0-context-custom-context" tabindex="0">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -21,7 +21,7 @@ exports[`ic-tab-context component should render tab context with custom contextI
       </mock:shadow-root>
       One
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-1-context-custom-context" aria-disabled="false" aria-selected="false" context-id="custom-context" id="ic-tab-1-context-custom-context" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-1-context-custom-context" aria-disabled="false" aria-selected="false" context-id="custom-context" id="ic-tab-1-context-custom-context" role="tab" tab-id="ic-tab--1-context-custom-context" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -31,7 +31,7 @@ exports[`ic-tab-context component should render tab context with custom contextI
       </mock:shadow-root>
       Two
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-2-context-custom-context" aria-disabled="false" aria-selected="false" context-id="custom-context" id="ic-tab-2-context-custom-context" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-2-context-custom-context" aria-disabled="false" aria-selected="false" context-id="custom-context" id="ic-tab-2-context-custom-context" role="tab" tab-id="ic-tab--2-context-custom-context" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -42,7 +42,7 @@ exports[`ic-tab-context component should render tab context with custom contextI
       Three
     </ic-tab>
   </ic-tab-group>
-  <ic-tab-panel aria-labelledby="ic-tab-0-context-custom-context" context-id="custom-context" hidden="" id="ic-tab-panel-0-context-custom-context" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-0-context-custom-context" context-id="custom-context" id="ic-tab-panel-0-context-custom-context" panel-id="ic-tab--0-context-custom-context" role="tabpanel" tab-position="0">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -50,7 +50,7 @@ exports[`ic-tab-context component should render tab context with custom contextI
     </mock:shadow-root>
     Tab One
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-1-context-custom-context" context-id="custom-context" hidden="" id="ic-tab-panel-1-context-custom-context" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-1-context-custom-context" context-id="custom-context" hidden="" id="ic-tab-panel-1-context-custom-context" panel-id="ic-tab--1-context-custom-context" role="tabpanel" tab-position="1">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -58,7 +58,7 @@ exports[`ic-tab-context component should render tab context with custom contextI
     </mock:shadow-root>
     Tab Two
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-2-context-custom-context" context-id="custom-context" hidden="" id="ic-tab-panel-2-context-custom-context" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-2-context-custom-context" context-id="custom-context" hidden="" id="ic-tab-panel-2-context-custom-context" panel-id="ic-tab--2-context-custom-context" role="tabpanel" tab-position="2">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -80,7 +80,7 @@ exports[`ic-tab-context component should render tab context with tabs - light ap
         </div>
       </ic-horizontal-scroll>
     </mock:shadow-root>
-    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-0-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="true" class="ic-tab-light selected" context-id="default" id="ic-tab-0-context-default" role="tab" selected="" tab-id="ic-tab--0-context-default" tabindex="0">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -90,7 +90,7 @@ exports[`ic-tab-context component should render tab context with tabs - light ap
       </mock:shadow-root>
       One
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" class="ic-tab-light" context-id="default" id="ic-tab-1-context-default" role="tab" tab-id="ic-tab--1-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -100,7 +100,7 @@ exports[`ic-tab-context component should render tab context with tabs - light ap
       </mock:shadow-root>
       Two
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-2-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" class="ic-tab-light" context-id="default" id="ic-tab-2-context-default" role="tab" tab-id="ic-tab--2-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -111,7 +111,7 @@ exports[`ic-tab-context component should render tab context with tabs - light ap
       Three
     </ic-tab>
   </ic-tab-group>
-  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" hidden="" id="ic-tab-panel-0-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" class="ic-tab-panel-light" context-id="default" id="ic-tab-panel-0-context-default" panel-id="ic-tab--0-context-default" role="tabpanel" tab-position="0">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -119,7 +119,7 @@ exports[`ic-tab-context component should render tab context with tabs - light ap
     </mock:shadow-root>
     Tab One
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" class="ic-tab-panel-light" context-id="default" hidden="" id="ic-tab-panel-1-context-default" panel-id="ic-tab--1-context-default" role="tabpanel" tab-position="1">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -127,7 +127,7 @@ exports[`ic-tab-context component should render tab context with tabs - light ap
     </mock:shadow-root>
     Tab Two
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" hidden="" id="ic-tab-panel-2-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" class="ic-tab-panel-light" context-id="default" hidden="" id="ic-tab-panel-2-context-default" panel-id="ic-tab--2-context-default" role="tabpanel" tab-position="2">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -149,7 +149,7 @@ exports[`ic-tab-context component should render tab context with tabs - manual a
         </div>
       </ic-horizontal-scroll>
     </mock:shadow-root>
-    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-0-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="true" class="selected" context-id="default" id="ic-tab-0-context-default" role="tab" selected="" tab-id="ic-tab--0-context-default" tabindex="0">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -159,7 +159,7 @@ exports[`ic-tab-context component should render tab context with tabs - manual a
       </mock:shadow-root>
       One
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tab-id="ic-tab--1-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -169,7 +169,7 @@ exports[`ic-tab-context component should render tab context with tabs - manual a
       </mock:shadow-root>
       Two
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-2-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-2-context-default" role="tab" tab-id="ic-tab--2-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -180,7 +180,7 @@ exports[`ic-tab-context component should render tab context with tabs - manual a
       Three
     </ic-tab>
   </ic-tab-group>
-  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" hidden="" id="ic-tab-panel-0-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" id="ic-tab-panel-0-context-default" panel-id="ic-tab--0-context-default" role="tabpanel" tab-position="0">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -188,7 +188,7 @@ exports[`ic-tab-context component should render tab context with tabs - manual a
     </mock:shadow-root>
     Tab One
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" panel-id="ic-tab--1-context-default" role="tabpanel" tab-position="1">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -196,7 +196,7 @@ exports[`ic-tab-context component should render tab context with tabs - manual a
     </mock:shadow-root>
     Tab Two
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" hidden="" id="ic-tab-panel-2-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" hidden="" id="ic-tab-panel-2-context-default" panel-id="ic-tab--2-context-default" role="tabpanel" tab-position="2">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -218,7 +218,7 @@ exports[`ic-tab-context component should render tab context with tabs - selected
         </div>
       </ic-horizontal-scroll>
     </mock:shadow-root>
-    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-0-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-0-context-default" role="tab" tab-id="ic-tab--0-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -228,7 +228,7 @@ exports[`ic-tab-context component should render tab context with tabs - selected
       </mock:shadow-root>
       One
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tab-id="ic-tab--1-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -238,7 +238,7 @@ exports[`ic-tab-context component should render tab context with tabs - selected
       </mock:shadow-root>
       Two
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-2-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="true" class="selected" context-id="default" id="ic-tab-2-context-default" role="tab" selected="" tab-id="ic-tab--2-context-default" tabindex="0">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -249,7 +249,7 @@ exports[`ic-tab-context component should render tab context with tabs - selected
       Three
     </ic-tab>
   </ic-tab-group>
-  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" hidden="" id="ic-tab-panel-0-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" hidden="" id="ic-tab-panel-0-context-default" panel-id="ic-tab--0-context-default" role="tabpanel" tab-position="0">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -257,7 +257,7 @@ exports[`ic-tab-context component should render tab context with tabs - selected
     </mock:shadow-root>
     Tab One
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" panel-id="ic-tab--1-context-default" role="tabpanel" tab-position="1">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -265,7 +265,7 @@ exports[`ic-tab-context component should render tab context with tabs - selected
     </mock:shadow-root>
     Tab Two
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" hidden="" id="ic-tab-panel-2-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" id="ic-tab-panel-2-context-default" panel-id="ic-tab--2-context-default" role="tabpanel" tab-position="2">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -287,7 +287,7 @@ exports[`ic-tab-context component should render tab context with tabs 1`] = `
         </div>
       </ic-horizontal-scroll>
     </mock:shadow-root>
-    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-0-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-0-context-default" aria-disabled="false" aria-selected="true" class="selected" context-id="default" id="ic-tab-0-context-default" role="tab" selected="" tab-id="ic-tab--0-context-default" tabindex="0">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -297,7 +297,7 @@ exports[`ic-tab-context component should render tab context with tabs 1`] = `
       </mock:shadow-root>
       One
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-1-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-1-context-default" role="tab" tab-id="ic-tab--1-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -307,7 +307,7 @@ exports[`ic-tab-context component should render tab context with tabs 1`] = `
       </mock:shadow-root>
       Two
     </ic-tab>
-    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-2-context-default" role="tab" tabindex="-1">
+    <ic-tab aria-controls="ic-tab-panel-2-context-default" aria-disabled="false" aria-selected="false" context-id="default" id="ic-tab-2-context-default" role="tab" tab-id="ic-tab--2-context-default" tabindex="-1">
       <mock:shadow-root>
         <ic-typography class="ic-tab-label" variant="label">
           <span>
@@ -318,7 +318,7 @@ exports[`ic-tab-context component should render tab context with tabs 1`] = `
       Three
     </ic-tab>
   </ic-tab-group>
-  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" hidden="" id="ic-tab-panel-0-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-0-context-default" context-id="default" id="ic-tab-panel-0-context-default" panel-id="ic-tab--0-context-default" role="tabpanel" tab-position="0">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -326,7 +326,7 @@ exports[`ic-tab-context component should render tab context with tabs 1`] = `
     </mock:shadow-root>
     Tab One
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-1-context-default" context-id="default" hidden="" id="ic-tab-panel-1-context-default" panel-id="ic-tab--1-context-default" role="tabpanel" tab-position="1">
     <mock:shadow-root>
       <div>
         <slot></slot>
@@ -334,7 +334,7 @@ exports[`ic-tab-context component should render tab context with tabs 1`] = `
     </mock:shadow-root>
     Tab Two
   </ic-tab-panel>
-  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" hidden="" id="ic-tab-panel-2-context-default" role="tabpanel">
+  <ic-tab-panel aria-labelledby="ic-tab-2-context-default" context-id="default" hidden="" id="ic-tab-panel-2-context-default" panel-id="ic-tab--2-context-default" role="tabpanel" tab-position="2">
     <mock:shadow-root>
       <div>
         <slot></slot>

--- a/packages/web-components/src/components/ic-tab/ic-tab.tsx
+++ b/packages/web-components/src/components/ic-tab/ic-tab.tsx
@@ -14,6 +14,7 @@ import {
   IcThemeForegroundNoDefault,
   IcThemeForegroundEnum,
 } from "../../utils/types";
+import { removeDisabledFalse } from "../../utils/helpers";
 
 /**
  * @slot icon - Content will be rendered next to the tab label.
@@ -112,6 +113,10 @@ export class Tab {
     if (this.host) {
       this.host.focus();
     }
+  }
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.host);
   }
 
   componentDidUpdate(): void {

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -28,6 +28,7 @@ import {
   addFormResetListener,
   removeFormResetListener,
   isSlotUsed,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IC_INHERITED_ARIA } from "../../utils/constants";
 import {
@@ -391,6 +392,8 @@ export class TextField {
     }
 
     addFormResetListener(this.el, this.handleFormReset);
+
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -577,3 +577,12 @@ export const pxToRem = (px: string, base = 16) => {
   const tempPx = parseInt(px);
   return `${(1 / base) * tempPx}rem`;
 };
+
+export const removeDisabledFalse = (
+  disabled: boolean,
+  element: HTMLElement
+) => {
+  if (!disabled) {
+    element.removeAttribute("disabled");
+  }
+};


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Remove disabled attribute from components when disabled is false so that it doesn't get passed down to the native element causing dimmed to be read by screen readers

## Related issue
#799

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 