### PR TITLE
fix(web-components): ic-tooltip no longer interferes with previousSibling

### DIFF
--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -18,6 +18,7 @@ import { onComponentRequiredPropUndefined } from "../../utils/helpers";
 })
 export class Tooltip {
   private arrow: HTMLDivElement;
+  private ariaDescribedBy: HTMLElement;
   private delayedHideEvents = ["mouseleave"];
   private instantHideEvents = ["focusout"];
   private mouseOverTool: boolean = false;
@@ -60,9 +61,8 @@ export class Tooltip {
 
   @Watch("label")
   updateLabel(newValue: string): void {
-    const describedBySpan = this.el.previousElementSibling as HTMLElement;
-    if (describedBySpan !== null) {
-      describedBySpan.innerText = newValue;
+    if (this.ariaDescribedBy !== null) {
+      this.ariaDescribedBy.innerText = newValue;
     }
   }
 
@@ -102,13 +102,13 @@ export class Tooltip {
     );
 
     if (this.target !== undefined) {
-      const ariaDescribedBy = document.createElement("span");
-      ariaDescribedBy.id = `ic-tooltip-${this.target}`;
-      ariaDescribedBy.innerText = this.label;
-      ariaDescribedBy.classList.add("ic-tooltip-label");
-      Object.assign(ariaDescribedBy.style, this.screenReaderOnlyStyles);
+      this.ariaDescribedBy = document.createElement("span");
+      this.ariaDescribedBy.id = `ic-tooltip-${this.target}`;
+      this.ariaDescribedBy.innerText = this.label;
+      this.ariaDescribedBy.classList.add("ic-tooltip-label");
+      Object.assign(this.ariaDescribedBy.style, this.screenReaderOnlyStyles);
 
-      this.el.insertAdjacentElement("beforebegin", ariaDescribedBy);
+      this.el.insertAdjacentElement("beforebegin", this.ariaDescribedBy);
     }
   }
 


### PR DESCRIPTION
Ic Tooltip would, when the previous element is conditionally rendered in react lifecycle, replace the contents of it. Now we store ariaDescribedBy in a variable so we don't search for that previousElementSibling

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Changed how updateLabel() functions, instead of getting the previous element sibling on every call, it refers to an ariaDescribedBy variable created on load. 

However, i've been unable to add a test - because the issue occurs during react apps with conditional rendering. We only have web-component unit tests. I will enquire with the developer team :) 

## Related issue
#986 

## Checklist
- [x] I have added relevant unit and visual regression tests.