### PR TITLE
fix(web-components): conditionally adding aria-owns to search-bar

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -775,6 +775,8 @@ export class SearchBar {
     const disabledText = disabledMode && !readonly;
     const hasSuggestedSearch = value && this.hasOptionsOrFilterDisabled();
     const menuOpen = hasSuggestedSearch && open && filteredOptions.length > 0;
+    const menuRendered =
+      menuOpen && value.length >= this.charactersUntilSuggestion;
     const isOrHasLoaded =
       this.filteredOptions.length === 1 &&
       (this.filteredOptions[0].label === this.loadingLabel ||
@@ -829,7 +831,7 @@ export class SearchBar {
           onFocus={this.onInputFocus}
           aria-label={hideLabel ? label : ""}
           aria-describedby={describedById}
-          aria-owns={hasSuggestedSearch ? menuId : undefined}
+          aria-owns={menuRendered ? menuId : undefined}
           aria-haspopup={options.length > 0 ? "listbox" : undefined}
           ariaExpanded={expanded}
           ariaActiveDescendant={ariaActiveDescendant}
@@ -910,7 +912,7 @@ export class SearchBar {
             }}
             slot="menu"
           >
-            {menuOpen && value.length >= this.charactersUntilSuggestion && (
+            {menuRendered && (
               <ic-menu
                 class={{
                   "no-results": this.hadNoOptions() || isOrHasLoaded,

--- a/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
@@ -198,7 +198,7 @@ exports[`ic-search-bar search should render required variant: renders-required 1
 exports[`ic-search-bar search should render with helper-text: renders-with-helpertext 1`] = `
 <ic-search-bar class="search" helper-text="This is a description" label="Test label" value="espresso">
   <mock:shadow-root>
-    <ic-text-field aria-autocomplete="list" aria-describedby="ic-search-bar-input-7-helper-text ic-search-bar-input-7-assistive-hint" aria-haspopup="listbox" aria-owns="ic-search-bar-input-7-menu" value="Espresso">
+    <ic-text-field aria-autocomplete="list" aria-describedby="ic-search-bar-input-7-helper-text ic-search-bar-input-7-assistive-hint" aria-haspopup="listbox" value="Espresso">
       <mock:shadow-root>
         <ic-input-container>
           <!---->
@@ -216,7 +216,7 @@ exports[`ic-search-bar search should render with helper-text: renders-with-helpe
               </ic-typography>
             </ic-input-label>
             <ic-input-component-container validationstatus="">
-              <input aria-describedby="ic-search-bar-input-7-helper-text" aria-expanded="false" aria-invalid="false" aria-label="" aria-owns="ic-search-bar-input-7-menu" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-7" inputmode="search" name="ic-search-bar-input-7" placeholder="Search" role="combobox" type="text" value="Espresso">
+              <input aria-describedby="ic-search-bar-input-7-helper-text" aria-expanded="false" aria-invalid="false" aria-label="" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-7" inputmode="search" name="ic-search-bar-input-7" placeholder="Search" role="combobox" type="text" value="Espresso">
               <slot name="clear-button"></slot>
               <slot name="search-submit-button"></slot>
             </ic-input-component-container>
@@ -261,12 +261,12 @@ exports[`ic-search-bar search should render with helper-text: renders-with-helpe
 exports[`ic-search-bar search should render with options: renders-with-options 1`] = `
 <ic-search-bar class="search" label="Test label" value="espresso">
   <mock:shadow-root>
-    <ic-text-field aria-autocomplete="list" aria-describedby="ic-search-bar-input-6-assistive-hint" aria-haspopup="listbox" aria-owns="ic-search-bar-input-6-menu" value="Espresso">
+    <ic-text-field aria-autocomplete="list" aria-describedby="ic-search-bar-input-6-assistive-hint" aria-haspopup="listbox" value="Espresso">
       <mock:shadow-root>
         <ic-input-container>
           <ic-input-label for="ic-search-bar-input-6" helpertext="" label="Test label"></ic-input-label>
           <ic-input-component-container validationstatus="">
-            <input aria-describedby="" aria-expanded="false" aria-invalid="false" aria-label="" aria-owns="ic-search-bar-input-6-menu" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-6" inputmode="search" name="ic-search-bar-input-6" placeholder="Search" role="combobox" type="text" value="Espresso">
+            <input aria-describedby="" aria-expanded="false" aria-invalid="false" aria-label="" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-6" inputmode="search" name="ic-search-bar-input-6" placeholder="Search" role="combobox" type="text" value="Espresso">
             <slot name="clear-button"></slot>
             <slot name="search-submit-button"></slot>
           </ic-input-component-container>

--- a/packages/web-components/src/components/ic-search-bar/test/basic/ic-search-bar.e2e.ts
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/ic-search-bar.e2e.ts
@@ -171,6 +171,34 @@ describe("ic-search-bar", () => {
     expect(await menu.isVisible()).toBeTruthy();
   });
 
+  it("should begin with no aria-owns attribute and then add one when the menu appears", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ic-search-bar label="Test Label"></ic-search-bar>
+    `);
+
+    const searchBar = await page.find("ic-search-bar");
+    searchBar.setProperty("options", options);
+
+    await page.waitForChanges();
+
+    let textField = await page.find("ic-search-bar >>> ic-text-field");
+    let menu = await textField.find("ic-menu");
+
+    expect(textField).not.toHaveAttribute("aria-owns");
+    expect(menu).toBeNull();
+
+    await focusAndTypeIntoInput("ba", page);
+
+    await page.waitForChanges();
+
+    textField = await page.find("ic-search-bar >>> ic-text-field");
+    menu = await textField.find("ic-menu");
+
+    expect(textField).toHaveAttribute("aria-owns");
+    expect(menu).not.toBeNull();
+  });
+
   it("should focus on input when menu is initially displayed", async () => {
     const page = await newE2EPage();
     await page.setContent(`


### PR DESCRIPTION
only adding aria-owns if the menu is being rendered at the same time

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 