### PR TITLE
fix(web-components): hides tooltips for navigation buttons on menu

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -202,6 +202,7 @@ export class Button {
 
   componentWillUpdate(): void {
     this.loadingWidth();
+    this.setHasTooltip();
   }
 
   componentWillLoad(): void {
@@ -226,8 +227,7 @@ export class Button {
 
     const id = this.el.id;
     this.id = id !== undefined ? id : null;
-    this.hasTooltip =
-      !this.disableTooltip && (!!this.title || this.variant === "icon");
+    this.setHasTooltip();
 
     if (!this.hasTooltip) {
       const describedById = this.inheritedAttributes[
@@ -393,6 +393,11 @@ export class Button {
     if (forceComponentUpdate) {
       forceUpdate(this);
     }
+  };
+
+  private setHasTooltip = (): void => {
+    this.hasTooltip =
+      !this.disableTooltip && (!!this.title || this.variant === "icon");
   };
 
   render() {

--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -278,6 +278,43 @@ exports[`button component should test button as submit button on form 1`] = `
 </ic-button>
 `;
 
+exports[`button component should test tooltip visibility changes when disable tooltip prop changes 1`] = `
+<ic-button class="button-size-default button-variant-icon light" exportparts="button" id="test-button" variant="icon">
+  <mock:shadow-root>
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-label="Tooltip text" class="button" part="button" type="button">
+        <slot></slot>
+      </button>
+    </ic-tooltip>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should test tooltip visibility changes when disable tooltip prop changes 2`] = `
+<ic-button class="button-size-default button-variant-icon light" exportparts="button" id="test-button" variant="icon">
+  <mock:shadow-root>
+    <button aria-label="Tooltip text" class="button" part="button" type="button">
+      <slot></slot>
+    </button>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
+exports[`button component should test tooltip visibility changes when disable tooltip prop changes 3`] = `
+<ic-button class="button-size-default button-variant-icon light" exportparts="button" id="test-button" variant="icon">
+  <mock:shadow-root>
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-label="Tooltip text" class="button" part="button" type="button">
+        <slot></slot>
+      </button>
+    </ic-tooltip>
+  </mock:shadow-root>
+  Button
+</ic-button>
+`;
+
 exports[`button component should update aria-expanded when attribute changed 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
+++ b/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
@@ -344,6 +344,24 @@ describe("button component", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should test tooltip visibility changes when disable tooltip prop changes", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: "<ic-button variant='icon' aria-label='Tooltip text' id='test-button'>Button</ic-button>",
+    });
+    expect(page.root).toMatchSnapshot();
+
+    page.root.disableTooltip = true;
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+
+    page.root.disableTooltip = false;
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
   it("should test blur handler", async () => {
     const page = await newSpecPage({
       components: [Button],

--- a/packages/web-components/src/components/ic-navigation-button/ic-navigation-button.tsx
+++ b/packages/web-components/src/components/ic-navigation-button/ic-navigation-button.tsx
@@ -137,6 +137,7 @@ export class NavigationButton {
       this.initialAppearance;
     let size: "default" | "large" = "large";
     let fullWidth = false;
+    let disableTooltip = false;
 
     if (this.mode === "menu") {
       label = this.label;
@@ -145,6 +146,7 @@ export class NavigationButton {
       size = "default";
       fullWidth = true;
       className = "popout-menu-button";
+      disableTooltip = true;
     }
 
     const buttonProps = {
@@ -157,6 +159,7 @@ export class NavigationButton {
       download,
       referrerpolicy,
       fullWidth,
+      disableTooltip,
     };
 
     return (


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Hides tooltips for top navigation icon buttons, when on popout menu

## Related issue
#1267 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.