### PR TITLE
1015 upgrade stenciljs from v3 to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "@stencil/core": "^4.1.0"
+      },
       "devDependencies": {
         "@commitlint/cli": "^17.3.0",
         "@commitlint/config-conventional": "^17.3.0",
@@ -3270,6 +3273,18 @@
         "eslint": "<9 && ^8.0.0",
         "eslint-plugin-react": "^7.0.0",
         "typescript": "^4.9.4"
+      }
+    },
+    "node_modules/@stencil/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-yIpL+CX02fy5zvFXwXcHZjjEILRm3aiONbucpfLIWPS7zcBAuucdROssartEa+D7E1JRko97ydxn1Ntdu4GoWg==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -20303,6 +20318,11 @@
         "eslint-utils": "^3.0.0",
         "tsutils": "3.0.0"
       }
+    },
+    "@stencil/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-yIpL+CX02fy5zvFXwXcHZjjEILRm3aiONbucpfLIWPS7zcBAuucdROssartEa+D7E1JRko97ydxn1Ntdu4GoWg=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "dependencies": {
+    "@stencil/core": "^4.1.0"
   }
 }

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.16.0",
-        "@stencil/react-output-target": "^0.4.0",
+        "@stencil/react-output-target": "^0.5.3",
         "@storybook/addon-a11y": "^6.4.8",
         "@storybook/addon-actions": "^6.4.8",
         "@storybook/addon-docs": "^6.4.8",
@@ -4055,12 +4055,12 @@
       }
     },
     "node_modules/@stencil/react-output-target": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.4.0.tgz",
-      "integrity": "sha512-X7XW6aHSU7ZypkFj4wX/XL7ROj2GXcdTL+Emo1mKNg5laBcuTVtt8zPR4ERG/grq8ec8wav+FxBuSlQ3cH0qcg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.5.3.tgz",
+      "integrity": "sha512-68jwRp35CjAcwhTJ9yFD/3n+jrHOqvEH2jreVuPVvZK+4tkhPlYlwz0d1E1RlF3jyifUSfdkWUGgXIEy8Fo3yw==",
       "dev": true,
       "peerDependencies": {
-        "@stencil/core": "^2.9.0 || ^3.0.0-beta.0"
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "node_modules/@storybook/addon-a11y": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
-    "@stencil/react-output-target": "^0.4.0",
+    "@stencil/react-output-target": "^0.5.3",
     "@storybook/addon-a11y": "^6.4.8",
     "@storybook/addon-actions": "^6.4.8",
     "@storybook/addon-docs": "^6.4.8",

--- a/packages/react/src/react-component-lib/utils/attachProps.ts
+++ b/packages/react/src/react-component-lib/utils/attachProps.ts
@@ -63,6 +63,17 @@ export const getClassName = (classList: DOMTokenList, newProps: any, oldProps: a
 };
 
 /**
+ * Transforms a React event name to a browser event name.
+ */
+export const transformReactEventName = (eventNameSuffix: string) => {
+  switch (eventNameSuffix) {
+    case 'doubleclick':
+      return 'dblclick';
+  }
+  return eventNameSuffix;
+};
+
+/**
  * Checks if an event is supported in the current execution environment.
  * @license Modernizr 3.0.0pre (Custom Build) | MIT
  */
@@ -70,7 +81,7 @@ export const isCoveredByReact = (eventNameSuffix: string) => {
   if (typeof document === 'undefined') {
     return true;
   } else {
-    const eventName = 'on' + eventNameSuffix;
+    const eventName = 'on' + transformReactEventName(eventNameSuffix);
     let isSupported = eventName in document;
 
     if (!isSupported) {

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -18,7 +18,7 @@
         "@mdx-js/react": "^1.6.22",
         "@open-wc/testing-helpers": "^2.0.2",
         "@stencil/postcss": "^2.1.0",
-        "@stencil/react-output-target": "^0.4.0",
+        "@stencil/react-output-target": "^0.5.3",
         "@storybook/addon-a11y": "^6.4.8",
         "@storybook/addon-actions": "^6.4.3",
         "@storybook/addon-essentials": "^6.4.3",
@@ -3659,12 +3659,12 @@
       }
     },
     "node_modules/@stencil/react-output-target": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.4.0.tgz",
-      "integrity": "sha512-X7XW6aHSU7ZypkFj4wX/XL7ROj2GXcdTL+Emo1mKNg5laBcuTVtt8zPR4ERG/grq8ec8wav+FxBuSlQ3cH0qcg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.5.3.tgz",
+      "integrity": "sha512-68jwRp35CjAcwhTJ9yFD/3n+jrHOqvEH2jreVuPVvZK+4tkhPlYlwz0d1E1RlF3jyifUSfdkWUGgXIEy8Fo3yw==",
       "dev": true,
       "peerDependencies": {
-        "@stencil/core": "^2.9.0 || ^3.0.0-beta.0"
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "node_modules/@storybook/addon-a11y": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -47,7 +47,7 @@
     "@mdx-js/react": "^1.6.22",
     "@open-wc/testing-helpers": "^2.0.2",
     "@stencil/postcss": "^2.1.0",
-    "@stencil/react-output-target": "^0.4.0",
+    "@stencil/react-output-target": "^0.5.3",
     "@storybook/addon-a11y": "^6.4.8",
     "@storybook/addon-actions": "^6.4.3",
     "@storybook/addon-essentials": "^6.4.3",


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update stencil v3 to v4 and update stencil/react-output-target to minimum version allowed for stencil v4. Also includes updates to a react file that were made automatically after installing the new stencil version.

## Related issue
#1015 

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 