### PR TITLE
adds button pressed styling

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -104,9 +104,29 @@
   background-color: var(--button-default-hover);
 }
 
+:host(.button-variant-primary) .button:hover:focus {
+  background-color: var(--button-default-hover);
+  border-color: var(--button-default-hover);
+}
+
+:host(.button-variant-primary:not(.light)) .button:hover:focus {
+  color: var(--ic-architectural-white);
+}
+
 :host(.button-variant-primary) .button:active:not(:focus),
 :host(.button-variant-primary.loading) .button {
   background-color: var(--button-default-active);
+}
+:host(.button-variant-primary) .button:active:focus {
+  background-color: var(--button-default-active);
+}
+
+:host(.button-variant-primary) .button:active {
+  background-color: var(--button-default-active);
+}
+
+:host(.button-variant-primary:not(.light)) .button:active {
+  color: var(--ic-architectural-white);
 }
 
 :host(.button-variant-primary.disabled) .button {
@@ -119,20 +139,23 @@
   color: var(--ic-architectural-500);
 }
 
-/* Secondary */
+/* Secondary  */
 
 :host(.button-variant-secondary) .button {
   border: var(--ic-space-1px) solid var(--button-default);
   color: var(--button-default);
 }
 
-:host(.button-variant-secondary) .button:hover:not(:focus) {
+:host(.button-variant-secondary) .button:hover:not(:focus),
+:host(.button-variant-secondary) .button:hover:focus {
   background-color: var(--button-default-background-hover);
   border-color: var(--button-default-hover);
   color: var(--button-default-hover);
 }
 
-:host(.button-variant-secondary) .button:active:not(:focus) {
+:host(.button-variant-secondary) .button:active:not(:focus),
+:host(.button-variant-secondary) .button:active:focus,
+:host(.button-variant-secondary) .button:active {
   border-color: var(--button-default-active);
   background-color: var(--button-default-background-active);
   color: var(--button-default-active);
@@ -166,12 +189,15 @@
   color: var(--button-default);
 }
 
-:host(.button-variant-tertiary) .button:hover:not(:focus) {
+:host(.button-variant-tertiary) .button:hover:not(:focus),
+:host(.button-variant-tertiary) .button:hover:focus {
   background-color: var(--button-default-background-hover);
   color: var(--button-default-hover);
 }
 
 :host(.button-variant-tertiary) .button:active:not(:focus),
+:host(.button-variant-tertiary) .button:active:focus,
+:host(.button-variant-tertiary) .button:active,
 :host(.button-variant-tertiary.loading) .button {
   background-color: var(--button-default-background-active);
   color: var(--button-default-active);
@@ -233,11 +259,13 @@
   text-transform: uppercase;
 }
 
-:host(.button-variant-destructive) .button:hover:not(:focus) {
+:host(.button-variant-destructive) .button:hover:not(:focus),
+:host(.button-variant-destructive) .button:hover:focus {
   background-color: var(--ic-action-destructive-hover);
 }
 
 :host(.button-variant-destructive) .button:active:not(:focus),
+:host(.button-variant-destructive) .button:active:focus,
 :host(.button-variant-destructive.loading) .button {
   background-color: var(--ic-action-destructive-active);
 }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
adds pressed button styling whilst ensuring the order of events is: 

Button exists on page unfocused or hovered showing default state.
Mouse over causes hover state.
Mouse down causes active state plus applies focus
Mouse up event causes complete click event (if still over button) and button remains hovered and focused.
Mouse leaves button area causing default state to return, with focus still displayed.

## Related issue
#844 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 