### PR TITLE
Increase width of button when it is loading and has an icon

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -88,6 +88,10 @@
   pointer-events: none;
 }
 
+:host(.loading-with-icon) .button {
+  min-width: var(--min-width, 8.25rem);
+}
+
 /* Variants */
 
 /* Primary */

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -358,6 +358,7 @@ export class Button {
           [`button-variant-${this.variant}`]: true,
           [`button-size-${this.size}`]: true,
           ["loading"]: this.loading,
+          ["loading-with-icon"]: this.loading && this.hasIconSlot(),
           ["dark"]: this.appearance === IcThemeForegroundEnum.Dark,
           ["light"]: this.appearance === IcThemeForegroundEnum.Light,
           ["full-width"]: this.fullWidth,


### PR DESCRIPTION
## Summary of the changes
Increased width of button by 2rem when it is loading and the icon slot is used (24px for the icon plus the 8px gap).

This can be checked in the 'Playground with icon' story.

When a button is changed from not loading to loading, the width still decreases but to a larger width if it has an icon. This matches the behaviour of buttons when they don't have an icon - they are set to a set width, so not exactly the same width as the button when it isn't loading.

## Related issue
#838

## Checklist
- [x] I have ensured any changes match the Figma component library. 