### PR TITLE
fix(web-components): prevents sticky page header overlapping dropdown…

### DIFF
--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -365,7 +365,7 @@
   --ic-z-index-base-value: 0;
   --ic-z-index-page-header: calc(var(--ic-z-index-base-value) + 10);
   --ic-z-index-back-to-top: calc(var(--ic-z-index-base-value) + 20);
-  --ic-z-index-menu: calc(var(--ic-z-index-base-value) + 50);
+  --ic-z-index-menu: calc(var(--ic-z-index-base-value) + 70);
   --ic-z-index-popover: calc(var(--ic-z-index-base-value) + 50);
   --ic-z-index-navigation-item: calc(var(--ic-z-index-base-value) + 50);
   --ic-z-index-navigation-menu: calc(var(--ic-z-index-base-value) + 60);


### PR DESCRIPTION
… menu

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
following the fix for #653 the sticky page header was overlapping drop down menu. This fix increases the menu z-index and prevents this