### PR TITLE
Fix console error in side navigation if no href / slotted link

### DIFF
--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -382,8 +382,10 @@ export class SideNavigation {
   ): number => {
     const navItemLink =
       (navItems[0].shadowRoot &&
-        navItems[0].shadowRoot.querySelector("ic-tooltip a")) ||
-      navItems[0].querySelector("a");
+        (navItems[0].shadowRoot.querySelector("ic-tooltip a") ||
+          navItems[0].shadowRoot.querySelector("ic-tooltip div"))) ||
+      navItems[0].querySelector("a") ||
+      navItems[0].querySelector("div");
     const navItemSVG = navItems[0].querySelector("svg");
 
     const navStyles = {


### PR DESCRIPTION
## Summary of the changes
Update if statement in side navigation code to look for `<div>` if `<a>` not present - for when neither an href or slotted link is used.

I have tested this by console logging the `navItemLink` variable - tested on navigation items with an href, with a slotted link and with neither, and the `<a>` or `<div>` is always found

## Related issue
#863 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 