### PR TITLE
fix(web-components): update radio group to use resize observer

### DIFF
--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.css
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.css
@@ -24,7 +24,7 @@ ic-input-label ic-typography {
   margin-bottom: calc(var(--ic-space-sm) / 2);
 }
 
-.radio-buttons-container {
+:host .radio-buttons-container {
   display: flex;
   flex-direction: column;
   gap: var(--ic-space-xxs);
@@ -34,12 +34,12 @@ ic-input-label ic-typography {
   gap: var(--ic-space-xxxs);
 }
 
-:host([orientation="horizontal"]) .radio-buttons-container {
+:host .radio-buttons-container.horizontal {
   display: flex;
   flex-direction: row;
   gap: calc(var(--ic-space-xl) + var(--ic-space-xs));
 }
 
-:host(.small[orientation="horizontal"]) .radio-buttons-container {
+:host(.small) .radio-buttons-container.horizontal {
   gap: var(--ic-space-xl);
 }

--- a/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ic-radio-group should render as helper text: renders-with-helpertext 1`] = `
-<ic-radio-group helpertext="helper test" label="test label" name="test" orientation="vertical">
+<ic-radio-group helpertext="helper test" label="test label" name="test">
   <mock:shadow-root>
     <div aria-label="test label" role="radiogroup">
       <ic-input-label label="test label"></ic-input-label>
@@ -28,7 +28,7 @@ exports[`ic-radio-group should render as helper text: renders-with-helpertext 1`
 `;
 
 exports[`ic-radio-group should render as required: renders-required 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical" required="">
+<ic-radio-group label="test label" name="test" required="">
   <mock:shadow-root>
     <div aria-label="test label, required" role="radiogroup">
       <ic-input-label label="test label" required=""></ic-input-label>
@@ -55,7 +55,7 @@ exports[`ic-radio-group should render as required: renders-required 1`] = `
 `;
 
 exports[`ic-radio-group should render radio option disabled: renders-disabled 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical">
+<ic-radio-group label="test label" name="test">
   <mock:shadow-root>
     <div aria-label="test label" role="radiogroup">
       <ic-input-label label="test label"></ic-input-label>
@@ -84,7 +84,7 @@ exports[`ic-radio-group should render radio option disabled: renders-disabled 1`
 `;
 
 exports[`ic-radio-group should render with dynamic additional field: renders-with-dynamic-additional-field 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical">
+<ic-radio-group label="test label" name="test">
   <mock:shadow-root>
     <div aria-label="test label" role="radiogroup">
       <ic-input-label label="test label"></ic-input-label>
@@ -136,7 +136,7 @@ exports[`ic-radio-group should render with dynamic additional field: renders-wit
 `;
 
 exports[`ic-radio-group should render with selected option: renders-with-selected-option 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical" required="">
+<ic-radio-group label="test label" name="test" required="">
   <mock:shadow-root>
     <div aria-label="test label, required" role="radiogroup">
       <ic-input-label label="test label" required=""></ic-input-label>
@@ -163,7 +163,7 @@ exports[`ic-radio-group should render with selected option: renders-with-selecte
 `;
 
 exports[`ic-radio-group should render with selected static additional field: renders-with-selected-additional-field 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical">
+<ic-radio-group label="test label" name="test">
   <mock:shadow-root>
     <div aria-label="test label" role="radiogroup">
       <ic-input-label label="test label"></ic-input-label>
@@ -209,7 +209,7 @@ exports[`ic-radio-group should render with selected static additional field: ren
 `;
 
 exports[`ic-radio-group should render with unselected static additional field: renders-with-unselected-additional-field 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical">
+<ic-radio-group label="test label" name="test">
   <mock:shadow-root>
     <div aria-label="test label" role="radiogroup">
       <ic-input-label label="test label"></ic-input-label>
@@ -255,7 +255,7 @@ exports[`ic-radio-group should render with unselected static additional field: r
 `;
 
 exports[`ic-radio-group should render with validation status: renders-with-validation-status 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical" required="" validation-status="error" validation-text="error">
+<ic-radio-group label="test label" name="test" required="" validation-status="error" validation-text="error">
   <mock:shadow-root>
     <div aria-label="test label, required" role="radiogroup">
       <ic-input-label class="error" label="test label" required=""></ic-input-label>
@@ -283,7 +283,7 @@ exports[`ic-radio-group should render with validation status: renders-with-valid
 `;
 
 exports[`ic-radio-group should render: renders 1`] = `
-<ic-radio-group label="test label" name="test" orientation="vertical">
+<ic-radio-group label="test label" name="test">
   <mock:shadow-root>
     <div aria-label="test label" role="radiogroup">
       <ic-input-label label="test label"></ic-input-label>

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
@@ -280,7 +280,7 @@ describe("ic-radio-group", () => {
       </ic-radio-group>`,
     });
 
-    expect(page.rootInstance.orientation).toMatch("vertical");
+    expect(page.rootInstance.currentOrientation).toMatch("vertical");
   });
 
   it("should change the orientation of the radio group to vertical if the user has additional fields on any of the radio buttons in the group", async () => {
@@ -294,7 +294,46 @@ describe("ic-radio-group", () => {
       </ic-radio-group>`,
     });
 
-    expect(page.rootInstance.orientation).toMatch("vertical");
+    expect(page.rootInstance.currentOrientation).toMatch("vertical");
+  });
+
+  it("should call runResizeObserver", async () => {
+    const page = await newSpecPage({
+      components: [RadioGroup, RadioOption, TextField],
+      html: `<ic-radio-group label="test label" name="test" required orientation="horizontal">
+        <ic-radio-option value="test1" selected></ic-radio-option>
+        <ic-radio-option value="test" disabled label="test label" group-label="test group">
+         <ic-text-field slot="additional-field" placeholder="Placeholder" label="Test label"></ic-text-field>
+        </ic-radio-option>      
+      </ic-radio-group>`,
+    });
+
+    await page.rootInstance.runResizeObserver();
+    page.waitForChanges();
+
+    const resize = new ResizeObserver(() => {
+      page.rootInstance.checkOrientation();
+    });
+
+    page.waitForChanges();
+
+    expect(page.rootInstance.resizeObserver).toBe(resize);
+  });
+
+  it("should call checkOrientation", async () => {
+    const page = await newSpecPage({
+      components: [RadioGroup, RadioOption, TextField],
+      html: `<ic-radio-group label="test label" name="test" required orientation="horizontal">
+      <ic-radio-option value="test1" selected></ic-radio-option>
+      <ic-radio-option value="test2"></ic-radio-option> 
+      <ic-radio-option value="test3"></ic-radio-option>    
+    </ic-radio-group>`,
+    });
+
+    await page.rootInstance.checkOrientation();
+    page.waitForChanges();
+
+    expect(page.rootInstance.currentOrientation).toBe("vertical");
   });
 
   it("should test key down handler", async () => {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update radio group to use resize observer to ensure horizontal orientation doesn't cut off radio options

## Related issue
#1055

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 