### PR TITLE
Dynamic pages update for pagination

### DIFF
--- a/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
@@ -79,6 +79,11 @@ export class Pagination {
    */
   @Prop() pages!: number;
 
+  @Watch("pages")
+  watchNumberPagesHandler(): void {
+    this.watchPageChangeHandler();
+  }
+
   /**
    * The type of pagination to be used.
    */
@@ -94,6 +99,12 @@ export class Pagination {
     if (this.type === "simple") {
       return;
     }
+
+    this.startEllipsis = false;
+    this.endEllipsis = false;
+    this.startItems = [];
+    this.endItems = [];
+    this.midItems = [];
 
     const startItems = [];
     let startItemCount = 0;

--- a/packages/web-components/src/components/ic-pagination/test/basic/ic-pagination.spec.ts
+++ b/packages/web-components/src/components/ic-pagination/test/basic/ic-pagination.spec.ts
@@ -448,4 +448,19 @@ describe("ic-pagination appearance tests", () => {
 
     expect(page.rootInstance.currentPage).toBe(3);
   });
+
+  it("should update number of pages dynamically if the prop is updated", async () => {
+    const page = await newSpecPage({
+      components: [Pagination],
+      html: `<ic-pagination pages=15 ></ic-pagination>`,
+    });
+
+    expect(page.rootInstance.pages).toEqual(15);
+
+    page.rootInstance.pages = 7;
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.pages).toEqual(7);
+  });
 });


### PR DESCRIPTION
## Summary of the changes
Allows the pagination to dynamically update and re-render the number of pages when the pages prop is updated.

## Related issue
#921 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 