### PR TITLE
1012 ic button using aria controls or aria owns on ic button

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -25,7 +25,7 @@
       "GHSA-w5p7-h5w8-2hfq": {
         "active": true,
         "notes": "requires upgrade to storybook v7",
-        "expiry": "16 October 2023"
+        "expiry": "5 November 2023"
       }
     },
     {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -213,6 +213,8 @@ export namespace Components {
           * The appearance of the button, e.g. dark, light, or the default.
          */
         "appearance"?: IcThemeForeground;
+        "ariaControlsId": string | boolean;
+        "ariaOwnsId": string | boolean;
         /**
           * If `true`, the ic-tooltip which is shown for icon variant will be disabled. Title or aria-label must be set if this prop is not applied.
          */
@@ -2740,6 +2742,8 @@ declare namespace LocalJSX {
           * The appearance of the button, e.g. dark, light, or the default.
          */
         "appearance"?: IcThemeForeground;
+        "ariaControlsId"?: string | boolean;
+        "ariaOwnsId"?: string | boolean;
         /**
           * If `true`, the ic-tooltip which is shown for icon variant will be disabled. Title or aria-label must be set if this prop is not applied.
          */

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -66,6 +66,16 @@ export class Button {
   @Prop({ mutable: true }) appearance?: IcThemeForeground = "default";
 
   /**
+   * @internal Used to identify any related child component
+   */
+  @Prop() ariaControlsId: string | boolean;
+
+  /**
+   * @internal Used to identify any related child component
+   */
+  @Prop() ariaOwnsId: string | boolean;
+
+  /**
    * If `true`, the button will be in disabled state.
    */
   @Prop() disabled?: boolean = false;
@@ -461,6 +471,8 @@ export class Button {
           ["with-badge"]: isSlotUsed(this.el, "badge"),
         }}
         onClick={this.handleClick}
+        aria-owns={this.ariaOwnsId}
+        aria-controls={this.ariaControlsId}
       >
         {this.hasTooltip && (
           <ic-tooltip

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -240,7 +240,7 @@ export class MenuItem {
             }
             aria-disabled={`${this.disabled}`}
             aria-label={this.getMenuItemAriaLabel()}
-            aria-controls={
+            ariaControlsId={
               this.submenuTriggerFor !== undefined
                 ? `ic-popover-submenu-${this.submenuTriggerFor}`
                 : false
@@ -251,7 +251,7 @@ export class MenuItem {
                 ? "menu"
                 : false
             }
-            aria-owns={
+            ariaOwnsId={
               this.submenuTriggerFor !== undefined
                 ? `ic-popover-submenu-${this.submenuTriggerFor}`
                 : false

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -647,7 +647,7 @@ export class SideNavigation {
               full-width="true"
               appearance={foregroundColor}
               onClick={this.toggleMenu}
-              aria-owns="side-navigation"
+              ariaOwnsId="side-navigation"
               aria-haspopup="true"
               aria-expanded="false"
             >


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add aria owns and aria controls to host tag of button, and added props so that they can be added from other components.

## Related issue
#1012 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 