### PR TITLE
chore(web-components): remove watch from storybook command

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -23,7 +23,7 @@
     "test:watch": "stencil test --spec --e2e --watchAll",
     "test-a11y": "jest",
     "create-component": "stencil generate",
-    "storybook": "npm-run-all --parallel build:watch start-storybook",
+    "storybook": "npm-run-all --parallel build start-storybook",
     "start-storybook": "start-storybook -p 6006 -s dist --no-manager-cache",
     "build-storybook": "rimraf /storybook-static && build-storybook -s public",
     "prettier": "prettier --config ../../.prettierrc.json --ignore-path ../../.prettierignore src --check",


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Remove watch from storybook command to fix error when building as it's looking to run a command that no longer exists.

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 