### PR TITLE
Update flaky select test to try and stop it failing

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.e2e.ts
+++ b/packages/web-components/src/components/ic-select/ic-select.e2e.ts
@@ -600,9 +600,7 @@ describe("ic-select", () => {
 
     it("should close menu when Shift + Tab is pressed to move focus onto the input", async () => {
       const page = await newE2EPage();
-      await page.setContent(
-        `${getTestSelect(options)}<button>Test button</button>`
-      );
+      await page.setContent(`${getTestSelect(options)}`);
       await page.waitForChanges();
 
       const select = await page.find("ic-select >>> #ic-select-input-0");
@@ -612,6 +610,8 @@ describe("ic-select", () => {
 
       await page.keyboard.down("Shift");
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
+
       await page.keyboard.up("Shift");
       await page.waitForChanges();
 


### PR DESCRIPTION
## Summary of the changes
Added page.waitForChanges to flaky select test. Removed unnecessary test button which is also rendered to make sure it is not affecting the behaviour being tested at all (may be interfering with the tabbing? But not needed anyway)

I wasn't getting the E2E tests failing at all so no idea if this will stop it failing sometimes for others. If anyone has any other ideas to improve it further then let me know :)

## Related issue
#694

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 