### PR TITLE
Z index not correct for sticky ic page

### DIFF
--- a/packages/web-components/src/components/ic-page-header/ic-page-header.css
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.css
@@ -13,6 +13,7 @@
   position: sticky;
   top: 0;
   box-shadow: var(--ic-elevation-overlay);
+  z-index: var(--ic-z-index-sticky-page-header);
 }
 
 header {
@@ -131,5 +132,6 @@ header.tabs {
     position: sticky;
     top: 0;
     box-shadow: var(--ic-elevation-overlay);
+    z-index: var(--ic-z-index-sticky-page-header);
   }
 }

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -369,6 +369,7 @@
   --ic-z-index-popover: calc(var(--ic-z-index-base-value) + 50);
   --ic-z-index-navigation-item: calc(var(--ic-z-index-base-value) + 50);
   --ic-z-index-navigation-menu: calc(var(--ic-z-index-base-value) + 60);
+  --ic-z-index-sticky-page-header: calc(var(--ic-z-index-base-value) + 60);
   --ic-z-index-side-navigation: calc(var(--ic-z-index-base-value) + 60);
   --ic-z-index-dialog: calc(var(--ic-z-index-base-value) + 100);
   --ic-z-index-toast: calc(var(--ic-z-index-base-value) + 110);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
adds new z-index value for sticky page header to prevent select box overlapping

## Related issue
#653

