### PR TITLE
fix(web-components): open ic-dialog during initialisation using the open prop

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-12-04T12:40:14",
+  "timestamp": "2023-12-08T14:47:48",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.3.0",

--- a/packages/react/src/stories/ic-dialog.stories.mdx
+++ b/packages/react/src/stories/ic-dialog.stories.mdx
@@ -739,3 +739,55 @@ export const dropdownItems = () => {
     </IcDialog>
   </Story>
 </Canvas>
+
+### Hidden close button
+
+export const showHiddenCloseButtonDialog = () => {
+  const dialog = document.querySelector("#hidden-close-button-dialog");
+  dialog.open = true;
+};
+
+<Canvas>
+  <Story name="Hidden close button" parameters={{ loki: { skip: true } }}>
+    <IcButton variant="primary" onClick={showHiddenCloseButtonDialog}>
+      Launch dialog with hidden close button
+    </IcButton>
+    <IcDialog
+      id="hidden-close-button-dialog"
+      heading="This dialog does not have a close button"
+      label="Hidden Close Button Dialog"
+      hideCloseButton
+    >
+      <IcTypography>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </IcTypography>
+    </IcDialog>
+  </Story>
+</Canvas>
+
+### Auto opening
+
+export const showAutoOpenCloseButtonDialog = () => {
+  const dialog = document.querySelector("#auto-opening-dialog");
+  dialog.open = true;
+};
+
+<Canvas>
+  <Story name="Auto Opening" parameters={{ loki: { skip: true } }}>
+    <IcButton variant="primary" onClick={showAutoOpenCloseButtonDialog}>
+      Launch auto opening dialog
+    </IcButton>
+    <IcDialog
+      id="auto-opening-dialog"
+      heading="This dialog opens automatically using the open prop"
+      label="Auto opening dialog"
+      open
+    >
+      <IcTypography>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </IcTypography>
+    </IcDialog>
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.stories.mdx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.stories.mdx
@@ -540,35 +540,6 @@ import readme from "./readme.md";
   </Story>
 </Canvas>
 
-### Hidden close button
-
-<Canvas>
-  <Story name="Hidden close button" parameters={{ loki: { skip: true } }}>
-    {html`
-      <script>
-        function showHiddenCloseButtonDialog() {
-          dialog = document.querySelector("#hidden-close-button-dialog");
-          dialog.open = true;
-        }
-      </script>
-      <ic-button variant="primary" onclick="showHiddenCloseButtonDialog()"
-        >Launch dialog with hidden close button</ic-button
-      >
-      <ic-dialog
-        id="hidden-close-button-dialog"
-        heading="This dialog does not have a close button"
-        label="Hidden Close Button Dialog"
-        hide-close-button
-      >
-        <ic-typography>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </ic-typography>
-      </ic-dialog>
-    `}
-  </Story>
-</Canvas>
-
 ### Events example
 
 <Canvas>
@@ -1215,6 +1186,64 @@ import readme from "./readme.md";
         <ic-button class="show">Show</ic-button>
         <ic-button class="hide">Hide</ic-button>
         <div id="base"></div>
+      </ic-dialog>
+    `}
+  </Story>
+</Canvas>
+
+### Hidden close button
+
+<Canvas>
+  <Story name="Hidden close button" parameters={{ loki: { skip: true } }}>
+    {html`
+      <script>
+        function showHiddenCloseButtonDialog() {
+          dialog = document.querySelector("#hidden-close-button-dialog");
+          dialog.open = true;
+        }
+      </script>
+      <ic-button variant="primary" onclick="showHiddenCloseButtonDialog()"
+        >Launch dialog with hidden close button</ic-button
+      >
+      <ic-dialog
+        id="hidden-close-button-dialog"
+        heading="This dialog does not have a close button"
+        label="Hidden Close Button Dialog"
+        hide-close-button
+      >
+        <ic-typography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </ic-typography>
+      </ic-dialog>
+    `}
+  </Story>
+</Canvas>
+
+### Auto opening
+
+<Canvas>
+  <Story name="Auto Opening" parameters={{ loki: { skip: true } }}>
+    {html`
+      <script>
+        function showAutoOpenCloseButtonDialog() {
+          dialog = document.querySelector("#auto-opening-dialog");
+          dialog.open = true;
+        }
+      </script>
+      <ic-button variant="primary" onclick="showAutoOpenCloseButtonDialog()"
+        >Launch auto opening dialog</ic-button
+      >
+      <ic-dialog
+        id="auto-opening-dialog"
+        heading="This dialog opens automatically using the open prop"
+        label="Auto opening dialog"
+        open
+      >
+        <ic-typography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </ic-typography>
       </ic-dialog>
     `}
   </Story>

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
@@ -117,38 +117,7 @@ export class Dialog {
   @Watch("open")
   watchOpenHandler(): void {
     if (this.open) {
-      this.dialogRendered = true;
-
-      if (this.disableHeightConstraint) {
-        this.dialogEl.show();
-      } else {
-        this.dialogEl.showModal();
-      }
-
-      setTimeout(() => {
-        this.fadeIn = true;
-
-        /**
-         * This is required to set scroll back to top if:
-         * - dialog content goes below the fold
-         * - is closed using cancel or confirm and reopened.
-         *
-         * Without this, the scroll bar will start from the dialog's last scroll-x coordinate.
-         */
-        if (this.disableHeightConstraint && this.backdropEl.scrollTop !== 0) {
-          this.backdropEl.scrollTop = 0;
-        }
-      }, 10);
-
-      setTimeout(() => {
-        this.setInitialFocus();
-        checkResizeObserver(this.runResizeObserver);
-      }, 75);
-
-      setTimeout(() => {
-        this.getFocusedElementIndex();
-        this.icDialogOpened.emit();
-      }, 80);
+      this.dialogOpened();
     } else {
       this.fadeIn = false;
       if (this.resizeObserver !== null) {
@@ -225,6 +194,10 @@ export class Dialog {
     this.setAlertVariant();
 
     this.refreshInteractiveElementsOnSlotChange();
+
+    if (this.open) {
+      this.dialogOpened();
+    }
   }
 
   componentDidRender(): void {
@@ -307,6 +280,41 @@ export class Dialog {
   async confirmDialog(): Promise<void> {
     this.icDialogConfirmed.emit();
   }
+
+  private dialogOpened = () => {
+    this.dialogRendered = true;
+
+    if (this.disableHeightConstraint) {
+      this.dialogEl.show();
+    } else {
+      this.dialogEl.showModal();
+    }
+
+    setTimeout(() => {
+      this.fadeIn = true;
+
+      /**
+       * This is required to set scroll back to top if:
+       * - dialog content goes below the fold
+       * - is closed using cancel or confirm and reopened.
+       *
+       * Without this, the scroll bar will start from the dialog's last scroll-x coordinate.
+       */
+      if (this.disableHeightConstraint && this.backdropEl.scrollTop !== 0) {
+        this.backdropEl.scrollTop = 0;
+      }
+    }, 10);
+
+    setTimeout(() => {
+      this.setInitialFocus();
+      checkResizeObserver(this.runResizeObserver);
+    }, 75);
+
+    setTimeout(() => {
+      this.getFocusedElementIndex();
+      this.icDialogOpened.emit();
+    }, 80);
+  };
 
   private runResizeObserver = () => {
     this.resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
## Summary of the changes
A new open prop has recently been added to the IcDialog component, which replaces the deprecated showDialog and hideDialog methods.

The trouble is, when an instance of an IcDialog component is initialised using the new open prop, with open="true", the dialog remains hidden. This is because the dialog is only made visible when the value of the open prop changes, i.e. when it is assigned a different value after the component has been initialised (which happens in the watchOpenHandler method).

In particular, this causes a problem for testing IcDialog based components using Cypress component tests, as it is currently not possible to instantiate a component using a prop of open="true" and then just go ahead and run assertions in Cypress, as a change of state is needed for the open prop to make the dialog visible in the tests, which involves some hacky and unreliable workarounds to get it working.

The small change in this PR fixes the issue. Now, if users of the IcDialog component pass in open="true", then the dialog is made visible during initialisation within the componentDidLoad function, reusing the existing code that executes whenever the watchOpenHandler is executed.

## Related issue
N/A

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.