### PR TITLE
fix textfield slotted in checkbox change event not running

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-11-07T14:26:48",
+  "timestamp": "2023-11-10T13:08:19",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.3.0",
@@ -3292,6 +3292,11 @@
         }
       ],
       "listeners": [
+        {
+          "event": "icChange",
+          "capture": false,
+          "passive": false
+        },
         {
           "event": "icCheck",
           "capture": false,

--- a/packages/react/src/stories/ic-checkbox.stories.mdx
+++ b/packages/react/src/stories/ic-checkbox.stories.mdx
@@ -9,6 +9,7 @@ import { IcCheckboxGroup, IcCheckbox, IcTextField } from "../components";
 import checkboxReadme from "../../../web-components/src/components/ic-checkbox/readme.md";
 import checkboxGroupReadme from "../../../web-components/src/components/ic-checkbox-group/readme.md";
 import { useForm } from "react-hook-form";
+import { useState } from "react";
 
 <Meta title="React Components/Checkbox" component={IcCheckboxGroup} />
 
@@ -304,5 +305,40 @@ export const Form = () => {
         </IcCheckboxGroup>
       </IcCheckbox>
     </IcCheckboxGroup>
+  </Story>
+</Canvas>
+
+### TextField value change
+
+export const TextField = () => {
+  const [textBoxValue, setTextBoxValue] = useState("");
+  const onChangeTextBox = (e) => {
+    setTextBoxValue(e.detail.value);
+  };
+  return (
+    <div>
+      <IcCheckboxGroup label="This is a label" name="1">
+        <IcCheckbox
+          additionalFieldDisplay="static"
+          value="valueName1"
+          label="option1"
+        >
+          <IcTextField
+            slot="additional-field"
+            placeholder="Placeholder"
+            label="What's your favourite type of coffee?"
+            onIcChange={onChangeTextBox}
+          />
+        </IcCheckbox>
+      </IcCheckboxGroup>
+      <br />
+      <div>textbox value :{textBoxValue}</div>
+    </div>
+  );
+};
+
+<Canvas>
+  <Story name="TextField value change">
+    <TextField />
   </Story>
 </Canvas>

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.stories.mdx
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.stories.mdx
@@ -459,3 +459,42 @@ import readme from "./readme.md";
     }
   </Story>
 </Canvas>
+
+### TextField value change
+
+<Canvas>
+  <Story name="TextField value change" parameters={{ loki: { skip: true } }}>
+    {(args) =>
+      html`
+        <script>
+          var textOutputEl = document.querySelector("#value-text");
+          function handleIcChange(ev) {
+            textOutputEl.innerHTML = ev.target.value;
+          }
+          document
+            .querySelector("ic-text-field")
+            .addEventListener("icChange", handleIcChange);
+        </script>
+        <div>
+          <ic-checkbox-group label="This is a label" name="group1">
+            <ic-checkbox
+              value="valueName1"
+              label="Unselected / Default"
+              additional-field-display="static"
+            >
+              <ic-text-field
+                slot="additional-field"
+                placeholder="Placeholder"
+                label="What's your favourite type of coffee?"
+              ></ic-text-field>
+            </ic-checkbox>
+          </ic-checkbox-group>
+          <br />
+          <span>textfield value: </span>
+          <span id="value-text"></span>
+          <div></div>
+        </div>
+      `
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.tsx
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.tsx
@@ -81,6 +81,15 @@ export class CheckboxGroup {
    */
   @Event() icChange: EventEmitter<IcChangeEventDetail>;
 
+  @Listen("icChange")
+  handleChange(ev: CustomEvent): void {
+    //don't pass on the event if it has come from slotted text field
+    //otherwise any icChange handler bound to the checkbox group will also run
+    if ((ev.target as HTMLElement).tagName === "IC-TEXT-FIELD") {
+      ev.stopImmediatePropagation();
+    }
+  }
+
   componentWillLoad(): void {
     removeDisabledFalse(this.disabled, this.el);
   }

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -140,9 +140,6 @@ export class Checkbox {
     removeDisabledFalse(this.disabled, this.el);
 
     addFormResetListener(this.el, this.handleFormReset);
-    this.el
-      .querySelector(this.IC_TEXT_FIELD)
-      ?.addEventListener("icChange", this.eventHandler);
   }
 
   componentDidLoad(): void {
@@ -174,9 +171,6 @@ export class Checkbox {
 
   disconnectedCallback(): void {
     removeFormResetListener(this.el, this.handleFormReset);
-    this.el
-      .querySelector(this.IC_TEXT_FIELD)
-      ?.removeEventListener("icChange", this.eventHandler);
   }
 
   /**
@@ -190,10 +184,6 @@ export class Checkbox {
       checkboxEl.focus();
     }
   }
-
-  private eventHandler = (event: CustomEvent) => {
-    event.stopImmediatePropagation();
-  };
 
   private handleClick = () => {
     this.checked = !this.checked;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
fixes issue where icchange event would not fire for a textfield, when slotted in a checkbox as an additional field

## Related issue
#1252 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.