### PR TITLE
fix(web-components): add conditional check to navigation buttons in top nav

### DIFF
--- a/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.css
+++ b/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.css
@@ -59,7 +59,11 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--ic-space-xs);
-  margin: var(--ic-space-md) var(--ic-space-md) var(--ic-space-xl);
+  padding: var(--ic-space-md) var(--ic-space-md) var(--ic-space-xl);
+}
+
+.status-version-no-buttons {
+  border-top: var(--ic-space-1px) solid var(--ic-architectural-200);
 }
 
 .menu-status {

--- a/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.tsx
+++ b/packages/web-components/src/components/ic-navigation-menu/ic-navigation-menu.tsx
@@ -207,7 +207,12 @@ export class NavigationMenu {
             </div>
           )}
           {(this.status !== "" || this.version !== "") && (
-            <div class="menu-status-version-container">
+            <div
+              class={{
+                ["menu-status-version-container"]: true,
+                ["status-version-no-buttons"]: !this.hasButtons,
+              }}
+            >
               {this.status !== "" && (
                 <div class="menu-status">
                   <ic-typography

--- a/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`ic-navigation-menu should render with version and status: renders-with-
           </ic-button>
         </div>
       </nav>
-      <div class="menu-status-version-container">
+      <div class="menu-status-version-container status-version-no-buttons">
         <div class="menu-status">
           <ic-typography aria-label="app tag" class="menu-status-text" variant="label-uppercase">
             Beta
@@ -120,7 +120,7 @@ exports[`ic-navigation-menu should test slotted link: renders-with-slotted-link 
         </div>
         <slot name="navigation"></slot>
       </nav>
-      <div class="menu-status-version-container">
+      <div class="menu-status-version-container status-version-no-buttons">
         <div class="menu-status">
           <ic-typography aria-label="app tag" class="menu-status-text" variant="label-uppercase">
             Beta
@@ -237,7 +237,7 @@ exports[`ic-navigation-menu should test slotted navigation group: renders-with-s
         </div>
         <slot name="navigation"></slot>
       </nav>
-      <div class="menu-status-version-container">
+      <div class="menu-status-version-container status-version-no-buttons">
         <div class="menu-status">
           <ic-typography aria-label="app tag" class="menu-status-text" variant="label-uppercase">
             Beta
@@ -284,7 +284,7 @@ exports[`ic-navigation-menu should test slotted navigation item: renders-with-sl
         </div>
         <slot name="navigation"></slot>
       </nav>
-      <div class="menu-status-version-container">
+      <div class="menu-status-version-container status-version-no-buttons">
         <div class="menu-status">
           <ic-typography aria-label="app tag" class="menu-status-text" variant="label-uppercase">
             Beta

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -514,9 +514,11 @@ export class TopNavigation {
               ["inline"]: this.inline,
             }}
           >
-            <div class="menu-buttons-slot" slot="buttons">
-              <slot name="buttons"></slot>
-            </div>
+            {this.hasIconButtons && (
+              <div class="menu-buttons-slot" slot="buttons">
+                <slot name="buttons"></slot>
+              </div>
+            )}
             <ul slot="navigation">
               <slot name="navigation"></slot>
             </ul>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add conditional check to navigation buttons in top navigation so that it doesn't appear as two dividers if there are no navigation buttons on small devices

## Related issue
#1299

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.