### PR TITLE
fix(web-components): changes side-nav and nav-items z-index

### DIFF
--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -390,12 +390,12 @@
   --ic-z-index-base-value: 0;
   --ic-z-index-page-header: calc(var(--ic-z-index-base-value) + 10);
   --ic-z-index-back-to-top: calc(var(--ic-z-index-base-value) + 20);
-  --ic-z-index-menu: calc(var(--ic-z-index-base-value) + 70);
   --ic-z-index-popover: calc(var(--ic-z-index-base-value) + 50);
-  --ic-z-index-navigation-item: calc(var(--ic-z-index-base-value) + 50);
-  --ic-z-index-navigation-menu: calc(var(--ic-z-index-base-value) + 60);
   --ic-z-index-sticky-page-header: calc(var(--ic-z-index-base-value) + 60);
-  --ic-z-index-side-navigation: calc(var(--ic-z-index-base-value) + 60);
+  --ic-z-index-navigation-item: calc(var(--ic-z-index-base-value) + 70);
+  --ic-z-index-navigation-menu: calc(var(--ic-z-index-base-value) + 70);
+  --ic-z-index-menu: calc(var(--ic-z-index-base-value) + 70);
+  --ic-z-index-side-navigation: calc(var(--ic-z-index-base-value) + 70);
   --ic-z-index-dialog: calc(var(--ic-z-index-base-value) + 100);
   --ic-z-index-toast: calc(var(--ic-z-index-base-value) + 110);
   --ic-z-index-tooltip: calc(var(--ic-z-index-base-value) + 110);


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

Changes z-index for side-nav and nav items to prevent sticky page header from overlapping nav-items on focus and side nav on smaller viewports

## Related issue

#1142 

## Checklist
- [ ] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge).
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [ ] All prop combinations work without issue. 