### PR TITLE
fix(web-components): moves slot guidance so it shows in code guidance

### DIFF
--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
@@ -5,6 +5,9 @@ import chevronIcon from "../../assets/chevron-icon.svg";
 import backIcon from "../../assets/back-icon.svg";
 import { isSlotUsed } from "../../utils/helpers";
 
+/**
+ * @slot icon - Content will be rendered to the left of the breadcrumb page title.
+ */
 @Component({
   tag: "ic-breadcrumb",
   styleUrl: "ic-breadcrumb.css",
@@ -14,10 +17,6 @@ import { isSlotUsed } from "../../utils/helpers";
 })
 export class Breadcrumb {
   @Element() el: HTMLIcBreadcrumbElement;
-
-  /**
-   * @slot icon - Content will be rendered to the left of the breadcrumb page title.
-   */
 
   /**
    * If `true`, aria-current will be set on the breadcrumb.

--- a/packages/web-components/src/components/ic-breadcrumb/readme.md
+++ b/packages/web-components/src/components/ic-breadcrumb/readme.md
@@ -27,6 +27,13 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot     | Description                                                        |
+| -------- | ------------------------------------------------------------------ |
+| `"icon"` | Content will be rendered to the left of the breadcrumb page title. |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
@@ -14,6 +14,11 @@ import {
 import closeIcon from "../../assets/close-icon.svg";
 import { isSlotUsed, checkResizeObserver } from "../../utils/helpers";
 
+/**
+ * @slot dialog-controls - Content will be place at the bottom of the dialog.
+ * @slot heading - Content will be placed at the top of the dialog.
+ * @slot label - Content will be placed above the dialog heading.
+ */
 @Component({
   tag: "ic-dialog",
   styleUrl: "ic-dialog.css",
@@ -45,12 +50,6 @@ export class Dialog {
 
   @State() dialogRendered: boolean = false;
   @State() fadeIn: boolean = false;
-
-  /**
-   * @slot dialog-controls - Content will be place at the bottom of the dialog.
-   * @slot heading - Content will be placed at the top of the dialog.
-   * @slot label - Content will be placed above the dialog heading.
-   */
 
   /**
    * If a status is set, sets the heading for the displayed alert.

--- a/packages/web-components/src/components/ic-dialog/readme.md
+++ b/packages/web-components/src/components/ic-dialog/readme.md
@@ -75,6 +75,15 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot                | Description                                        |
+| ------------------- | -------------------------------------------------- |
+| `"dialog-controls"` | Content will be place at the bottom of the dialog. |
+| `"heading"`         | Content will be placed at the top of the dialog.   |
+| `"label"`           | Content will be placed above the dialog heading.   |
+
+
 ## CSS Custom Properties
 
 | Name                  | Description       |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Slot information was in the wrong place in .tsx files so it was not appearing on the guidance site. Ticket moves slot info to top of file.

## Related issue
#1069
