### PR TITLE
fix(web-components): rename method to match prop name

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -491,7 +491,7 @@ export namespace Components {
          */
         "required"?: boolean;
         "setCalendarFocus": () => Promise<void>;
-        "setDisabledDays": (days: IcWeekDays[]) => Promise<void>;
+        "setDisableDays": (days: IcWeekDays[]) => Promise<void>;
         "showCalendarButton"?: boolean;
         /**
           * If `true`, a button which clears the date input when clicked will be displayed.

--- a/packages/web-components/src/components/ic-date-input/ic-date-input.tsx
+++ b/packages/web-components/src/components/ic-date-input/ic-date-input.tsx
@@ -355,7 +355,7 @@ export class DateInput {
    * @internal Used to pass disabledDays from parent component.
    */
   @Method()
-  async setDisabledDays(days: IcWeekDays[]): Promise<void> {
+  async setDisableDays(days: IcWeekDays[]): Promise<void> {
     this.disableDays = days;
   }
 

--- a/packages/web-components/src/components/ic-date-input/test/basic/ic-date-input.spec.tsx
+++ b/packages/web-components/src/components/ic-date-input/test/basic/ic-date-input.spec.tsx
@@ -1957,10 +1957,10 @@ describe("ic-date-input component", () => {
     });
   });
 
-  describe("setDisabledDays", () => {
-    it("should test setting disabledDays ", async () => {
+  describe("setDisableDays", () => {
+    it("should test setting disableDays ", async () => {
       const { component, componentInstance } = await createDateInputEnv();
-      await component.setDisabledDays([0, 1]);
+      await component.setDisableDays([0, 1]);
 
       expect(componentInstance.disableDays).toEqual([0, 1]);
     });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Renames method to `setDisableDays`, to match prop name `disableDays`

## Related issue
N/A

## Checklist
- [x] I have added relevant unit and visual regression tests.
- [x] I have manually accessibility tested any changes, if relevant.
- [x] I have ensured any changes match the Figma component library. 