### PR TITLE
fix(web-components): fixes aria label not updating on button

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -295,7 +295,6 @@ export namespace Components {
           * The type of the button.
          */
         "type"?: IcButtonTypes;
-        "updateAriaLabel": (newValue: string) => Promise<void>;
         /**
           * The variant of the button to be displayed.
          */

--- a/packages/web-components/src/components/ic-button/readme.md
+++ b/packages/web-components/src/components/ic-button/readme.md
@@ -61,6 +61,14 @@ Type: `Promise<void>`
 | `"right-icon"` | Content will be placed to the right of the button label.                                    |
 
 
+## CSS Custom Properties
+
+| Name          | Description                  |
+| ------------- | ---------------------------- |
+| `--height`    | The height of the button.    |
+| `--min-width` | Minimum width of the button. |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -278,7 +278,33 @@ exports[`button component should test button as submit button on form 1`] = `
 </ic-button>
 `;
 
-exports[`button component should update when method called 1`] = `
+exports[`button component should update aria-expanded when attribute changed 1`] = `
+<ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
+  <mock:shadow-root>
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" placement="bottom" target="ic-button-with-tooltip-test-button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-expanded="false" class="button" part="button" type="button">
+        <slot></slot>
+      </button>
+    </ic-tooltip>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should update aria-expanded when attribute changed 2`] = `
+<ic-button aria-expanded="true" class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
+  <mock:shadow-root>
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" placement="bottom" target="ic-button-with-tooltip-test-button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-expanded="true" class="button" part="button" type="button">
+        <slot></slot>
+      </button>
+    </ic-tooltip>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should update aria-label when attribute changed 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
     <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
@@ -291,11 +317,37 @@ exports[`button component should update when method called 1`] = `
 </ic-button>
 `;
 
-exports[`button component should update when method called 2`] = `
+exports[`button component should update aria-label when attribute changed 2`] = `
+<ic-button aria-label="New tooltip text" class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
+  <mock:shadow-root>
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="New tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-label="New tooltip text" class="button" part="button" type="button">
+        <slot></slot>
+      </button>
+    </ic-tooltip>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should update tooltip label when title attribute changed 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
     <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-label="New tooltip text" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
+        <slot></slot>
+      </button>
+    </ic-tooltip>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should update tooltip label when title attribute changed 2`] = `
+<ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" title="New tooltip text" variant="icon">
+  <mock:shadow-root>
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="New tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>

--- a/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
+++ b/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
@@ -204,7 +204,7 @@ describe("button component", () => {
     expect(page.root).toMatchSnapshot();
   });
 
-  it("should update when method called", async () => {
+  it("should update aria-label when attribute changed", async () => {
     const page = await newSpecPage({
       components: [Button],
       html: "<ic-button variant='icon' aria-label='Tooltip text' id='test-button'>Button</ic-button>",
@@ -212,7 +212,46 @@ describe("button component", () => {
 
     expect(page.root).toMatchSnapshot();
 
-    await page.root.updateAriaLabel("New tooltip text");
+    page.root.setAttribute("aria-label", "New tooltip text");
+    await page.waitForChanges();
+
+    page.rootInstance.hostMutationCallback([{ attributeName: "aria-label" }]);
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it("should update aria-expanded when attribute changed", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: "<ic-button variant='icon' aria-expanded='false' id='test-button'>Button</ic-button>",
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.root.setAttribute("aria-expanded", "true");
+    await page.waitForChanges();
+
+    page.rootInstance.hostMutationCallback([
+      { attributeName: "aria-expanded" },
+    ]);
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it("should update tooltip label when title attribute changed", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: "<ic-button variant='icon' title='Tooltip text' id='test-button'>Button</ic-button>",
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.root.setAttribute("title", "New tooltip text");
+    await page.waitForChanges();
+
+    page.rootInstance.hostMutationCallback([{ attributeName: "title" }]);
     await page.waitForChanges();
 
     expect(page.root).toMatchSnapshot();

--- a/packages/web-components/src/components/ic-link/ic-link.tsx
+++ b/packages/web-components/src/components/ic-link/ic-link.tsx
@@ -75,11 +75,7 @@ export class Link {
   @Prop() target?: string;
 
   componentWillLoad(): void {
-    this.inheritedAttributes = inheritAttributes(this.el, [
-      ...IC_INHERITED_ARIA,
-      "aria-expanded",
-    ]);
-
+    this.inheritedAttributes = inheritAttributes(this.el, IC_INHERITED_ARIA);
     this.updateTheme();
   }
 

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -48,6 +48,7 @@ export class SideNavigation {
   private resizeObserver: ResizeObserver = null;
   private COLLAPSED_ICON_LABELS_END = "collapsed-icon-labels-end";
   private COLLAPSED_ICON_LABELS_START = "collapsed-icon-labels-start";
+  private menuButton: HTMLIcButtonElement = null;
 
   @Element() el: HTMLIcSideNavigationElement;
 
@@ -214,16 +215,14 @@ export class SideNavigation {
   };
 
   private setMobileMenuAriaAttributes = (menuOpen: boolean) => {
-    const nativeButton = this.el.shadowRoot
-      .querySelector("#menu-button")
-      .shadowRoot.querySelector("button");
-
-    if (menuOpen) {
-      nativeButton.setAttribute("aria-expanded", "true");
-      nativeButton.setAttribute("aria-label", "Close navigation menu");
-    } else {
-      nativeButton.setAttribute("aria-expanded", "false");
-      nativeButton.setAttribute("aria-label", "Open navigation menu");
+    if (this.menuButton !== null) {
+      if (menuOpen) {
+        this.menuButton.setAttribute("aria-expanded", "true");
+        this.menuButton.setAttribute("aria-label", "Close navigation menu");
+      } else {
+        this.menuButton.setAttribute("aria-expanded", "false");
+        this.menuButton.setAttribute("aria-label", "Open navigation menu");
+      }
     }
   };
 
@@ -656,6 +655,7 @@ export class SideNavigation {
               ariaOwnsId="side-navigation"
               aria-haspopup="true"
               aria-expanded="false"
+              ref={(el) => (this.menuButton = el)}
             >
               <span
                 class="mobile-top-bar-menu-icon"

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -329,8 +329,6 @@ export class TextField {
     this.inheritedAttributes = inheritAttributes(this.el, [
       ...IC_INHERITED_ARIA,
       "title",
-      "aria-autocomplete",
-      "aria-haspopup",
     ]);
 
     if (this.readonly) {

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -202,14 +202,14 @@ export class TopNavigation {
 
     if (this.searchBar !== null) {
       if (this.mobileSearchBarVisible) {
-        this.mobileSearchButtonEl.updateAriaLabel("Hide search");
+        this.mobileSearchButtonEl.setAttribute("aria-label", "Hide search");
         this.hasFullWidthSearchBar = true;
         this.searchBar.fullWidth = true;
         setTimeout(() => {
           this.searchBar.focus();
         }, 100);
       } else {
-        this.mobileSearchButtonEl.updateAriaLabel("Show search");
+        this.mobileSearchButtonEl.setAttribute("aria-label", "Show search");
         this.hasFullWidthSearchBar = false;
         this.searchBar.fullWidth = false;
       }

--- a/packages/web-components/src/utils/constants.ts
+++ b/packages/web-components/src/utils/constants.ts
@@ -31,6 +31,7 @@ export const VARIANT_ICONS = {
 // Global ARIA attributes
 export const IC_INHERITED_ARIA = [
   "aria-atomic",
+  "aria-autocomplete",
   "aria-busy",
   "aria-controls",
   "aria-current",
@@ -40,6 +41,7 @@ export const IC_INHERITED_ARIA = [
   "aria-disabled",
   "aria-dropeffect",
   "aria-errormessage",
+  "aria-expanded",
   "aria-flowto",
   "aria-grabbed",
   "aria-haspopup",


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
- Fixes issue where aria-label update was not passed to native button element.
- Now will reflect any changes made to any aria- attribute or title attribute.
- Moved all aria-* attributes from components into IC_INHERITED_ARIA.
- Removes internal method for updating the aria-label as no longer required. Can now call setAttribute() directly on IcButton element.

## Related issue
#1110 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 