### PR TITLE
fix(web-components): prevents disabled search options being selected

### DIFF
--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -35,6 +35,7 @@ import { IcSearchBarSearchModes } from "../ic-search-bar/ic-search-bar.types";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export class Menu {
   private firstRender: boolean = true;
+  private disabledOptionSelected: boolean = false;
   private hasPreviouslyBlurred: boolean = false;
   private hasTimedOut: boolean = false;
   private isLoading: boolean = false;
@@ -548,9 +549,20 @@ export class Menu {
         break;
       case "Enter":
         event.preventDefault();
-        this.setInputValue(highlightedOptionIndex);
-        if (menuOptions[highlightedOptionIndex] !== undefined) {
-          this.value = menuOptions[highlightedOptionIndex][this.valueField];
+        if (highlightedOptionIndex >= 0) {
+          if (menuOptions[highlightedOptionIndex] !== undefined) {
+            if (
+              this.isSearchBar &&
+              menuOptions[highlightedOptionIndex].disabled === true
+            ) {
+              this.disabledOptionSelected = true;
+            } else {
+              this.setInputValue(highlightedOptionIndex);
+              this.value = menuOptions[highlightedOptionIndex][this.valueField];
+            }
+          }
+        } else {
+          this.setInputValue(highlightedOptionIndex);
         }
         break;
       case "Escape":
@@ -720,6 +732,10 @@ export class Menu {
   private handleMenuKeyUp = (event: KeyboardEvent): void => {
     if (event.key === "Tab" && event.shiftKey) {
       this.preventClickOpen = false;
+    }
+    if (event.key === "Enter" && this.disabledOptionSelected) {
+      this.disabledOptionSelected = false;
+      event.stopImmediatePropagation();
     }
   };
 

--- a/packages/web-components/src/components/ic-menu/test/basic/ic-menu.spec.tsx
+++ b/packages/web-components/src/components/ic-menu/test/basic/ic-menu.spec.tsx
@@ -376,6 +376,9 @@ describe("ic-menu in isolation", () => {
     ) as HTMLIcSearchBarElement;
     const input = window.document.createElement("input");
 
+    const searchMenuOptions = JSON.parse(JSON.stringify(menuOptions));
+    searchMenuOptions[3].disabled = true;
+
     searchBar.setFocus = jest.fn();
 
     const page = await newSpecPage({
@@ -384,12 +387,12 @@ describe("ic-menu in isolation", () => {
         <ic-menu
           open
           activationType="automatic"
-          options={menuOptions}
+          options={searchMenuOptions}
           menuId="menu-id"
           inputLabel="input-label"
           inputEl={input}
           anchorEl={searchBar}
-          value={menuOptions[0].value}
+          value={searchMenuOptions[0].value}
           parentEl={searchBar}
         ></ic-menu>
       ),
@@ -475,6 +478,23 @@ describe("ic-menu in isolation", () => {
         }),
       })
     );
+
+    page.rootInstance.setHighlightedOption(2);
+
+    await page.waitForChanges();
+
+    page.rootInstance.manSetInputValueKeyboardOpen(keyboardEvent("ArrowDown"));
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.value).toBe(searchMenuOptions[2].value);
+
+    page.rootInstance.manSetInputValueKeyboardOpen(keyboardEvent("Enter"));
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.disabledOptionSelected).toBe(true);
+    expect(page.rootInstance.value).toBe(searchMenuOptions[2].value);
 
     page.rootInstance.manSetInputValueKeyboardOpen(keyboardEvent("Escape"));
 
@@ -1040,7 +1060,7 @@ describe("ic-menu in isolation", () => {
 
     page.rootInstance.preventClickOpen = true;
 
-    const key = keyboardEvent("Tab");
+    let key = keyboardEvent("Tab");
 
     key.shiftKey = true;
 
@@ -1051,6 +1071,16 @@ describe("ic-menu in isolation", () => {
     await page.waitForChanges();
 
     expect(page.rootInstance.preventClickOpen).toBe(false);
+
+    page.rootInstance.disabledOptionSelected = true;
+    key = keyboardEvent("Enter");
+    await page.waitForChanges();
+
+    page.rootInstance.handleMenuKeyUp(key);
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.disabledOptionSelected).toBe(false);
   });
   it("tests connectedCallback function", async () => {
     const searchBar = window.document.createElement(IcSearchBar);

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.stories.mdx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.stories.mdx
@@ -96,7 +96,8 @@ import readme from "./readme.md";
             { label: "Double Espresso", value: "doubleespresso" },
             { label: "Flat White", value: "flatwhite" },
             { label: "Cappuccino", value: "cappucino" },
-            { label: "Americano", value: "americano" },
+            { label: "Americano", value: "americano", disabled: true },
+            { label: "Cafe au lait", value: "cafe" },
             { label: "Mocha", value: "mocha" },
           ];
         </script>`
@@ -123,7 +124,7 @@ import readme from "./readme.md";
             { label: "Double Espresso", value: "doubleespresso" },
             { label: "Flat White", value: "flatwhite" },
             { label: "Cappuccino", value: "cappucino" },
-            { label: "Americano", value: "americano" },
+            { label: "Americano", value: "americano", disabled: true },
             { label: "Mocha", value: "mocha" },
           ];
         </script>`


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
disabled options in search bar suggestions can no longer be selected

## Related issue
#1090 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 