### PR TITLE
feat(root): add action to check for tasks in PR description not compl…

### DIFF
--- a/.github/workflows/check-tasks-completed.yml
+++ b/.github/workflows/check-tasks-completed.yml
@@ -1,0 +1,12 @@
+name: Prevent PRs with tasks not completed
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(github.event.pull_request.body, '- [ ]')
+        run: exit 1


### PR DESCRIPTION
## Summary of the changes
Added 'check-tasks-completed' action to check there are no tasks in PR description which are not completed.

I have tested this by adding an uncompleted task to a PR description. The action fails, but then when you click on the checkbox on the task to mark it as done, it runs again and passes (and vice versa).

## Related issue
#866 