### PR TITLE
1210 ic toast update toast to use prop to openclose

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -16258,39 +16258,7 @@
           "required": false
         }
       ],
-      "methods": [
-        {
-          "name": "setVisible",
-          "returns": {
-            "type": "Promise<HTMLElement>",
-            "docs": "The element that previously had focus before the toast appeared"
-          },
-          "complexType": {
-            "signature": "() => Promise<HTMLElement>",
-            "parameters": [],
-            "references": {
-              "Promise": {
-                "location": "global",
-                "id": "global::Promise"
-              },
-              "HTMLElement": {
-                "location": "global",
-                "id": "global::HTMLElement"
-              }
-            },
-            "return": "Promise<HTMLElement>"
-          },
-          "signature": "setVisible() => Promise<HTMLElement>",
-          "parameters": [],
-          "docs": "Used to display the individual toast",
-          "docsTags": [
-            {
-              "name": "returns",
-              "text": "The element that previously had focus before the toast appeared"
-            }
-          ]
-        }
-      ],
+      "methods": [],
       "events": [
         {
           "event": "icDismiss",
@@ -16380,7 +16348,33 @@
       "docs": "",
       "docsTags": [],
       "usage": {},
-      "props": [],
+      "props": [
+        {
+          "name": "openToast",
+          "type": "HTMLIcToastElement",
+          "complexType": {
+            "original": "HTMLIcToastElement",
+            "resolved": "HTMLIcToastElement",
+            "references": {
+              "HTMLIcToastElement": {
+                "location": "global",
+                "id": "global::HTMLIcToastElement"
+              }
+            }
+          },
+          "mutable": true,
+          "reflectToAttr": false,
+          "docs": "The toast element to be displayed.",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "HTMLIcToastElement"
+            }
+          ],
+          "optional": false,
+          "required": false
+        }
+      ],
       "methods": [
         {
           "name": "setVisible",
@@ -16392,13 +16386,8 @@
             "signature": "(toast: HTMLIcToastElement) => Promise<void>",
             "parameters": [
               {
-                "tags": [
-                  {
-                    "name": "param",
-                    "text": "toast The toast element being requested to display"
-                  }
-                ],
-                "text": "The toast element being requested to display"
+                "tags": [],
+                "text": ""
               }
             ],
             "references": {
@@ -16415,13 +16404,14 @@
           },
           "signature": "setVisible(toast: HTMLIcToastElement) => Promise<void>",
           "parameters": [],
-          "docs": "Handles setting the visibility of various toasts based on what is already visible",
+          "docs": "",
           "docsTags": [
             {
-              "name": "param",
-              "text": "toast The toast element being requested to display"
+              "name": "deprecated",
+              "text": "Use openToast prop to display toast instead."
             }
-          ]
+          ],
+          "deprecation": "Use openToast prop to display toast instead."
         }
       ],
       "events": [],

--- a/packages/react/src/stories/ic-toast.stories.mdx
+++ b/packages/react/src/stories/ic-toast.stories.mdx
@@ -18,9 +18,8 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="Default">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       return (
         <>
@@ -40,9 +39,8 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="With variant">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       return (
         <>
@@ -67,9 +65,8 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="Multiline message">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       return (
         <>
@@ -93,14 +90,12 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="Slotted action elements">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       function func2() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast2"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast2");
       }
       return (
         <>
@@ -140,9 +135,8 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="Auto dismiss">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       return (
         <>
@@ -169,9 +163,8 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="Custom neutral icon">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       return (
         <>
@@ -208,9 +201,8 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
   <Story name="Example on page">
     {() => {
       function func() {
-        document
-          .querySelector("ic-toast-region")
-          .setVisible(document.getElementById("toast1"));
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
       }
       return (
         <>

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2100,7 +2100,6 @@ export namespace Components {
          */
         "neutralIconAriaLabel"?: string;
         /**
-          * Used to display the individual toast
           * @returns The element that previously had focus before the toast appeared
          */
         "setVisible": () => Promise<HTMLElement>;
@@ -2111,8 +2110,11 @@ export namespace Components {
     }
     interface IcToastRegion {
         /**
-          * Handles setting the visibility of various toasts based on what is already visible
-          * @param toast The toast element being requested to display
+          * The toast element to be displayed.
+         */
+        "openToast": HTMLIcToastElement;
+        /**
+          * @deprecated Use openToast prop to display toast instead.
          */
         "setVisible": (toast: HTMLIcToastElement) => Promise<void>;
     }
@@ -4913,6 +4915,10 @@ declare namespace LocalJSX {
         "variant"?: IcStatusVariants;
     }
     interface IcToastRegion {
+        /**
+          * The toast element to be displayed.
+         */
+        "openToast"?: HTMLIcToastElement;
     }
     interface IcTooltip {
         /**

--- a/packages/web-components/src/components/ic-toast-region/ic-toast-region.tsx
+++ b/packages/web-components/src/components/ic-toast-region/ic-toast-region.tsx
@@ -1,4 +1,12 @@
-import { Component, Element, h, Listen, Method } from "@stencil/core";
+import {
+  Component,
+  Element,
+  h,
+  Listen,
+  Method,
+  Prop,
+  Watch,
+} from "@stencil/core";
 import { IcFocusableComponents } from "../../utils/types";
 
 @Component({ tag: "ic-toast-region" })
@@ -7,6 +15,18 @@ export class ToastRegion {
   private previouslyFocused: HTMLElement;
 
   @Element() el: HTMLIcToastRegionElement;
+
+  /**
+   * The toast element to be displayed.
+   */
+  @Prop({ mutable: true }) openToast: HTMLIcToastElement;
+  @Watch("openToast")
+  watchOpenToastHandler(newValue: HTMLIcToastElement): void {
+    if (this.openToast !== undefined) {
+      this.showToast(newValue);
+      this.openToast = undefined;
+    }
+  }
 
   @Listen("icDismiss", { capture: true })
   handleDismissedToast(): void {
@@ -22,12 +42,7 @@ export class ToastRegion {
     }
   }
 
-  /**
-   * Handles setting the visibility of various toasts based on what is already visible
-   * @param toast The toast element being requested to display
-   */
-  @Method()
-  async setVisible(toast: HTMLIcToastElement): Promise<void> {
+  private showToast = (toast: HTMLIcToastElement) => {
     const visibleToasts = Array.from(
       document.querySelectorAll("ic-toast")
     ).filter((el) => window.getComputedStyle(el).display !== "none");
@@ -35,6 +50,14 @@ export class ToastRegion {
       toast.setVisible().then((res) => (this.previouslyFocused = res));
     }
     if (visibleToasts.length > 0) this.pendingVisibility.push(toast);
+  };
+
+  /**
+   * @deprecated Use openToast prop to display toast instead.
+   */
+  @Method()
+  async setVisible(toast: HTMLIcToastElement): Promise<void> {
+    this.showToast(toast);
   }
 
   render() {

--- a/packages/web-components/src/components/ic-toast-region/readme.md
+++ b/packages/web-components/src/components/ic-toast-region/readme.md
@@ -5,11 +5,18 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property    | Attribute | Description                        | Type                 | Default     |
+| ----------- | --------- | ---------------------------------- | -------------------- | ----------- |
+| `openToast` | --        | The toast element to be displayed. | `HTMLIcToastElement` | `undefined` |
+
+
 ## Methods
 
 ### `setVisible(toast: HTMLIcToastElement) => Promise<void>`
 
-Handles setting the visibility of various toasts based on what is already visible
+<span style="color:red">**[DEPRECATED]**</span> Use openToast prop to display toast instead.<br/><br/>
 
 #### Returns
 

--- a/packages/web-components/src/components/ic-toast-region/test/basic/ic-toast-region.spec.ts
+++ b/packages/web-components/src/components/ic-toast-region/test/basic/ic-toast-region.spec.ts
@@ -15,7 +15,7 @@ describe("ic-toast-region component", () => {
     expect(page.root).toMatchSnapshot();
   });
 
-  it("should test showing and hiding toasts", async () => {
+  it("should test showing and hiding toasts with deprecated showVisible method", async () => {
     const page = await newSpecPage({
       components: [ToastRegion, Toast],
       html: `<ic-toast-region>
@@ -31,6 +31,39 @@ describe("ic-toast-region component", () => {
     expect(page.rootInstance.pendingVisibility.length).toBe(1);
 
     await page.root.setVisible(toasts[1]);
+
+    expect(page.rootInstance.pendingVisibility.length).toBe(2);
+
+    await page.rootInstance.handleDismissedToast();
+    expect(page.rootInstance.pendingVisibility.length).toBe(1);
+
+    await page.rootInstance.handleDismissedToast();
+    expect(page.rootInstance.pendingVisibility.length).toBe(0);
+
+    await page.rootInstance.handleDismissedToast();
+    expect(page.rootInstance.pendingVisibility.length).toBe(0);
+  });
+
+  it("should test showing and hiding toasts with openToast prop", async () => {
+    const page = await newSpecPage({
+      components: [ToastRegion, Toast],
+      html: `<ic-toast-region>
+      <ic-toast heading="Heading"></ic-toast>
+      <ic-toast heading="Heading"></ic-toast>
+      </ic-toast-region>`,
+    });
+
+    const toasts = page.root.querySelectorAll("ic-toast");
+
+    page.root.openToast = toasts[0];
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.pendingVisibility.length).toBe(1);
+
+    page.root.openToast = toasts[1];
+
+    await page.waitForChanges();
 
     expect(page.rootInstance.pendingVisibility.length).toBe(2);
 

--- a/packages/web-components/src/components/ic-toast/ic-toast.stories.mdx
+++ b/packages/web-components/src/components/ic-toast/ic-toast.stories.mdx
@@ -15,7 +15,7 @@ import readme from "./readme.md";
         var toastRegion = document.querySelector("ic-toast-region");
         function func() {
           var x = document.getElementById("toast1");
-          toastRegion.setVisible(x);
+          toastRegion.openToast = x;
         }
       </script>
       <ic-toast-region>
@@ -33,7 +33,7 @@ import readme from "./readme.md";
         var toastRegion = document.querySelector("ic-toast-region");
         function func() {
           var x = document.getElementById("toast1");
-          toastRegion.setVisible(x);
+          toastRegion.openToast = x;
         }
       </script>
       <ic-toast-region>
@@ -57,7 +57,7 @@ import readme from "./readme.md";
           var toastRegion = document.querySelector("ic-toast-region");
           function func() {
             var x = document.getElementById("toast1");
-            toastRegion.setVisible(x);
+            toastRegion.openToast = x;
           }
         </script>
         <ic-toast-region>
@@ -82,11 +82,11 @@ import readme from "./readme.md";
           var toastRegion = document.querySelector("ic-toast-region");
           function func() {
             var x = document.getElementById("toast1");
-            toastRegion.setVisible(x);
+            toastRegion.openToast = x;
           }
           function func2() {
             var x = document.getElementById("toast2");
-            toastRegion.setVisible(x);
+            toastRegion.openToast = x;
           }
         </script>
         <ic-toast-region>
@@ -117,24 +117,39 @@ import readme from "./readme.md";
 
 <Canvas>
   <Story name="Auto dismiss" parameters={{ loki: { skip: true } }}>
-    {(args) => html`<button onclick="func()">Display toast</button>
-      <script>
-        var toastRegion = document.querySelector("ic-toast-region");
-        function func() {
-          var x = document.getElementById("toast1");
-          toastRegion.setVisible(x);
-        }
-      </script>
-      <ic-toast-region>
-        <ic-toast
-          id="toast1"
-          variant="info"
-          heading="Your coffee is ready"
-          message="Please dismiss and collect"
-          dismiss-mode="automatic"
-          auto-dismiss-timeout="10000"
-        ></ic-toast>
-      </ic-toast-region>`}
+    {(args) =>
+      html`<button onclick="func()">Display toast 1</button>
+        <button onclick="func2()">Display toast 2</button>
+        <script>
+          var toastRegion = document.querySelector("ic-toast-region");
+          function func() {
+            var x = document.getElementById("toast1");
+            toastRegion.openToast = x;
+          }
+          function func2() {
+            var x = document.getElementById("toast2");
+            toastRegion.openToast = x;
+          }
+        </script>
+        <ic-toast-region>
+          <ic-toast
+            id="toast1"
+            variant="info"
+            heading="Your coffee is ready"
+            message="Please dismiss and collect"
+            dismiss-mode="automatic"
+            auto-dismiss-timeout="10000"
+          ></ic-toast>
+          <ic-toast
+            id="toast2"
+            heading="Your coffee was lost"
+            message="Please dismiss and try again"
+            variant="error"
+            dismiss-mode="automatic"
+            auto-dismiss-timeout="10000"
+          ></ic-toast>
+        </ic-toast-region>`
+    }
   </Story>
 </Canvas>
 
@@ -150,7 +165,7 @@ import readme from "./readme.md";
         var toastRegion = document.querySelector("ic-toast-region");
         function func() {
           var x = document.getElementById("toast1");
-          toastRegion.setVisible(x);
+          toastRegion.openToast = x;
         }
       </script>
       <ic-toast-region>
@@ -186,7 +201,7 @@ import readme from "./readme.md";
         var toastRegion = document.querySelector("ic-toast-region");
         function func() {
           var x = document.getElementById("toast1");
-          toastRegion.setVisible(x);
+          toastRegion.openToast = x;
         }
       </script>
       <ic-toast-region>
@@ -306,5 +321,23 @@ import readme from "./readme.md";
       <br />
       <ic-typography variant="h3">The end</ic-typography>
       <br />`}
+  </Story>
+</Canvas>
+
+### Deprecated - setVisible
+
+<Canvas>
+  <Story name="Deprecated - setVisible" parameters={{ loki: { skip: true } }}>
+    {(args) => html`<button onclick="func()">Display toast</button>
+      <script>
+        var toastRegion = document.querySelector("ic-toast-region");
+        function func() {
+          var x = document.getElementById("toast1");
+          toastRegion.setVisible(x);
+        }
+      </script>
+      <ic-toast-region>
+        <ic-toast id="toast1" heading="Your coffee is ready"></ic-toast>
+      </ic-toast-region>`}
   </Story>
 </Canvas>

--- a/packages/web-components/src/components/ic-toast/ic-toast.tsx
+++ b/packages/web-components/src/components/ic-toast/ic-toast.tsx
@@ -114,6 +114,9 @@ export class Toast {
     }
 
     if (this.isManual) {
+      const toastMessage: string = isPropDefined(this.message)
+        ? `. ${this.message}`
+        : "";
       this.el.setAttribute(
         "aria-label",
         this.variant
@@ -123,11 +126,7 @@ export class Toast {
       (this.variant || this.message) &&
         this.el.setAttribute(
           "aria-description",
-          this.variant
-            ? `${this.heading}${
-                isPropDefined(this.message) ? `. ${this.message}` : ""
-              }`
-            : this.message
+          this.variant ? `${this.heading}${toastMessage}` : this.message
         );
     }
   }
@@ -191,7 +190,7 @@ export class Toast {
   }
 
   /**
-   * Used to display the individual toast
+   * @internal Used to display the individual toast.
    * @returns The element that previously had focus before the toast appeared
    */
   @Method()

--- a/packages/web-components/src/components/ic-toast/readme.md
+++ b/packages/web-components/src/components/ic-toast/readme.md
@@ -25,19 +25,6 @@
 | `icDismiss` | Is emitted when the user dismisses the toast | `CustomEvent<void>` |
 
 
-## Methods
-
-### `setVisible() => Promise<HTMLElement>`
-
-Used to display the individual toast
-
-#### Returns
-
-Type: `Promise<HTMLElement>`
-
-The element that previously had focus before the toast appeared
-
-
 ## Slots
 
 | Slot             | Description                                                                                                         |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Deprecate setVisible method on toast region.
Add openToast prop to toast region.
Add internal decorator to setVisible on toast.
Update to toast after some linting issues.

## Related issue
#1210 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.