### PR TITLE
fix(web-components): moves slot to top of file so it shows in guidanc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.3.0](https://github.com/mi6/ic-ui-kit/compare/v2.2.0...v2.3.0) (2023-09-04)
+
+### Bug Fixes
+
+- **fonts:** run new audit fix command ([86477f5](https://github.com/mi6/ic-ui-kit/commit/86477f551ee9e7983d8e2283a8be987a66a100e7))
+- **react:** fix for react package error running bootstrap ([ba9a5a7](https://github.com/mi6/ic-ui-kit/commit/ba9a5a77e154c82133e356c2b89d1f6ff8c47e1d))
+- **react:** run new audit fix command ([85a1e3c](https://github.com/mi6/ic-ui-kit/commit/85a1e3c5302c9ca7ff74c71bb63c43b4e5c4cf55))
+- **web-components:** adds check to see if resizeObserver exists before removing ([c11e60b](https://github.com/mi6/ic-ui-kit/commit/c11e60b372bb47002b726e0120ddf31b17b7f4f6))
+- **web-components:** adds short title ([c313835](https://github.com/mi6/ic-ui-kit/commit/c313835ea8286487b24934aa8805b85d96b8810c))
+- **web-components:** conditionally adding aria-owns to search-bar ([92a6857](https://github.com/mi6/ic-ui-kit/commit/92a68575736da28c33bfe043719535d58d8247cd))
+- **web-components:** ic-button and ic-navigation no longer read twice to screen readers ([8ae07b9](https://github.com/mi6/ic-ui-kit/commit/8ae07b9c2e586988911904fff689848cfdda0bb9))
+- **web-components:** ic-tooltip no longer interacting with previousSibling ([932a6c9](https://github.com/mi6/ic-ui-kit/commit/932a6c9b799d198f4f430a1eab20165070080b41))
+- **web-components:** prevents sticky page header overlapping dropdown menu ([a26bf3d](https://github.com/mi6/ic-ui-kit/commit/a26bf3ddf5f58a5acb196c9c5902e9be8c38d957)), closes [#653](https://github.com/mi6/ic-ui-kit/issues/653)
+- **web-components:** remove !important from all font sizes except h1 ([59afec9](https://github.com/mi6/ic-ui-kit/commit/59afec941e5174606f7b21de2bb085378962f918))
+- **web-components:** remove !important so bold is applied to code extra small ([b2ede34](https://github.com/mi6/ic-ui-kit/commit/b2ede34297da1f5c6c0f1ec42078f74f23738a4e))
+- **web-components:** run new audit fix command ([eecaef4](https://github.com/mi6/ic-ui-kit/commit/eecaef4076650448a8e85b4ff2e417da4e6c0f5a))
+- **web-components:** update tooltip and popover menu to adjust placement on dialogs ([adbf3c0](https://github.com/mi6/ic-ui-kit/commit/adbf3c088379a5ce7ceab9816ea836199e152be3)), closes [#1006](https://github.com/mi6/ic-ui-kit/issues/1006)
+
+### Features
+
+- **react:** add stories for empty state component ([defecfa](https://github.com/mi6/ic-ui-kit/commit/defecfafc0f7f53bf3db77e7421e75d57fa09139)), closes [#655](https://github.com/mi6/ic-ui-kit/issues/655)
+- **react:** add story for new sizes for checkboxes ([6656c9c](https://github.com/mi6/ic-ui-kit/commit/6656c9c98c5854a1023909e09321b17f312b28e8)), closes [#643](https://github.com/mi6/ic-ui-kit/issues/643)
+- **react:** update button to use left-icon slot ([a600ce9](https://github.com/mi6/ic-ui-kit/commit/a600ce9a6a6646393da6ee3ff297751602e31936)), closes [#974](https://github.com/mi6/ic-ui-kit/issues/974)
+- **react:** update stories for typography to show new props ([ddb4404](https://github.com/mi6/ic-ui-kit/commit/ddb440484202acd6682da64b4d8983d2e9df2ff0)), closes [#988](https://github.com/mi6/ic-ui-kit/issues/988)
+- **root:** updates node version to 18 ([5708a60](https://github.com/mi6/ic-ui-kit/commit/5708a605d6cee479af02911092f38ee950190b87))
+- **web-components:** add new props to typography and add playground story to demonstrate ([fa75460](https://github.com/mi6/ic-ui-kit/commit/fa754603d0716f39ecbfae605a2704ba2c2826c6)), closes [#988](https://github.com/mi6/ic-ui-kit/issues/988)
+- **web-components:** add right icon to ic button, deprecate icon slot and update icon sizes ([2e96862](https://github.com/mi6/ic-ui-kit/commit/2e96862741c4f08a718be89d2cbf914f972686a2)), closes [#974](https://github.com/mi6/ic-ui-kit/issues/974)
+- **web-components:** add sizes small and large to checkboxes ([07337cc](https://github.com/mi6/ic-ui-kit/commit/07337cce01396bac4918e344e58c823438f6d9db)), closes [#643](https://github.com/mi6/ic-ui-kit/issues/643)
+- **web-components:** create empty state component ([2f5d653](https://github.com/mi6/ic-ui-kit/commit/2f5d653c0a837049ca492f7c2c6a005cd50ded0c)), closes [#655](https://github.com/mi6/ic-ui-kit/issues/655)
+- **web-components:** update iconography and add new colour variables ([e67c9c7](https://github.com/mi6/ic-ui-kit/commit/e67c9c7ca801594c9077a56ca69540c0cb92cf31)), closes [#713](https://github.com/mi6/ic-ui-kit/issues/713)
+
 # [2.2.0](https://github.com/mi6/ic-ui-kit/compare/v2.1.0-beta.18...v2.2.0) (2023-08-07)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "2.2.0",
+  "version": "2.3.0",
   "command": {
     "publish": {
       "registry": "https://registry.npmjs.org"

--- a/packages/fonts/CHANGELOG.md
+++ b/packages/fonts/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.3.0](https://github.com/mi6/ic-ui-kit/compare/v2.2.0...v2.3.0) (2023-09-04)
+
+### Bug Fixes
+
+- **fonts:** run new audit fix command ([86477f5](https://github.com/mi6/ic-ui-kit/commit/86477f551ee9e7983d8e2283a8be987a66a100e7))
+
 # [2.2.0](https://github.com/mi6/ic-ui-kit/compare/v2.1.0-beta.18...v2.2.0) (2023-08-07)
 
 **Note:** Version bump only for package @ukic/fonts

--- a/packages/fonts/package-lock.json
+++ b/packages/fonts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukic/fonts",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukic/fonts",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@fontsource/nunito-sans": "^4.5.4",

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukic/fonts",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Typography assets for @ukic components",
   "scripts": {
     "build": "rimraf ./dist && webpack --config webpack.config.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.3.0](https://github.com/mi6/ic-ui-kit/compare/v2.2.0...v2.3.0) (2023-09-04)
+
+### Bug Fixes
+
+- **react:** fix for react package error running bootstrap ([ba9a5a7](https://github.com/mi6/ic-ui-kit/commit/ba9a5a77e154c82133e356c2b89d1f6ff8c47e1d))
+- **react:** run new audit fix command ([85a1e3c](https://github.com/mi6/ic-ui-kit/commit/85a1e3c5302c9ca7ff74c71bb63c43b4e5c4cf55))
+
+### Features
+
+- **react:** add stories for empty state component ([defecfa](https://github.com/mi6/ic-ui-kit/commit/defecfafc0f7f53bf3db77e7421e75d57fa09139)), closes [#655](https://github.com/mi6/ic-ui-kit/issues/655)
+- **react:** add story for new sizes for checkboxes ([6656c9c](https://github.com/mi6/ic-ui-kit/commit/6656c9c98c5854a1023909e09321b17f312b28e8)), closes [#643](https://github.com/mi6/ic-ui-kit/issues/643)
+- **react:** update button to use left-icon slot ([a600ce9](https://github.com/mi6/ic-ui-kit/commit/a600ce9a6a6646393da6ee3ff297751602e31936)), closes [#974](https://github.com/mi6/ic-ui-kit/issues/974)
+- **react:** update stories for typography to show new props ([ddb4404](https://github.com/mi6/ic-ui-kit/commit/ddb440484202acd6682da64b4d8983d2e9df2ff0)), closes [#988](https://github.com/mi6/ic-ui-kit/issues/988)
+- **web-components:** add right icon to ic button, deprecate icon slot and update icon sizes ([2e96862](https://github.com/mi6/ic-ui-kit/commit/2e96862741c4f08a718be89d2cbf914f972686a2)), closes [#974](https://github.com/mi6/ic-ui-kit/issues/974)
+
 # [2.2.0](https://github.com/mi6/ic-ui-kit/compare/v2.1.0-beta.18...v2.2.0) (2023-08-07)
 
 ### Bug Fixes

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukic/react",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukic/react",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ukic/react",
   "sideEffects": false,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "React-wrapped web components compiled using StencilJS",
   "scripts": {
     "build": "npm run clean && npm run compile && npm run copy:core-css && npm run copy:normalize-css",
@@ -22,8 +22,8 @@
     "dist/"
   ],
   "dependencies": {
-    "@ukic/fonts": "^2.2.0",
-    "@ukic/web-components": "^2.2.0"
+    "@ukic/fonts": "^2.3.0",
+    "@ukic/web-components": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.3.0](https://github.com/mi6/ic-ui-kit/compare/v2.2.0...v2.3.0) (2023-09-04)
+
+### Bug Fixes
+
+- **web-components:** adds check to see if resizeObserver exists before removing ([c11e60b](https://github.com/mi6/ic-ui-kit/commit/c11e60b372bb47002b726e0120ddf31b17b7f4f6))
+- **web-components:** adds short title ([c313835](https://github.com/mi6/ic-ui-kit/commit/c313835ea8286487b24934aa8805b85d96b8810c))
+- **web-components:** conditionally adding aria-owns to search-bar ([92a6857](https://github.com/mi6/ic-ui-kit/commit/92a68575736da28c33bfe043719535d58d8247cd))
+- **web-components:** ic-button and ic-navigation no longer read twice to screen readers ([8ae07b9](https://github.com/mi6/ic-ui-kit/commit/8ae07b9c2e586988911904fff689848cfdda0bb9))
+- **web-components:** ic-tooltip no longer interacting with previousSibling ([932a6c9](https://github.com/mi6/ic-ui-kit/commit/932a6c9b799d198f4f430a1eab20165070080b41))
+- **web-components:** prevents sticky page header overlapping dropdown menu ([a26bf3d](https://github.com/mi6/ic-ui-kit/commit/a26bf3ddf5f58a5acb196c9c5902e9be8c38d957)), closes [#653](https://github.com/mi6/ic-ui-kit/issues/653)
+- **web-components:** remove !important from all font sizes except h1 ([59afec9](https://github.com/mi6/ic-ui-kit/commit/59afec941e5174606f7b21de2bb085378962f918))
+- **web-components:** remove !important so bold is applied to code extra small ([b2ede34](https://github.com/mi6/ic-ui-kit/commit/b2ede34297da1f5c6c0f1ec42078f74f23738a4e))
+- **web-components:** run new audit fix command ([eecaef4](https://github.com/mi6/ic-ui-kit/commit/eecaef4076650448a8e85b4ff2e417da4e6c0f5a))
+- **web-components:** update tooltip and popover menu to adjust placement on dialogs ([adbf3c0](https://github.com/mi6/ic-ui-kit/commit/adbf3c088379a5ce7ceab9816ea836199e152be3)), closes [#1006](https://github.com/mi6/ic-ui-kit/issues/1006)
+
+### Features
+
+- **web-components:** add new props to typography and add playground story to demonstrate ([fa75460](https://github.com/mi6/ic-ui-kit/commit/fa754603d0716f39ecbfae605a2704ba2c2826c6)), closes [#988](https://github.com/mi6/ic-ui-kit/issues/988)
+- **web-components:** add right icon to ic button, deprecate icon slot and update icon sizes ([2e96862](https://github.com/mi6/ic-ui-kit/commit/2e96862741c4f08a718be89d2cbf914f972686a2)), closes [#974](https://github.com/mi6/ic-ui-kit/issues/974)
+- **web-components:** add sizes small and large to checkboxes ([07337cc](https://github.com/mi6/ic-ui-kit/commit/07337cce01396bac4918e344e58c823438f6d9db)), closes [#643](https://github.com/mi6/ic-ui-kit/issues/643)
+- **web-components:** create empty state component ([2f5d653](https://github.com/mi6/ic-ui-kit/commit/2f5d653c0a837049ca492f7c2c6a005cd50ded0c)), closes [#655](https://github.com/mi6/ic-ui-kit/issues/655)
+- **web-components:** update iconography and add new colour variables ([e67c9c7](https://github.com/mi6/ic-ui-kit/commit/e67c9c7ca801594c9077a56ca69540c0cb92cf31)), closes [#713](https://github.com/mi6/ic-ui-kit/issues/713)
+
 # [2.2.0](https://github.com/mi6/ic-ui-kit/compare/v2.1.0-beta.18...v2.2.0) (2023-08-07)
 
 ### Bug Fixes

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukic/web-components",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukic/web-components",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.2",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukic/web-components",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A web component UI library compiled with StencilJS",
   "main": "dist/index.cjs.js",
   "module": "./dist/index.js",
@@ -39,7 +39,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.2",
     "@stencil/core": "^3.3.1",
-    "@ukic/fonts": "^2.2.0"
+    "@ukic/fonts": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
@@ -5,6 +5,10 @@ import chevronIcon from "../../assets/chevron-icon.svg";
 import backIcon from "../../assets/back-icon.svg";
 import { isSlotUsed } from "../../utils/helpers";
 
+/**
+ * @slot icon - Content will be rendered to the left of the breadcrumb page title.
+ */
+
 @Component({
   tag: "ic-breadcrumb",
   styleUrl: "ic-breadcrumb.css",
@@ -14,10 +18,6 @@ import { isSlotUsed } from "../../utils/helpers";
 })
 export class Breadcrumb {
   @Element() el: HTMLIcBreadcrumbElement;
-
-  /**
-   * @slot icon - Content will be rendered to the left of the breadcrumb page title.
-   */
 
   /**
    * If `true`, aria-current will be set on the breadcrumb.

--- a/packages/web-components/src/components/ic-breadcrumb/readme.md
+++ b/packages/web-components/src/components/ic-breadcrumb/readme.md
@@ -27,6 +27,13 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot     | Description                                                        |
+| -------- | ------------------------------------------------------------------ |
+| `"icon"` | Content will be rendered to the left of the breadcrumb page title. |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
@@ -14,6 +14,12 @@ import {
 import closeIcon from "../../assets/close-icon.svg";
 import { isSlotUsed, checkResizeObserver } from "../../utils/helpers";
 
+/**
+ * @slot dialog-controls - Content will be place at the bottom of the dialog.
+ * @slot heading - Content will be placed at the top of the dialog.
+ * @slot label - Content will be placed above the dialog heading.
+ */
+
 @Component({
   tag: "ic-dialog",
   styleUrl: "ic-dialog.css",
@@ -45,12 +51,6 @@ export class Dialog {
 
   @State() dialogRendered: boolean = false;
   @State() fadeIn: boolean = false;
-
-  /**
-   * @slot dialog-controls - Content will be place at the bottom of the dialog.
-   * @slot heading - Content will be placed at the top of the dialog.
-   * @slot label - Content will be placed above the dialog heading.
-   */
 
   /**
    * If a status is set, sets the heading for the displayed alert.

--- a/packages/web-components/src/components/ic-dialog/readme.md
+++ b/packages/web-components/src/components/ic-dialog/readme.md
@@ -75,6 +75,15 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot                | Description                                        |
+| ------------------- | -------------------------------------------------- |
+| `"dialog-controls"` | Content will be place at the bottom of the dialog. |
+| `"heading"`         | Content will be placed at the top of the dialog.   |
+| `"label"`           | Content will be placed above the dialog heading.   |
+
+
 ## CSS Custom Properties
 
 | Name                  | Description       |


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

slot information was incorrectly placed in the file so slot guidance was not appearing on the code documentation on the site. Moved slots to top of file, below imports

## Related issue
#1069 

## Checklist
