### PR TITLE
fix(web-components): updated searchable select to clear input when va…

### DIFF
--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -550,7 +550,6 @@ export class Menu {
           this.setHighlightedOption(0);
         } else if (this.isSearchableSelect) {
           (this.parentEl as HTMLIcSelectElement).setFocus();
-          this.value = null;
         }
         this.focusFromSearchKeypress = true;
         break;
@@ -561,7 +560,6 @@ export class Menu {
             this.setHighlightedOption(0);
           } else if (this.isSearchableSelect) {
             (this.parentEl as HTMLIcSelectElement).setFocus();
-            this.value = null;
           }
           this.focusFromSearchKeypress = true;
         }

--- a/packages/web-components/src/components/ic-menu/test/basic/ic-menu.spec.tsx
+++ b/packages/web-components/src/components/ic-menu/test/basic/ic-menu.spec.tsx
@@ -648,7 +648,7 @@ describe("ic-menu in isolation", () => {
 
     await page.waitForChanges();
 
-    expect(page.rootInstance.value).toBe(null);
+    expect(page.rootInstance.value).toBe(menuOptions[0].value);
   });
   it("tests setInputValue function when default parameter passed", async () => {
     const select = window.document.createElement(

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -265,7 +265,7 @@ export class Select {
       this.currValue = this.value;
     }
 
-    if (this.searchable && !!this.currValue) {
+    if (this.searchable) {
       this.searchableSelectInputValue =
         this.getLabelFromValue(this.currValue) || this.currValue;
     }

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
@@ -1685,4 +1685,27 @@ describe("ic-select searchable", () => {
     await waitForTimeout(1000);
     expect(page.rootInstance.filteredOptions).toHaveLength(0);
   });
+
+  it("should clear the searchable input if the value is programatically set to undefined", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      html: `<ic-select label="IC Select Test" searchable="true"></ic-select>`,
+    });
+    page.rootInstance.searchableSelectInputValue = "test";
+    await page.waitForChanges();
+
+    const event = new Event("input", {
+      bubbles: true,
+      cancelable: true,
+    });
+    const input = page.root.shadowRoot.querySelector("input");
+    input.dispatchEvent(event);
+    page.rootInstance.loading = true;
+    await page.waitForChanges();
+    expect(page.rootInstance.filteredOptions).toHaveLength(1);
+
+    page.rootInstance.value = undefined;
+    await page.waitForChanges();
+    expect(page.rootInstance.searchableSelectInputValue).toBeUndefined;
+  });
 });


### PR DESCRIPTION
…lue programatically set

## Summary of the changes
when value set to undefined, the input now clears. also preventing the value from being cleared when keys pressed on menu

## Related issue
#818 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 