### PR TITLE
fix(web-components): duplicate a.link styles for div.link on nav items

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -411,6 +411,10 @@ svg {
 :host(.navigation-item-side-nav.navigation-item-top-nav-child)
   a.link
   ic-typography,
+:host(.navigation-item-side-nav) div.link ic-typography,
+:host(.navigation-item-side-nav.navigation-item-top-nav-child)
+  div.link
+  ic-typography,
 .navigation-item-side-nav-slotted-text {
   opacity: var(--navigation-item-label-opacity);
   transition: opacity var(--ic-easing-transition-slow);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Duplicate a.link styles for div.link on nav items so that when there is no href the label doesn't show when collapsed

## Related issue
#726

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 