### PR TITLE
fix(web-components): fixes lint errors

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -347,11 +347,6 @@ div.icon-container {
   height: calc(var(--ic-space-md) + var(--ic-space-xxs));
 }
 
-:host(.button-size-large) div.icon-container {
-  width: calc(var(--ic-space-md) + var(--ic-space-xxs));
-  height: calc(var(--ic-space-md) + var(--ic-space-xxs));
-}
-
 ::slotted(:not(ic-badge)) {
   width: var(--icon-width) !important;
   height: var(--icon-height) !important;

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.css
@@ -166,6 +166,7 @@
   transition: var(--ic-easing-transition-slow);
   overflow: hidden;
 }
+
 :host(.navigation-group-side-nav) .link,
 :host(.navigation-group-side-nav) ::slotted(a) {
   height: var(--navigation-child-items-height, auto);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
fixes lint errors in navigation group and button css

## Related issue
N/A

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 