### PR TITLE
fix(web-components): add role tab to divs in horizontal scroll

### DIFF
--- a/packages/web-components/src/components/ic-horizontal-scroll/ic-horizontal-scroll.tsx
+++ b/packages/web-components/src/components/ic-horizontal-scroll/ic-horizontal-scroll.tsx
@@ -225,6 +225,7 @@ export class HorizontalScroll {
             ["hidden"]: !itemOverflow,
             ["disabled"]: firstItemVisible,
           }}
+          role="tab"
         >
           <ic-button
             class="scroll-arrow"
@@ -247,6 +248,7 @@ export class HorizontalScroll {
             ["hidden"]: !itemOverflow,
             ["disabled"]: lastItemVisible,
           }}
+          role="tab"
         >
           <span class="scroll-splitter-right"></span>
           <ic-button

--- a/packages/web-components/src/components/ic-horizontal-scroll/test/basic/__snapshots__/ic-horizontal-scroll.spec.ts.snap
+++ b/packages/web-components/src/components/ic-horizontal-scroll/test/basic/__snapshots__/ic-horizontal-scroll.spec.ts.snap
@@ -3,14 +3,14 @@
 exports[`ic-horizontal-scroll should render the correct HTML for the chosen appearance: renders-appearance 1`] = `
 <ic-horizontal-scroll>
   <mock:shadow-root>
-    <div aria-hidden="true" class="disabled hidden scroll-container-left">
+    <div aria-hidden="true" class="disabled hidden scroll-container-left" role="tab">
       <ic-button appearance="default" aria-label="Scroll left" class="scroll-arrow" disabled="" tabindex="-1" variant="icon">
         svg
       </ic-button>
       <span class="scroll-splitter-left"></span>
     </div>
     <slot></slot>
-    <div aria-hidden="true" class="hidden scroll-container-right">
+    <div aria-hidden="true" class="hidden scroll-container-right" role="tab">
       <span class="scroll-splitter-right"></span>
       <ic-button appearance="default" aria-label="Scroll right" class="scroll-arrow" tabindex="-1" variant="icon">
         svg
@@ -91,14 +91,14 @@ exports[`ic-horizontal-scroll should render the correct HTML for the chosen appe
 exports[`ic-horizontal-scroll should render: renders 1`] = `
 <ic-horizontal-scroll>
   <mock:shadow-root>
-    <div aria-hidden="true" class="disabled hidden scroll-container-left">
+    <div aria-hidden="true" class="disabled hidden scroll-container-left" role="tab">
       <ic-button appearance="default" aria-label="Scroll left" class="scroll-arrow" disabled="" tabindex="-1" variant="icon">
         svg
       </ic-button>
       <span class="scroll-splitter-left"></span>
     </div>
     <slot></slot>
-    <div aria-hidden="true" class="hidden scroll-container-right">
+    <div aria-hidden="true" class="hidden scroll-container-right" role="tab">
       <span class="scroll-splitter-right"></span>
       <ic-button appearance="default" aria-label="Scroll right" class="scroll-arrow" tabindex="-1" variant="icon">
         svg


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add role tab to divs in horizontal scroll to stop axe issue.

I couldn't find an alternative to stop the axe accessibility issues other than to add role="tab" to the left and right arrow button divs, but I've checked in multiple components (page header, top nav, tabs) and it doesn't seem to have a negative affect on anything due to the aria hidden, so I think it should be okay.

## Related issue
#721

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 