### PR TITLE
fix(web-components): fixes ic-button aria-describedby not working

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.stories.mdx
+++ b/packages/web-components/src/components/ic-button/ic-button.stories.mdx
@@ -791,3 +791,28 @@ export const defaultArgs = {
     `}
   </Story>
 </Canvas>
+
+### Aria-describedby
+
+<Canvas>
+  <Story name="Aria-describedby" parameters={{ loki: { skip: true } }}>
+    {html`
+      <script>
+        function btnClick() {
+          var descEl = document.querySelector("#button-description");
+          descEl.innerText = "See, I told you it was amazing!";
+        }
+      </script>
+      <div style="padding: 6px">
+        <span id="button-description">This button does something amazing</span>
+        <br />
+        <ic-button
+          variant="primary"
+          onclick="btnClick()"
+          aria-describedby="button-description"
+          >Button</ic-button
+        >
+      </div>
+    `}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -221,6 +221,34 @@ exports[`button component should render with defined "a" tag props 1`] = `
 </ic-button>
 `;
 
+exports[`button component should test aria-describedby is set 1`] = `
+<ic-button class="button-size-default button-variant-primary light" exportparts="button" id="ic-button">
+  <mock:shadow-root>
+    <button aria-describedby="button-description" class="button" part="button" type="button">
+      <slot></slot>
+    </button>
+    <span class="ic-button-describedby" id="button-description">
+      This is the button description
+    </span>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should test aria-describedby is updated 1`] = `
+<ic-button class="button-size-default button-variant-primary light" exportparts="button" id="ic-button">
+  <mock:shadow-root>
+    <button aria-describedby="button-description" class="button" part="button" type="button">
+      <slot></slot>
+    </button>
+    <span class="ic-button-describedby" id="button-description">
+      This is the new description
+    </span>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
 exports[`button component should test button as submit button on form 1`] = `
 <ic-button class="button-size-default button-variant-primary light" exportparts="button" form="new-form" id="ic-button" type="submit">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-button/test/basic/ic-button.e2e.ts
+++ b/packages/web-components/src/components/ic-button/test/basic/ic-button.e2e.ts
@@ -233,4 +233,39 @@ describe("ic-button component", () => {
 
     expect(spy).toHaveReceivedEvent();
   });
+
+  it("should test aria-describedby being updated", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      `
+      <script>
+        function btnClick(){
+          var descEl = document.querySelector("#button-description");
+          descEl.innerText = "See, I told you it was amazing!";
+        }
+      </script>
+      <div>
+        <span id="button-description">This button does something amazing</span>
+        <br />
+        <ic-button variant="primary" onclick="btnClick()" aria-describedby="button-description"
+          >Button</ic-button
+        >
+      </div>
+      `
+    );
+
+    const button = await page.find("ic-button");
+    let hiddenDescribedBy = await page.find(
+      "ic-button >>> #button-description"
+    );
+    expect(hiddenDescribedBy.innerText).toBe(
+      "This button does something amazing"
+    );
+
+    await button.click();
+    await page.waitForChanges();
+
+    hiddenDescribedBy = await page.find("ic-button >>> #button-description");
+    expect(hiddenDescribedBy.innerText).toBe("See, I told you it was amazing!");
+  });
 });

--- a/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
+++ b/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
@@ -257,6 +257,38 @@ describe("button component", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should test aria-describedby is set", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: `<span id="button-description">
+        This is the button description
+      </span>
+      <ic-button id='ic-button' aria-describedby="button-description">Button</ic-button>
+      `,
+    });
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it("should test aria-describedby is updated", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: `<span id="button-description">
+        This is the button description
+      </span>
+      <ic-button id='ic-button' aria-describedby="button-description">Button</ic-button>
+      `,
+    });
+
+    (document.querySelector("#button-description") as HTMLElement).innerText =
+      "This is the new description";
+    page.rootInstance.mutationCallback();
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
   it("should test blur handler", async () => {
     const page = await newSpecPage({
       components: [Button],

--- a/packages/web-components/src/components/ic-dialog/test/basic/ic-dialog.e2e.ts
+++ b/packages/web-components/src/components/ic-dialog/test/basic/ic-dialog.e2e.ts
@@ -1,5 +1,9 @@
 import { newE2EPage } from "@stencil/core/testing";
 
+beforeAll(() => {
+  jest.spyOn(console, "warn").mockImplementation(jest.fn());
+});
+
 const DIALOG_DELAY_MS = 300;
 
 describe("ic-dialog", () => {

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.e2e.ts
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.e2e.ts
@@ -1,6 +1,10 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { KeyInput } from "puppeteer";
 
+beforeAll(() => {
+  jest.spyOn(console, "warn").mockImplementation(jest.fn());
+});
+
 const options = `[
   { label: 'Test label 1', value: 'Test value 1' },
   { label: 'Test label 2', value: 'Test value 2' },

--- a/packages/web-components/src/components/ic-typography/test/basic/ic-typography.e2e.ts
+++ b/packages/web-components/src/components/ic-typography/test/basic/ic-typography.e2e.ts
@@ -1,5 +1,9 @@
 import { newE2EPage } from "@stencil/core/testing";
 
+beforeAll(() => {
+  jest.spyOn(console, "warn").mockImplementation(jest.fn());
+});
+
 describe("ic-typograpghy", () => {
   it("should test truncation", async () => {
     const page = await newE2EPage();

--- a/packages/web-components/src/testspec.setup.ts
+++ b/packages/web-components/src/testspec.setup.ts
@@ -28,6 +28,17 @@ Object.defineProperty(global, "ResizeObserver", {
   value: mockResizeObserver,
 });
 
+// MutationObserver isn't available in test environment
+const mockMutationObserver = jest.fn();
+mockMutationObserver.mockReturnValue({
+  observe: jest.fn().mockReturnValue(null),
+  unobserve: jest.fn().mockReturnValue(null),
+  disconnect: jest.fn().mockReturnValue(null),
+});
+Object.defineProperty(global, "MutationObserver", {
+  value: mockMutationObserver,
+});
+
 export const waitForTimeout = async (ms: number): Promise<void> => {
   await new Promise((r) => setTimeout(r, ms));
 };


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes aria-describedby not working by allowing it to be set to a sibling element of the ic-button element. When the component loads it creates an element in the shadowDOM with the same id and sets the innerText to match the light DOM element.
A mutationObserver is used to keep the shadowDOM element in sync with the light DOM element, if the text content changes.

## Related issue
#898 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 