### PR TITLE
fix(web-components): update text field to not call watchValueHandler on first load

### DIFF
--- a/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
@@ -918,3 +918,21 @@ import readme from "./readme.md";
     }
   </Story>
 </Canvas>
+
+### Logging icChange
+
+<Canvas>
+  <Story name="Logging icChange" parameters={{ loki: { skip: true } }}>
+    {(args) =>
+      html`<script>
+          function handleIcChange(ev) {
+            console.log(ev.detail.value, "icChange");
+          }
+          document
+            .querySelector("ic-text-field")
+            .addEventListener("icChange", handleIcChange);
+        </script>
+        <ic-text-field label="What is your favourite coffee?"> </ic-text-field>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -266,28 +266,8 @@ export class TextField {
       this.inputEl.value = newValue;
     }
 
-    this.numChars = newValue.length;
+    this.getMaxLengthExceeded(newValue);
 
-    if (this.type === "number") {
-      if (newValue && Number(newValue) < Number(this.min)) {
-        this.minValueUnattained = true;
-      } else {
-        this.minValueUnattained = false;
-      }
-      if (Number(newValue) > Number(this.max)) {
-        this.maxValueExceeded = true;
-      } else {
-        this.maxValueExceeded = false;
-      }
-    }
-
-    if (this.maxLength > 0) {
-      if (newValue.length > this.maxLength) {
-        this.maxLengthExceeded = true;
-      } else {
-        this.maxLengthExceeded = false;
-      }
-    }
     this.icChange.emit({ value: newValue });
   }
 
@@ -330,7 +310,11 @@ export class TextField {
   }
 
   componentWillLoad(): void {
-    this.watchValueHandler(this.value);
+    if (this.value !== this.initialValue) {
+      this.watchValueHandler(this.value);
+    }
+
+    this.getMaxLengthExceeded(this.value);
 
     this.inheritedAttributes = inheritAttributes(this.el, [
       ...IC_INHERITED_ARIA,
@@ -373,6 +357,20 @@ export class TextField {
       this.inputEl.focus();
     }
   }
+
+  private getMaxLengthExceeded = (value: string) => {
+    this.numChars = value.length;
+
+    if (this.type === "number") {
+      this.minValueUnattained =
+        value && Number(value) < Number(this.min) ? true : false;
+      this.maxValueExceeded = Number(value) > Number(this.max) ? true : false;
+    }
+
+    if (this.maxLength > 0) {
+      this.maxLengthExceeded = value.length > this.maxLength ? true : false;
+    }
+  };
 
   private onInput = (ev: Event) => {
     this.value = (ev.target as HTMLInputElement).value;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update text field to not call watchValueHandler on first load and move max length exceeded code into its own function so that it can be called in componentWillLoad and the watchValueHandler. Added a web component story logging out icChange

## Related issue
#1163

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.