### PR TITLE
docs(web-components): fixes error in IcAlert docs

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.tsx
+++ b/packages/web-components/src/components/ic-alert/ic-alert.tsx
@@ -50,7 +50,7 @@ export class Alert {
   @Prop() message?: string;
 
   /**
-   * If `true`, the title and message will appear inline instead of above and below.
+   * If `true`, the title and message will appear above and below instead of inline.
    */
   @Prop() titleAbove?: boolean = false;
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
titleAbove prop was incorrectly documented.

## Related issue
N/A

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 