### PR TITLE
fix(web-components): update tooltip and popover menu to adjust placement on dialogs

### DIFF
--- a/packages/web-components/src/components/ic-dialog/ic-dialog.stories.mdx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.stories.mdx
@@ -328,6 +328,10 @@ import readme from "./readme.md";
         select1.addEventListener("icChange", function (event) {
           console.log(event.detail.value);
         });
+        var icPopover = document.querySelector("ic-popover-menu");
+        function buttonClick() {
+          icPopover.open = true;
+        }
       </script>
       <ic-button variant="primary" onclick="showDialog()"
         >Launch dialog</ic-button
@@ -356,6 +360,66 @@ import readme from "./readme.md";
         >
           <ic-checkbox label="Option" value="confirm" id="focus"></ic-checkbox>
         </ic-checkbox-group>
+        <ic-button id="button-1" onclick="buttonClick()"
+          >Show popover</ic-button
+        >
+        <ic-tooltip label="This is a description of the button">
+          <ic-chip label="Default">
+            <svg
+              slot="icon"
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM10 3C11.66 3 13 4.34 13 6C13 7.66 11.66 9 10 9C8.34 9 7 7.66 7 6C7 4.34 8.34 3 10 3ZM10 17.2C7.5 17.2 5.29 15.92 4 13.98C4.03 11.99 8 10.9 10 10.9C11.99 10.9 15.97 11.99 16 13.98C14.71 15.92 12.5 17.2 10 17.2Z"
+              />
+            </svg> </ic-chip
+        ></ic-tooltip>
+        <div>
+          <ic-popover-menu anchor="button-1" aria-label="popover">
+            <ic-menu-item label="Copy code" disabled="true"></ic-menu-item>
+            <ic-menu-group label="View">
+              <ic-menu-item
+                label="Zoom in"
+                keyboard-shortcut="Cmd+"
+              ></ic-menu-item>
+            </ic-menu-group>
+            <ic-menu-item
+              label="Actions"
+              submenu-trigger-for="abc"
+            ></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu submenu-id="abc">
+            <ic-menu-item
+              label="Find"
+              submenu-trigger-for="abc123"
+            ></ic-menu-item>
+          </ic-popover-menu>
+          <ic-popover-menu submenu-id="abc123">
+            <ic-menu-item
+              disabled="true"
+              label="Search the web"
+              description="This will search the web to find the thing you are looking for."
+            ></ic-menu-item>
+            <ic-menu-item label="Find icons">
+              <svg
+                slot="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </ic-menu-item>
+          </ic-popover-menu>
+        </div>
         <ic-button
           variant="tertiary"
           onclick="hideDialog()"

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.css
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.css
@@ -27,6 +27,18 @@
   display: none;
 }
 
+:host(.on-dialog) {
+  inset: auto !important;
+}
+
+:host(.on-dialog-fix-translate) {
+  transform: translate(0, var(--ic-space-xs)) !important;
+}
+
+:host(.on-dialog-translate-y) {
+  transform: translate(0, calc(-1 * var(--translate-y))) !important;
+}
+
 .menu {
   border: var(--ic-border-default);
   border-radius: var(--ic-border-radius);

--- a/packages/web-components/src/components/ic-popover-menu/test/basic/__snapshots__/ic-popover-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-popover-menu/test/basic/__snapshots__/ic-popover-menu.spec.ts.snap
@@ -149,6 +149,95 @@ exports[`ic-popover-menu should render a menu item and menu group: should render
 </ic-popover-menu>
 `;
 
+exports[`ic-popover-menu should render on a dialog 1`] = `
+<ic-dialog class="hidden">
+  <mock:shadow-root>
+    <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div class="heading-area">
+        <div class="heading-content">
+          <div class="label">
+            <slot name="label">
+              <ic-typography id="dialog-label" variant="label"></ic-typography>
+            </slot>
+          </div>
+          <div class="heading">
+            <slot name="heading">
+              <ic-typography id="dialog-heading" variant="h4"></ic-typography>
+            </slot>
+          </div>
+        </div>
+        <ic-button aria-label="Dismiss" class="close-icon" variant="icon">
+          <span class="close-icon-svg">
+            svg
+          </span>
+        </ic-button>
+      </div>
+      <div class="content-area">
+        <div id="dialog-content">
+          <slot></slot>
+        </div>
+      </div>
+      <div class="dialog-controls">
+        <slot name="dialog-controls">
+          <ic-button class="dialog-control-button" variant="tertiary">
+            Cancel
+          </ic-button>
+          <ic-button class="dialog-control-button" data-gets-focus variant="primary">
+            Confirm
+          </ic-button>
+        </slot>
+      </div>
+    </dialog>
+  </mock:shadow-root>
+  <ic-button data-gets-focus id="anchorEl"></ic-button>
+  <ic-popover-menu anchor="#anchorEl" aria-label="popover-menu" class="on-dialog on-dialog-translate-y open" data-popper-placement="top" data-popper-reference-hidden open="" style="--translate-y: 108px; position: absolute; left: 0; top: auto; margin: 0; right: auto; bottom: 0; transform: translate(0px, 0px);">
+    <mock:shadow-root>
+      <div class="menu" id="ic-popover-submenu-undefined" tabindex="0">
+        <div>
+          <ul aria-label="popover-menu" class="button" role="menu">
+            <slot></slot>
+          </ul>
+        </div>
+      </div>
+    </mock:shadow-root>
+    <ic-menu-item label="Button 1" variant="default">
+      <mock:shadow-root>
+        <li aria-disabled="false" role="menuitem">
+          <ic-button aria-disabled="false" aria-label="Button 1" disabletooltip="" fullwidth="" variant="tertiary">
+            <div class="focus-border">
+              <div class="menu-item-info">
+                <div class="menu-labels">
+                  <ic-typography class="menu-item-label">
+                    Button 1
+                  </ic-typography>
+                </div>
+              </div>
+            </div>
+          </ic-button>
+        </li>
+      </mock:shadow-root>
+    </ic-menu-item>
+    <ic-menu-item label="Button 2" variant="default">
+      <mock:shadow-root>
+        <li aria-disabled="false" role="menuitem">
+          <ic-button aria-disabled="false" aria-label="Button 2" disabletooltip="" fullwidth="" variant="tertiary">
+            <div class="focus-border">
+              <div class="menu-item-info">
+                <div class="menu-labels">
+                  <ic-typography class="menu-item-label">
+                    Button 2
+                  </ic-typography>
+                </div>
+              </div>
+            </div>
+          </ic-button>
+        </li>
+      </mock:shadow-root>
+    </ic-menu-item>
+  </ic-popover-menu>
+</ic-dialog>
+`;
+
 exports[`ic-popover-menu should render when anchor starts with #: should render when target starts with # 1`] = `
 <ic-popover-menu anchor="#anchorEl" aria-label="popover-menu">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-popover-menu/test/basic/ic-popover-menu.spec.ts
+++ b/packages/web-components/src/components/ic-popover-menu/test/basic/ic-popover-menu.spec.ts
@@ -3,6 +3,7 @@ import { MenuItem } from "../../../ic-menu-item/ic-menu-item";
 import { PopoverMenu } from "../../ic-popover-menu";
 import { waitForTimeout } from "../../../../testspec.setup";
 import { MenuGroup } from "../../../ic-menu-group/ic-menu-group";
+import { Dialog } from "../../../ic-dialog/ic-dialog";
 
 describe("ic-popover-menu", () => {
   it("should render with anchor", async () => {
@@ -57,6 +58,21 @@ describe("ic-popover-menu", () => {
     expect(page.root).toMatchSnapshot(
       "should render a back button when submenu-id is set"
     );
+  });
+
+  it("should render on a dialog", async () => {
+    const page = await newSpecPage({
+      components: [PopoverMenu, MenuItem, Dialog],
+      html: `<ic-dialog>
+      <ic-button id="anchorEl"></ic-button>
+      <ic-popover-menu anchor="#anchorEl" aria-label="popover-menu" open="true">
+      <ic-menu-item label="Button 1"></ic-menu-item>
+      <ic-menu-item label="Button 2"></ic-menu-item>
+      </ic-popover-menu>
+      </ic-dialog>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
   });
 
   it("should set openingFromChild to true when openFromChild method is called", async () => {

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
@@ -66,6 +66,7 @@
   left: 0;
   top: var(--ic-space-xxxs);
   border-top: 0;
+  transform: translateX(var(--tooltip-arrow-translate));
 }
 
 :host(.ic-tooltip)
@@ -82,6 +83,7 @@
   left: 0;
   top: var(--ic-space-1px);
   border-bottom: 0;
+  transform: translateX(var(--tooltip-arrow-translate));
 }
 
 :host(.ic-tooltip)
@@ -112,6 +114,13 @@
   border-radius: var(--ic-border-radius) 0 0 var(--ic-border-radius);
   border-right: 0;
   top: calc(-1 * var(--ic-space-1px));
+}
+
+:host(.on-dialog) .ic-tooltip-container {
+  transform: translate(
+    var(--tooltip-translate-x),
+    var(--tooltip-translate-y)
+  ) !important;
 }
 
 @media (forced-colors: active) {

--- a/packages/web-components/src/components/ic-tooltip/test/basic/__snapshots__/ic-tooltip.spec.ts.snap
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/__snapshots__/ic-tooltip.spec.ts.snap
@@ -1,13 +1,200 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ic-loading-indicator component should render: ic-tooltip-render 1`] = `
-<ic-tooltip class="ic-tooltip" label="tooltip">
+exports[`ic-tooltip component getTooltipTranslate should update for bottom 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="position: absolute; left: 0; top: 0; margin: 0;">
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
-      <div class="ic-tooltip-arrow" data-popper-arrow style="position: absolute;"></div>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for bottom-end 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="bottom-end" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -100px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for bottom-start 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="bottom-start" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for left 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="left" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -100px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for left-end 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="left-end" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -132px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for right 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="right" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for right-end 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="right-end" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for top 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="top" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for top-end 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="top-end" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -132px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update for top-start 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="top-start" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component getTooltipTranslate should update when tooltip is outside of dialog 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip" placement="left" target="test-button">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
+    </div>
+    <slot></slot>
+  </mock:shadow-root>
+  <button id="test-button">
+    Click
+  </button>
+</ic-tooltip>
+`;
+
+exports[`ic-tooltip component should render: ic-tooltip-render 1`] = `
+<ic-tooltip class="ic-tooltip" label="tooltip">
+  <mock:shadow-root>
+    <div class="ic-tooltip-container" role="tooltip">
+      <ic-typography variant="caption">
+        tooltip
+      </ic-typography>
+      <div class="ic-tooltip-arrow" data-popper-arrow></div>
     </div>
     <slot></slot>
   </mock:shadow-root>

--- a/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.e2e.ts
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.e2e.ts
@@ -22,6 +22,9 @@ describe("ic-tooltip component", () => {
     await page.waitForChanges();
 
     const tooltip = await page.find(".ic-tooltip >>> .ic-tooltip-container");
+    const button = await page.find("button");
+
+    await button.hover();
 
     expect(await tooltip.getAttribute("data-popper-placement")).toBe(
       "right-end"

--- a/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
@@ -6,7 +6,7 @@ beforeAll(() => {
   jest.spyOn(console, "error").mockImplementation(jest.fn());
 });
 
-describe("ic-loading-indicator component", () => {
+describe("ic-tooltip component", () => {
   it("should render", async () => {
     const page = await newSpecPage({
       components: [Tooltip],
@@ -182,5 +182,198 @@ describe("ic-loading-indicator component", () => {
     await page.waitForChanges();
 
     expect(page.rootInstance.toolTip.getAttribute("data-show")).toBeNull;
+  });
+
+  describe("getTooltipTranslate", () => {
+    it("should update for bottom", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for bottom-start", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="bottom-start"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for bottom-end", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="bottom-end"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for top", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="top"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for top-start", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="top-start"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for top-end", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="top-end"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for left", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="left"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for left-end", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="left-end"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for right", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="right"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update for right-end", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="right-end"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+    });
+
+    it("should update when tooltip is outside of dialog", async () => {
+      const page = await newSpecPage({
+        components: [Tooltip],
+        html: `<ic-tooltip target="test-button" label="tooltip" placement="left"><button id="test-button">Click</button></ic-tooltip>`,
+      });
+
+      page.rootInstance.dialogOverflow = true;
+      await page.waitForChanges();
+
+      await page.rootInstance.getTooltipTranslate({
+        left: 0,
+        right: 40,
+        top: 100,
+        bottom: 132,
+      });
+      await page.waitForChanges();
+
+      expect(page.root).toMatchSnapshot();
+      expect(page.root.placement).toBe("right");
+    });
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update tooltip and popover menu to adjust placement on dialogs. Update tooltip to only create popper on show

## Related issue
#1006

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 