### PR TITLE
fix(web-components): update loading button to have minimum width of original button

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -93,10 +93,6 @@
   pointer-events: none;
 }
 
-:host(.loading-with-icon) .button {
-  min-width: var(--min-width, 8.25rem);
-}
-
 /* Variants */
 
 /* Primary */

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -180,6 +180,10 @@ export class Button {
     }
   }
 
+  componentWillUpdate(): void {
+    this.loadingWidth();
+  }
+
   componentWillLoad(): void {
     this.inheritedAttributes = inheritAttributes(this.el, [
       ...IC_INHERITED_ARIA,
@@ -311,6 +315,15 @@ export class Button {
     }
   }
 
+  private loadingWidth = () => {
+    if (this.loading) {
+      this.el.style.setProperty(
+        "--min-width",
+        `${this.el.getBoundingClientRect().width}px`
+      );
+    }
+  };
+
   // triggered when text content of sibling element in light DOM changes
   private mutationCallback = (): void => {
     this.describedByContent = this.describedByEl.innerText;
@@ -425,11 +438,6 @@ export class Button {
           [`button-variant-${this.variant}`]: true,
           [`button-size-${this.size}`]: true,
           ["loading"]: this.loading,
-          ["loading-with-icon"]:
-            this.loading &&
-            (this.hasIconSlot() ||
-              this.hasLeftIconSlot() ||
-              this.hasRightIconSlot()),
           ["dark"]: this.appearance === IcThemeForegroundEnum.Dark,
           ["light"]: this.appearance === IcThemeForegroundEnum.Light,
           ["full-width"]: this.fullWidth,


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update loading button to have minimum width of original button

## Related issue
#1066

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 