### PR TITLE
feat(web-components): added default no results state to select

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -367,6 +367,9 @@ export class Select {
 
     if (!this.options.length) {
       this.initialOptionsEmpty = true;
+      this.noOptions = [{ label: this.emptyOptionListText, value: "" }];
+      this.uniqueOptions = this.noOptions;
+      this.filteredOptions = this.noOptions;
     } else {
       this.setDefaultValue();
       this.uniqueOptions = this.deduplicateOptions(this.options);
@@ -616,6 +619,7 @@ export class Select {
       } else if (
         !this.hasTimedOut &&
         !this.loading &&
+        !this.noOptions?.length &&
         (!this.searchable || this.searchableMenuItemSelected)
       ) {
         this.noOptions = null;
@@ -772,9 +776,12 @@ export class Select {
       );
     }
 
-    if (!isGrouped) {
+    if (
+      !isGrouped &&
+      menuOptionsFiltered[0]?.label !== this.emptyOptionListText
+    ) {
       newFilteredOptions = menuOptionsFiltered;
-    } else {
+    } else if (isGrouped) {
       options.map((option) => {
         if (this.includeGroupTitlesInSearch) {
           if (menuOptionsFiltered.indexOf(option) !== -1) {
@@ -799,13 +806,11 @@ export class Select {
       });
     }
 
-    const noOptions = [{ label: this.emptyOptionListText, value: "" }];
-
     if (newFilteredOptions.length > 0 && !noChildOptionsWhenFiltered) {
       this.noOptions = null;
       this.filteredOptions = newFilteredOptions;
     } else {
-      this.noOptions = noOptions;
+      this.noOptions = [{ label: this.emptyOptionListText, value: "" }];
       this.filteredOptions = this.noOptions;
     }
   };
@@ -965,16 +970,13 @@ export class Select {
       currValue,
     } = this;
 
-    const noOptionSelect =
-      searchable &&
-      (this.loading ||
-        this.hasTimedOut ||
-        (this.noOptions !== null &&
-          this.noOptions[0] &&
-          this.noOptions[0].label === this.emptyOptionListText));
-    const inputValue = this.searchable ? this.hiddenInputValue : currValue;
-
-    renderHiddenInput(true, this.el, name, inputValue, disabled);
+    renderHiddenInput(
+      true,
+      this.el,
+      name,
+      this.searchable ? this.hiddenInputValue : currValue,
+      disabled
+    );
 
     const invalid =
       validationStatus === IcInformationStatus.Error ? "true" : "false";
@@ -1215,7 +1217,12 @@ export class Select {
           {!isMobileOrTablet() && (
             <ic-menu
               class={{
-                "no-results": noOptionSelect,
+                "no-results":
+                  this.loading ||
+                  this.hasTimedOut ||
+                  (this.noOptions !== null &&
+                    this.noOptions[0] &&
+                    this.noOptions[0].label === this.emptyOptionListText),
               }}
               ref={(el) => (this.menu = el)}
               inputEl={

--- a/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
@@ -78,7 +78,21 @@ exports[`ic-select searchable should render as required: required-searchable 1`]
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-26-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-26-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-26" type="hidden" value="">
@@ -109,7 +123,21 @@ exports[`ic-select should have correct validation status: with-validation-status
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-3-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-3-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
       <ic-input-validation arialivemode="polite" for="ic-select-input-3" message="" status="error"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -141,7 +169,21 @@ exports[`ic-select should not have a validation status if disabled: no-validatio
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-4-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-4-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" disabled="" name="ic-select-input-4" type="hidden" value="">
@@ -171,7 +213,21 @@ exports[`ic-select should not render a label when the 'hide-label' prop is suppl
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-0-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-0-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-0" type="hidden" value="">
@@ -202,7 +258,21 @@ exports[`ic-select should not render validation text if no validation status has
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-6-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-6-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-6" type="hidden" value="">
@@ -233,7 +303,21 @@ exports[`ic-select should render correct validation text: with-validation-text 1
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-5-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-5-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
       <ic-input-validation arialivemode="polite" for="ic-select-input-5" message="Test validation text" status="error"></ic-input-validation>
     </ic-input-container>
   </mock:shadow-root>
@@ -254,7 +338,21 @@ exports[`ic-select should render readonly: readonly 1`] = `
           </ic-typography>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-2-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-2-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-2" type="hidden" value="">
@@ -285,7 +383,21 @@ exports[`ic-select should test select as submit on form 1`] = `
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu></ic-menu>
+      <ic-menu class="no-results">
+        <ul aria-activedescendant="ic-select-input-1-menu-test-value" aria-label="IC Select Test" class="menu" id="ic-select-input-1-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-1-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  <p>
+                    No results found
+                  </p>
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-1" type="hidden" value="test-value">
@@ -327,7 +439,7 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
           </div>
         </div>
       </ic-input-component-container>
-      <ic-menu>
+      <ic-menu class="no-results">
         <ul aria-activedescendant="ic-select-input-7-menu-test-value" aria-label="IC Select Test" class="menu" id="ic-select-input-7-menu" role="listbox" tabindex="-1">
           <li aria-disabled="false" aria-label="Test label 1" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-7-menu-Test value 1" role="option" tabindex="-1">
             <div class="option-text-container">

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.e2e.ts
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.e2e.ts
@@ -1147,6 +1147,21 @@ describe("ic-select", () => {
         expect(icRetryLoad).toHaveReceivedEvent;
         expect(await getMenuVisibility(page)).toBe("visible");
       });
+
+      it("should render a No results message if no options are provided on render", async () => {
+        const page = await newE2EPage();
+        await page.setContent(getTestSelect(`[]`));
+        await page.waitForChanges();
+
+        const select = await page.find("ic-select >>> #ic-select-input-0");
+        await select.click();
+        await page.waitForChanges();
+
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const menuOptions = await menu.findAll("li");
+        expect(menuOptions).toHaveLength(1);
+        expect(menuOptions[0]).toEqualText("No results found");
+      });
     });
   });
 
@@ -2002,6 +2017,21 @@ describe("ic-select", () => {
           "ic-select >>> #ic-select-input-0-menu li"
         );
         expect(firstOption).toBeNull;
+      });
+
+      it("should render a No results message if no options are provided on render", async () => {
+        const page = await newE2EPage();
+        await page.setContent(getTestSearchableSelect(`[]`));
+        await page.waitForChanges();
+
+        const select = await page.find("ic-select >>> #ic-select-input-0");
+        await select.click();
+        await page.waitForChanges();
+
+        const menu = await page.find("ic-select >>> #ic-select-input-0-menu");
+        const menuOptions = await menu.findAll("li");
+        expect(menuOptions).toHaveLength(1);
+        expect(menuOptions[0]).toEqualText("No results found");
       });
     });
   });

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
@@ -1743,9 +1743,17 @@ describe("ic-select searchable", () => {
     ) as HTMLIcButtonElement;
     clearButton.click();
     await page.waitForChanges();
-    expect(page.rootInstance.filteredOptions).toHaveLength(0);
+    expect(page.rootInstance.filteredOptions).toHaveLength(1);
+    expect(page.rootInstance.filteredOptions[0]).toMatchObject({
+      label: noResults,
+      value: "",
+    });
     await waitForTimeout(1000);
-    expect(page.rootInstance.filteredOptions).toHaveLength(0);
+    expect(page.rootInstance.filteredOptions).toHaveLength(1);
+    expect(page.rootInstance.filteredOptions[0]).toMatchObject({
+      label: noResults,
+      value: "",
+    });
   });
 
   it("should clear the searchable input if the value is programatically set to undefined", async () => {

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -115,27 +115,22 @@ export const removeHiddenInput = (container: HTMLElement): void => {
   input?.remove();
 };
 
-export const hasShadowDom = (el: HTMLElement): boolean => {
-  return !!el.shadowRoot && !!el.attachShadow;
-};
+export const hasShadowDom = (el: HTMLElement): boolean =>
+  !!el.shadowRoot && !!el.attachShadow;
 
-export const getInputHelperTextID = (id: string): string => {
-  return id + "-helper-text";
-};
+export const getInputHelperTextID = (id: string): string => id + "-helper-text";
 
-export const getInputValidationTextID = (id: string): string => {
-  return id + "-validation-text";
-};
+export const getInputValidationTextID = (id: string): string =>
+  id + "-validation-text";
 
 export const getInputDescribedByText = (
   inputId: string,
   helperText: boolean,
   validationText: boolean
-): string => {
-  return `${helperText ? getInputHelperTextID(inputId) : ""} ${
+): string =>
+  `${helperText ? getInputHelperTextID(inputId) : ""} ${
     validationText ? getInputValidationTextID(inputId) : ""
   }`.trim();
-};
 
 /**
  * This method helps to understand the context in which a component exists,
@@ -183,13 +178,8 @@ export const getThemeFromContext = (
   return IcThemeForegroundEnum.Default;
 };
 
-export const isMobileOrTablet = (): boolean => {
-  let isMobileOrTablet = false;
-  if ("maxTouchPoints" in navigator) {
-    isMobileOrTablet = navigator.maxTouchPoints > 0;
-  }
-  return isMobileOrTablet;
-};
+export const isMobileOrTablet = (): boolean =>
+  "maxTouchPoints" in navigator ? navigator.maxTouchPoints > 0 : false;
 
 /**
  * Will create a button within the lightDOM which interacts with the parent form.
@@ -213,18 +203,12 @@ export const handleHiddenFormButtonClick = (
   hiddenFormButton.remove();
 };
 
-export const isEmptyString = (value: string): boolean => {
-  if (!value) {
-    return true;
-  }
-
-  return value.trim().length === 0;
-};
+export const isEmptyString = (value: string): boolean =>
+  value ? value.trim().length === 0 : true;
 
 // A helper function that checks if a prop has been defined
-export const isPropDefined = (prop: string) => {
-  return prop !== undefined ? prop : null;
-};
+export const isPropDefined = (prop: string): string | null =>
+  prop !== undefined ? prop : null;
 
 /**
  * Extracts the label using the value from an object. Requires the object to have a label and value property.
@@ -235,15 +219,9 @@ export const isPropDefined = (prop: string) => {
 export const getLabelFromValue = (
   value: string,
   options: IcMenuOption[],
-  valueField?: string,
-  labelField?: string
+  valueField = "value",
+  labelField = "label"
 ): string | undefined => {
-  if (valueField === undefined) {
-    valueField = "value";
-  }
-  if (labelField === undefined) {
-    labelField = "label";
-  }
   const ungroupedOptions: IcMenuOption[] = [];
   if (options.length > 0 && options.map) {
     options.map((option) => {
@@ -255,14 +233,10 @@ export const getLabelFromValue = (
         ungroupedOptions.push(option);
       }
     });
-    if (
-      ungroupedOptions.find((option) => option[valueField] === value) !==
-      undefined
-    ) {
-      return ungroupedOptions.find((option) => option[valueField] === value)[
-        labelField
-      ];
-    }
+    const matchingValue = ungroupedOptions.find(
+      (option) => option[valueField] === value
+    );
+    if (matchingValue !== undefined) return matchingValue[labelField];
   }
 
   return undefined;
@@ -281,50 +255,23 @@ export const getFilteredMenuOptions = (
   includeDescriptions: boolean,
   searchString: string,
   position: IcSearchMatchPositions,
-  labelField?: string
-): IcMenuOption[] => {
-  let rawFilteredOptions;
+  labelField = "label"
+): IcMenuOption[] =>
+  options.filter((option) => {
+    const label: string = option[labelField].toLowerCase();
+    const description = option.description?.toLowerCase();
+    const lowerSearchString = searchString.toLowerCase();
 
-  if (labelField === undefined) {
-    labelField = "label";
-  }
-
-  if (position === "anywhere") {
-    rawFilteredOptions = options.filter((option) => {
-      if (includeDescriptions) {
-        return (
-          option[labelField]
-            .toLowerCase()
-            .includes(searchString.toLowerCase()) ||
-          option.description?.toLowerCase().includes(searchString.toLowerCase())
-        );
-      } else {
-        return option[labelField]
-          .toLowerCase()
-          .includes(searchString.toLowerCase());
-      }
-    });
-  } else {
-    rawFilteredOptions = options.filter((option) => {
-      if (includeDescriptions) {
-        return (
-          option[labelField]
-            .toLowerCase()
-            .startsWith(searchString.toLowerCase()) ||
-          option.description
-            ?.toLowerCase()
-            .startsWith(searchString.toLowerCase())
-        );
-      } else {
-        return option[labelField]
-          .toLowerCase()
-          .startsWith(searchString.toLowerCase());
-      }
-    });
-  }
-
-  return rawFilteredOptions;
-};
+    return position === "anywhere"
+      ? includeDescriptions
+        ? label.includes(lowerSearchString) ||
+          description?.includes(lowerSearchString)
+        : label.includes(lowerSearchString)
+      : includeDescriptions
+      ? label.startsWith(lowerSearchString) ||
+        description?.startsWith(lowerSearchString)
+      : label.startsWith(lowerSearchString);
+  });
 
 export const deviceSizeMatches = (size: number): boolean =>
   window.matchMedia(`(max-width: ${size}px)`).matches;
@@ -346,9 +293,8 @@ export const getCurrentDeviceSize = (): number => {
   return DEVICE_SIZES.UNDEFINED;
 };
 
-export const getCssProperty = (cssVar: string): string => {
-  return getComputedStyle(document.documentElement).getPropertyValue(cssVar);
-};
+export const getCssProperty = (cssVar: string): string =>
+  getComputedStyle(document.documentElement).getPropertyValue(cssVar);
 
 /**
  * Returns the brightness of the theme colour, calculated by using the theme RGB CSS values by:
@@ -373,11 +319,10 @@ export const getThemeColorBrightness = (): number => {
  * Returns if dark or light foreground colors should be used for color contrast reasons
  * @returns "dark" or "light"
  */
-export const getThemeForegroundColor = (): IcThemeForeground => {
-  return getThemeColorBrightness() > DARK_MODE_THRESHOLD
+export const getThemeForegroundColor = (): IcThemeForeground =>
+  getThemeColorBrightness() > DARK_MODE_THRESHOLD
     ? IcThemeForegroundEnum.Dark
     : IcThemeForegroundEnum.Light;
-};
 
 export const getSlot = (element: HTMLElement, name: string): Element | null => {
   if (element && element.querySelector) {
@@ -454,11 +399,10 @@ export const hasValidationStatus = (
   return status !== "" && !disabled;
 };
 
-export const isSlotUsed = (element: HTMLElement, slotName: string): boolean => {
-  return Array.from(element.children).some(
+export const isSlotUsed = (element: HTMLElement, slotName: string): boolean =>
+  Array.from(element.children).some(
     (child) => child.getAttribute("slot") === slotName
   );
-};
 
 // added as a common method to allow detection of gatsby hydration issue, where (camelCase) props are initially undefined & then update
 // with a value. Allows a callback function to be executed when this is the case
@@ -562,9 +506,9 @@ export const rgbaStrToObj = (rgbaStr: string): IcColorRGBA => {
   return colorRGBA;
 };
 
-export const elementOverflowsX = (element: HTMLElement): boolean => {
-  return element.scrollWidth > element.clientWidth;
-};
+export const elementOverflowsX = (element: HTMLElement): boolean =>
+  element.scrollWidth > element.clientWidth;
+
 /**
  *
  * @param child - The child element
@@ -576,15 +520,10 @@ export const getParentElementType = (child: HTMLElement): string =>
 export const getParentElement = (child: HTMLElement): HTMLElement =>
   child.parentElement;
 
-export const hasClassificationBanner = (): boolean => {
-  return document.querySelector("ic-classification-banner:not([inline='true'])")
-    ? true
-    : false;
-};
+export const hasClassificationBanner = (): boolean =>
+  !!document.querySelector("ic-classification-banner:not([inline='true'])");
 
-export const getForm = (el: HTMLElement): HTMLFormElement | null => {
-  return el.closest("FORM");
-};
+export const getForm = (el: HTMLElement): HTMLFormElement => el.closest("FORM");
 
 export const addFormResetListener = (
   el: HTMLElement,
@@ -606,10 +545,8 @@ export const removeFormResetListener = (
   }
 };
 
-export const pxToRem = (px: string, base = 16): string => {
-  const tempPx = parseInt(px);
-  return `${(1 / base) * tempPx}rem`;
-};
+export const pxToRem = (px: string, base = 16): string =>
+  `${(1 / base) * parseInt(px)}rem`;
 
 export const removeDisabledFalse = (
   disabled: boolean,


### PR DESCRIPTION
## Summary of the changes
When no options are provided initially, select will now populate the menu with the no results option. Made some adjustments to when the no-results class is applied to the menu to accommodate this case.

Also refactored some functions to be cleaner

## Related issue
#1207 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] A11y unit test added and yields no issues.
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.