### PR TITLE
fix(web-components): removed unnecessary margin from active indicator…

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -257,10 +257,14 @@ svg {
   left: 0;
   width: var(--ic-space-xs);
   height: 2.5rem;
-  margin-top: 0.25rem;
-  margin-right: 0.313rem;
   background-color: var(--ic-action-default);
   transition: left 0s;
+}
+
+:host(.navigation-item-top-nav-child-selected) .link::before,
+:host(.navigation-item-side-menu-selected) .link::before,
+:host(.navigation-item-side-menu-selected) .link:focus::before {
+  margin-top: 0.25rem;
 }
 
 :host(.navigation-item-top-nav-child-selected) .link:focus {


### PR DESCRIPTION
… on ic-navigation-item

## Summary of the changes
Active indicator had unnecessary margin that caused it to misalign with its content

## Related issue
https://github.com/mi6/ic-design-system/issues/604

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met.