### PR TITLE
fix(web-components): added trigger to update enabled tabs when tab's …

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -4024,6 +4024,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "onTabClick"?: (event: IcTabCustomEvent<IcTabClickEventDetail>) => void;
         "onTabCreated"?: (event: IcTabCustomEvent<HTMLIcTabElement>) => void;
+        "onTabEnabled"?: (event: IcTabCustomEvent<void>) => void;
         "onTabFocus"?: (event: IcTabCustomEvent<IcTabClickEventDetail>) => void;
         "onTabRemoved"?: (event: IcTabCustomEvent<void>) => void;
         "selected"?: boolean;

--- a/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
@@ -123,6 +123,11 @@ export class TabContext {
     }
   }
 
+  @Listen("tabEnabled")
+  tabEnabledHandler(): void {
+    this.enabledTabs = this.getEnabledTabs();
+  }
+
   /**
    * @internal Used to set tab/tab panel IDs when a tab/tab panel has been removed
    */

--- a/packages/web-components/src/components/ic-tab-context/test/basic/ic-tab-context.spec.ts
+++ b/packages/web-components/src/components/ic-tab-context/test/basic/ic-tab-context.spec.ts
@@ -489,4 +489,27 @@ describe("ic-tab-context component", () => {
     expect(newlyUpdatedTab.tabId).toBe("ic-tab--1-context-default");
     expect(newlyUpdatedTabPanel.panelId).toBe("ic-tab--1-context-default");
   });
+
+  it("should add a tab to enabledTabs when the tab changes from disabled to enabled", async () => {
+    const page = await newSpecPage({
+      components: [TabContext, TabGroup, Tab, TabPanel],
+      html: `<ic-tab-context>
+      <ic-tab-group label="Example tab group">
+        <ic-tab disabled>One</ic-tab>
+        <ic-tab>Two</ic-tab>
+        <ic-tab>Three</ic-tab>
+      </ic-tab-group>
+      <ic-tab-panel>Tab One</ic-tab-panel>
+      <ic-tab-panel>Tab Two</ic-tab-panel>
+      <ic-tab-panel>Tab Three</ic-tab-panel>
+      </ic-tab-context>`,
+    });
+
+    const tab = page.root.querySelector("ic-tab");
+    expect(page.rootInstance.enabledTabs).not.toContain(tab);
+    tab.disabled = false;
+    expect(page.rootInstance.enabledTabs).toContain(tab);
+    tab.disabled = true;
+    expect(page.rootInstance.enabledTabs).not.toContain(tab);
+  });
 });

--- a/packages/web-components/src/components/ic-tab/ic-tab.tsx
+++ b/packages/web-components/src/components/ic-tab/ic-tab.tsx
@@ -7,6 +7,7 @@ import {
   Prop,
   h,
   Method,
+  Watch,
 } from "@stencil/core";
 
 import { IcTabClickEventDetail } from "./ic-tab.types";
@@ -51,6 +52,11 @@ export class Tab {
   /** @internal The position of the tab inside the tabs array in context. */
   @Prop() tabPosition?: number;
 
+  @Watch("disabled")
+  disabledWatchHandler(): void {
+    this.tabEnabled.emit();
+  }
+
   /**
    * @internal Emitted when a tab is selected.
    */
@@ -60,6 +66,11 @@ export class Tab {
    * @internal Emitted when a tab is dynamically created.
    */
   @Event() tabCreated: EventEmitter<HTMLIcTabElement>;
+
+  /**
+   * @internal Emitted when a tab's disabled prop changes
+   */
+  @Event() tabEnabled: EventEmitter<void>;
 
   /**
    * @internal Emitted when a tab is focussed.


### PR DESCRIPTION
…disabled state changes

## Summary of the changes
Added an internal event to let tab-context know when a disabled prop has changed, in order to update enabledTabs

## Related issue
#922 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 