### PR TITLE
fix(web-components): add css styling for ic-card icons when displayed in high contrast mode

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -10425,9 +10425,9 @@
       "integrity": "sha512-ekMJNRMqPtdFrBXOgCDYgJmHBXkfarxWV6cp21Ys16roGqa5pcmxOTvldk6xy3rObMWs6qk7joB/LqpUYMBwUQ=="
     },
     "node_modules/@ukic/web-components": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.4.0.tgz",
-      "integrity": "sha512-dNGQ4Kie5r0VvfycegeraI9ewmxcYvP53E+hJ9jVjqlEXNgM1IZ8R+QXQohR4u86vqe5jCS9VViUEUYzCdPGrQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.4.1.tgz",
+      "integrity": "sha512-EnIZg+wjRzLB2AR8C7k5wdhNWG40mhzUJoQMDbk+UEwFtsPAwfo5r1nlj6+xrrEWVPHmszvb0di926LUh72t/A==",
       "dependencies": {
         "@popperjs/core": "^2.11.2",
         "@stencil/core": "^4.1.0",

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.2",
-        "@stencil/core": "^4.3.0"
+        "@stencil/core": "^4.3.0",
+        "@ukic/fonts": "^2.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.16.0",
@@ -9734,6 +9735,11 @@
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
       "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
       "dev": true
+    },
+    "node_modules/@ukic/fonts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.3.0.tgz",
+      "integrity": "sha512-ekMJNRMqPtdFrBXOgCDYgJmHBXkfarxWV6cp21Ys16roGqa5pcmxOTvldk6xy3rObMWs6qk7joB/LqpUYMBwUQ=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",

--- a/packages/web-components/src/components/ic-card/ic-card.css
+++ b/packages/web-components/src/components/ic-card/ic-card.css
@@ -178,3 +178,24 @@ button {
 .expanded-content {
   margin-top: var(--ic-space-md);
 }
+
+/** High Contrast **/
+@media (forced-colors: active) {
+  .card ::slotted(svg) {
+    fill: currentcolor;
+  }
+
+  .card.disabled ::slotted(svg) {
+    fill: GrayText !important;
+  }
+
+  .card.disabled {
+    border-color: GrayText !important;
+  }
+
+  .card.disabled .card-message,
+  .card.disabled .subheading,
+  .card.disabled .card-title {
+    color: GrayText;
+  }
+}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fix issue where icons in ic-card don't take on the right colour in high contrast mode. Fix issue where disabled and non-clickable ic-cards don't use the correct border colour in high contrast mode.

## Related issue
#1139 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge).
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [ ] All prop combinations work without issue. 