### PR TITLE
fix(web-components): removes expandable from storybook

### DIFF
--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.mdx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.mdx
@@ -428,11 +428,7 @@ import NavigationGroup from "../ic-navigation-group/readme.md";
             />
           </svg>
         </ic-navigation-button>
-        <ic-navigation-group
-          slot="navigation"
-          label="Navigation group"
-          expandable="true"
-        >
+        <ic-navigation-group slot="navigation" label="Navigation group">
           <ic-navigation-item label="One" href="/"></ic-navigation-item>
           <ic-navigation-item label="Two" href="/"></ic-navigation-item>
           <ic-navigation-item label="Three" href="/"></ic-navigation-item>
@@ -451,11 +447,7 @@ import NavigationGroup from "../ic-navigation-group/readme.md";
           <ic-navigation-item label="Seven" href="/"></ic-navigation-item>
           <ic-navigation-item label="Eight" href="/"></ic-navigation-item>
         </ic-navigation-group>
-        <ic-navigation-group
-          slot="navigation"
-          label="Second navigation group"
-          expandable="true"
-        >
+        <ic-navigation-group slot="navigation" label="Second navigation group">
           <ic-navigation-item label="Another One" href="/"></ic-navigation-item>
           <ic-navigation-item label="Another Two" href="/"></ic-navigation-item>
           <ic-navigation-item


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Navigation group had expanded prop in storybook, however this is only applicable for side nav. This  fix removes it from the code. There is another ticket to remove from Design Kit

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.