### PR TITLE
ci(root): remove pre-release flags to resume semantic versioning

### DIFF
--- a/.github/workflows/ic-ui-kit-main.yml
+++ b/.github/workflows/ic-ui-kit-main.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           git config --global user.name ${{ secrets.USERNAME }}
           git config --global user.email ${{ secrets.EMAIL }}
-          HUSKY_SKIP_HOOKS=1 npx lerna publish --conventional-commits --conventional-prerelease --preid=beta --no-commit-hooks -y
+          HUSKY_SKIP_HOOKS=1 npx lerna publish --conventional-commits --no-commit-hooks -y
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukic/docs",
-  "version": "2.1.0-beta.18",
+  "version": "2.1.0",
   "description": "API documentation for @ukic components",
   "main": "docs.json",
   "types": "docs.d.ts",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukic/fonts",
-  "version": "2.1.0-beta.18",
+  "version": "2.1.0",
   "description": "Typography assets for @ukic components",
   "scripts": {
     "build": "rimraf ./dist && webpack --config webpack.config.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ukic/react",
   "sideEffects": false,
-  "version": "2.1.0-beta.18",
+  "version": "2.1.0",
   "description": "React-wrapped web components compiled using StencilJS",
   "scripts": {
     "build": "npm run clean && npm run compile && npm run copy:core-css && npm run copy:normalize-css",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukic/web-components",
-  "version": "2.1.0-beta.18",
+  "version": "2.1.0",
   "description": "A web component UI library compiled with StencilJS",
   "main": "dist/index.cjs.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary of the changes
Remove `--conventional-prerelease` and `--preid=beta` flags from the Lerna command. The removal of these flags transition ICDS from using pre-release versions with the “beta” identifier to adopting regular semantic versioning.

## Relevant information
This change will mean that merging it now will remove the prerelease as of the next release.

`npx lerna publish` has no `--dry-run` flag, for testing purposes, the following command would be suffice to test the change: `npx lerna publish --conventional-commits --no-commit-hooks --no-git-tag-version --no-push`, which currently returns:
```js
Changes:
       - @ukic/docs: 2.1.0 => 2.2.0
       - @ukic/fonts: 2.1.0 => 2.2.0
       - @ukic/react: 2.1.0 => 2.2.0
       - @ukic/web-components: 2.1.0 => 2.2.0
```

An addition check with `npm run release-check` returns the following:
```js
Changes:
        - @ukic/docs: 2.1.0 => 2.2.0
        - @ukic/fonts: 2.1.0 => 2.2.0
        - @ukic/react: 2.1.0 => 2.2.0
        - @ukic/web-components: 2.1.0 => 2.2.0
```

## Related issue
#938 