### PR TITLE
fix(web-components): add removeDisabledFalse helper to select

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -22,6 +22,7 @@ import {
   getFilteredMenuOptions,
   addFormResetListener,
   removeFormResetListener,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import { IC_INHERITED_ARIA } from "../../utils/constants";
 import {
@@ -829,6 +830,8 @@ export class Select {
       "tabindex",
       "title",
     ]);
+
+    removeDisabledFalse(this.disabled, this.host);
 
     this.setOptionsValuesFromLabels();
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add removeDisabledFalse helper to select to ensure dimmed isn't read out by a screen reader when disabled="false"

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 