### PR TITLE
Side navigation bug fixes

### DIFF
--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
@@ -198,11 +198,3 @@
   left: var(--navigation-group-title-position-left);
   white-space: nowrap;
 }
-
-.menu-visibility-visible {
-  visibility: visible;
-}
-
-.menu-visibility-hidden {
-  visibility: hidden;
-}

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -62,7 +62,6 @@
   flex-direction: column;
   flex: 1 1 0;
   overflow: auto;
-  visibility: hidden;
 }
 
 :host(.inline) .side-navigation-inner {
@@ -77,6 +76,10 @@
 :host(.xs-menu-close) .side-navigation {
   left: calc(var(--side-navigation-width) * -1);
   transition: left var(--ic-easing-transition-slow);
+}
+
+:host(.xs-menu-close) .side-navigation > * {
+  visibility: hidden;
 }
 
 :host(.anchor-right.xs-menu-open) .side-navigation {
@@ -99,7 +102,6 @@
   background-color: var(--ic-theme-primary);
   display: flex;
   flex-direction: column;
-  visibility: hidden;
 }
 
 :host(.inline) .bottom-wrapper {
@@ -333,10 +335,7 @@ slot[name="app-icon"]::slotted(a) {
 
 .menu-visibility-visible {
   visibility: visible;
-}
-
-.menu-visibility-hidden {
-  visibility: hidden;
+  width: 100%;
 }
 
 /* Media Queries */
@@ -419,15 +418,6 @@ slot[name="app-icon"]::slotted(a) {
   :host(.anchor-right) .side-navigation {
     left: auto;
     right: 0;
-  }
-
-  .side-navigation-inner {
-    width: 100%;
-    visibility: visible;
-  }
-
-  .bottom-wrapper {
-    visibility: visible;
   }
 
   .app-title-wrapper {

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -336,7 +336,7 @@ export class SideNavigation {
     }
   };
 
-  private transitionEndHandler = () => {
+  private transitionHandler = (type: string) => {
     const primaryNavigationWrapper = this.el.shadowRoot.querySelector(
       ".primary-navigation"
     );
@@ -345,22 +345,33 @@ export class SideNavigation {
       ".bottom-wrapper > .secondary-navigation"
     );
 
+    const classToRemove =
+      type === "start"
+        ? this.COLLAPSED_ICON_LABELS_END
+        : this.COLLAPSED_ICON_LABELS_START;
+
+    const classToAdd =
+      type === "start"
+        ? this.COLLAPSED_ICON_LABELS_START
+        : this.COLLAPSED_ICON_LABELS_END;
+
     if (primaryNavigationWrapper) {
-      primaryNavigationWrapper.classList.remove(this.COLLAPSED_ICON_LABELS_END);
-      primaryNavigationWrapper.classList.add(this.COLLAPSED_ICON_LABELS_START);
+      primaryNavigationWrapper.classList.remove(classToRemove);
+      primaryNavigationWrapper.classList.add(classToAdd);
     }
 
     if (secondaryNavigationWrapper) {
-      secondaryNavigationWrapper.classList.remove(
-        this.COLLAPSED_ICON_LABELS_END
-      );
-      secondaryNavigationWrapper.classList.add(
-        this.COLLAPSED_ICON_LABELS_START
-      );
+      secondaryNavigationWrapper.classList.remove(classToRemove);
+      secondaryNavigationWrapper.classList.add(classToAdd);
     }
   };
 
+  private transitionEndHandler = () => {
+    this.transitionHandler("end");
+  };
+
   private animateCollapsedIconLabels = () => {
+    this.transitionHandler("start");
     this.transitionEndHandler();
 
     this.el.addEventListener("transitionend", this.transitionEndHandler);

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -505,7 +505,7 @@ export class SideNavigation {
       currSize <= DEVICE_SIZES.L &&
       !this.disableAutoParentStyling
     ) {
-      if (this.static) {
+      if (this.static && this.menuExpanded) {
         this.setParentPaddingLeft("calc(var(--ic-space-xl) * 10)");
       } else {
         this.setParentPaddingLeft(paddingLeft);

--- a/packages/web-components/src/components/ic-side-navigation/test/basic/__snapshots__/ic-side-navigation.spec.ts.snap
+++ b/packages/web-components/src/components/ic-side-navigation/test/basic/__snapshots__/ic-side-navigation.spec.ts.snap
@@ -413,7 +413,7 @@ exports[`ic-side-navigation renders with slotted navigation item - collapsed ico
         </div>
       </div>
       <div class="side-navigation-inner">
-        <nav aria-labelledby="primary-navigation-landmark" class="collapsed-icon-labels-start primary-navigation">
+        <nav aria-labelledby="primary-navigation-landmark" class="collapsed-icon-labels-end primary-navigation">
           <span aria-hidden="true" class="navigation-landmark-title" id="primary-navigation-landmark">
             Primary
           </span>
@@ -423,7 +423,7 @@ exports[`ic-side-navigation renders with slotted navigation item - collapsed ico
         </nav>
       </div>
       <div class="bottom-wrapper">
-        <nav aria-labelledby="secondary-navigation-landmark" class="collapsed-icon-labels-start secondary-navigation">
+        <nav aria-labelledby="secondary-navigation-landmark" class="collapsed-icon-labels-end secondary-navigation">
           <span aria-hidden="true" class="navigation-landmark-title" id="secondary-navigation-landmark">
             Secondary
           </span>


### PR DESCRIPTION
## Summary of the changes
For #739: Updated CSS so that the visibility is handled by just the 'menu-visibility-visible' class instead of in the media query, and remove unused classes in ic-navigation-group CSS.

For #885: Fixed padding so content is pushed to the side the correct amount with static variant.

For #896: Updated transition handlers - re-added functionality for adding / removing classes on transition start.

## Related issue
#739, #885 and #896.

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 