### PR TITLE
ci(root): updated trigger to run if manually triggered

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -87,7 +87,7 @@ jobs:
         ic-ui-kit-e2e-tests,
         ic-ui-kit-visual-tests,
       ]
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch' }}
     name: "Deploy"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
The deploy step was skipping if run manually via workflow_dispatch. This was due to the if parameter in the deploy step not taking into the account a build being triggered by workflow_dispatch.

## Related issue
N/A

## Checklist
- [ ] I have added relevant unit and visual regression tests.
- [ ] I have manually accessibility tested any changes, if relevant.
- [ ] I have ensured any changes match the Figma component library. 