### PR TITLE
1348 side nav expanded event should appear in docs

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-12-22T11:45:54",
+  "timestamp": "2024-01-04T14:22:30",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.9.0",
@@ -189,13 +189,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-accordion": [
-          "ic-typography"
-        ]
+        "ic-accordion": ["ic-typography"]
       }
     },
     {
@@ -361,25 +357,12 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-accordion-group": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-accordion-group": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -611,31 +594,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-dialog"
-      ],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependents": ["ic-dialog"],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-alert": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-dialog": [
-          "ic-alert"
-        ]
+        "ic-alert": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-dialog": ["ic-alert"]
       }
     },
     {
@@ -682,13 +648,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-back-to-top": [
-          "ic-typography"
-        ]
+        "ic-back-to-top": ["ic-typography"]
       }
     },
     {
@@ -1058,13 +1020,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-badge": [
-          "ic-typography"
-        ]
+        "ic-badge": ["ic-typography"]
       }
     },
     {
@@ -1180,19 +1138,11 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-breadcrumb-group"
-      ],
-      "dependencies": [
-        "ic-link"
-      ],
+      "dependents": ["ic-breadcrumb-group"],
+      "dependencies": ["ic-link"],
       "dependencyGraph": {
-        "ic-breadcrumb": [
-          "ic-link"
-        ],
-        "ic-breadcrumb-group": [
-          "ic-breadcrumb"
-        ]
+        "ic-breadcrumb": ["ic-link"],
+        "ic-breadcrumb-group": ["ic-breadcrumb"]
       }
     },
     {
@@ -1293,16 +1243,10 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-breadcrumb"
-      ],
+      "dependencies": ["ic-breadcrumb"],
       "dependencyGraph": {
-        "ic-breadcrumb-group": [
-          "ic-breadcrumb"
-        ],
-        "ic-breadcrumb": [
-          "ic-link"
-        ]
+        "ic-breadcrumb-group": ["ic-breadcrumb"],
+        "ic-breadcrumb": ["ic-link"]
       }
     },
     {
@@ -2025,66 +1969,26 @@
         "ic-toast",
         "ic-top-navigation"
       ],
-      "dependencies": [
-        "ic-loading-indicator",
-        "ic-tooltip"
-      ],
+      "dependencies": ["ic-loading-indicator", "ic-tooltip"],
       "dependencyGraph": {
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-accordion-group": [
-          "ic-button"
-        ],
-        "ic-alert": [
-          "ic-button"
-        ],
-        "ic-card": [
-          "ic-button"
-        ],
-        "ic-dialog": [
-          "ic-button"
-        ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-menu": [
-          "ic-button"
-        ],
-        "ic-menu-item": [
-          "ic-button"
-        ],
-        "ic-navigation-button": [
-          "ic-button"
-        ],
-        "ic-navigation-menu": [
-          "ic-button"
-        ],
-        "ic-pagination": [
-          "ic-button"
-        ],
-        "ic-search-bar": [
-          "ic-button"
-        ],
-        "ic-select": [
-          "ic-button"
-        ],
-        "ic-side-navigation": [
-          "ic-button"
-        ],
-        "ic-toast": [
-          "ic-button"
-        ],
-        "ic-top-navigation": [
-          "ic-button"
-        ]
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-accordion-group": ["ic-button"],
+        "ic-alert": ["ic-button"],
+        "ic-card": ["ic-button"],
+        "ic-dialog": ["ic-button"],
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-menu": ["ic-button"],
+        "ic-menu-item": ["ic-button"],
+        "ic-navigation-button": ["ic-button"],
+        "ic-navigation-menu": ["ic-button"],
+        "ic-pagination": ["ic-button"],
+        "ic-search-bar": ["ic-button"],
+        "ic-select": ["ic-button"],
+        "ic-side-navigation": ["ic-button"],
+        "ic-toast": ["ic-button"],
+        "ic-top-navigation": ["ic-button"]
       }
     },
     {
@@ -2524,25 +2428,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-card": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-card": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -3029,13 +2920,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-checkbox": [
-          "ic-typography"
-        ]
+        "ic-checkbox": ["ic-typography"]
       }
     },
     {
@@ -3344,21 +3231,11 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-input-label",
-        "ic-input-validation"
-      ],
+      "dependencies": ["ic-input-label", "ic-input-validation"],
       "dependencyGraph": {
-        "ic-checkbox-group": [
-          "ic-input-label",
-          "ic-input-validation"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ]
+        "ic-checkbox-group": ["ic-input-label", "ic-input-validation"],
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"]
       }
     },
     {
@@ -3633,18 +3510,10 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-tooltip"
-      ],
+      "dependencies": ["ic-typography", "ic-tooltip"],
       "dependencyGraph": {
-        "ic-chip": [
-          "ic-typography",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-chip": ["ic-typography", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -3803,13 +3672,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-classification-banner": [
-          "ic-typography"
-        ]
+        "ic-classification-banner": ["ic-typography"]
       }
     },
     {
@@ -3921,13 +3786,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-data-entity": [
-          "ic-typography"
-        ]
+        "ic-data-entity": ["ic-typography"]
       }
     },
     {
@@ -4076,13 +3937,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-data-row": [
-          "ic-typography"
-        ]
+        "ic-data-row": ["ic-typography"]
       }
     },
     {
@@ -4658,31 +4515,13 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button",
-        "ic-alert"
-      ],
+      "dependencies": ["ic-typography", "ic-button", "ic-alert"],
       "dependencyGraph": {
-        "ic-dialog": [
-          "ic-typography",
-          "ic-button",
-          "ic-alert"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-alert": [
-          "ic-typography",
-          "ic-button"
-        ]
+        "ic-dialog": ["ic-typography", "ic-button", "ic-alert"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-alert": ["ic-typography", "ic-button"]
       }
     },
     {
@@ -4707,14 +4546,10 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-side-navigation"
-      ],
+      "dependents": ["ic-side-navigation"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-side-navigation": [
-          "ic-divider"
-        ]
+        "ic-side-navigation": ["ic-divider"]
       }
     },
     {
@@ -4934,13 +4769,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-empty-state": [
-          "ic-typography"
-        ]
+        "ic-empty-state": ["ic-typography"]
       }
     },
     {
@@ -5169,15 +5000,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-section-container",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-section-container", "ic-typography"],
       "dependencyGraph": {
-        "ic-footer": [
-          "ic-section-container",
-          "ic-typography"
-        ]
+        "ic-footer": ["ic-section-container", "ic-typography"]
       }
     },
     {
@@ -5432,15 +5257,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-section-container"
-      ],
+      "dependencies": ["ic-typography", "ic-section-container"],
       "dependencyGraph": {
-        "ic-footer-link-group": [
-          "ic-typography",
-          "ic-section-container"
-        ]
+        "ic-footer-link-group": ["ic-typography", "ic-section-container"]
       }
     },
     {
@@ -5765,15 +5584,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-section-container",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-section-container", "ic-typography"],
       "dependencyGraph": {
-        "ic-hero": [
-          "ic-section-container",
-          "ic-typography"
-        ]
+        "ic-hero": ["ic-section-container", "ic-typography"]
       }
     },
     {
@@ -5829,37 +5642,16 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-page-header",
-        "ic-tab-group",
-        "ic-top-navigation"
-      ],
-      "dependencies": [
-        "ic-button"
-      ],
+      "dependents": ["ic-page-header", "ic-tab-group", "ic-top-navigation"],
+      "dependencies": ["ic-button"],
       "dependencyGraph": {
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-page-header": [
-          "ic-horizontal-scroll"
-        ],
-        "ic-tab-group": [
-          "ic-horizontal-scroll"
-        ],
-        "ic-top-navigation": [
-          "ic-horizontal-scroll"
-        ]
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-page-header": ["ic-horizontal-scroll"],
+        "ic-tab-group": ["ic-horizontal-scroll"],
+        "ic-top-navigation": ["ic-horizontal-scroll"]
       }
     },
     {
@@ -6160,18 +5952,11 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-select",
-        "ic-text-field"
-      ],
+      "dependents": ["ic-select", "ic-text-field"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-select": [
-          "ic-input-component-container"
-        ],
-        "ic-text-field": [
-          "ic-input-component-container"
-        ]
+        "ic-select": ["ic-input-component-container"],
+        "ic-text-field": ["ic-input-component-container"]
       }
     },
     {
@@ -6234,18 +6019,11 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-select",
-        "ic-text-field"
-      ],
+      "dependents": ["ic-select", "ic-text-field"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-select": [
-          "ic-input-container"
-        ],
-        "ic-text-field": [
-          "ic-input-container"
-        ]
+        "ic-select": ["ic-input-container"],
+        "ic-text-field": ["ic-input-container"]
       }
     },
     {
@@ -6478,28 +6256,14 @@
         "ic-switch",
         "ic-text-field"
       ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-checkbox-group": [
-          "ic-input-label"
-        ],
-        "ic-radio-group": [
-          "ic-input-label"
-        ],
-        "ic-select": [
-          "ic-input-label"
-        ],
-        "ic-switch": [
-          "ic-input-label"
-        ],
-        "ic-text-field": [
-          "ic-input-label"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-checkbox-group": ["ic-input-label"],
+        "ic-radio-group": ["ic-input-label"],
+        "ic-select": ["ic-input-label"],
+        "ic-switch": ["ic-input-label"],
+        "ic-text-field": ["ic-input-label"]
       }
     },
     {
@@ -6671,25 +6435,13 @@
         "ic-select",
         "ic-text-field"
       ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-checkbox-group": [
-          "ic-input-validation"
-        ],
-        "ic-radio-group": [
-          "ic-input-validation"
-        ],
-        "ic-select": [
-          "ic-input-validation"
-        ],
-        "ic-text-field": [
-          "ic-input-validation"
-        ]
+        "ic-input-validation": ["ic-typography"],
+        "ic-checkbox-group": ["ic-input-validation"],
+        "ic-radio-group": ["ic-input-validation"],
+        "ic-select": ["ic-input-validation"],
+        "ic-text-field": ["ic-input-validation"]
       }
     },
     {
@@ -6980,14 +6732,10 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-breadcrumb"
-      ],
+      "dependents": ["ic-breadcrumb"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-breadcrumb": [
-          "ic-link"
-        ]
+        "ic-breadcrumb": ["ic-link"]
       }
     },
     {
@@ -7271,31 +7019,14 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-button",
-        "ic-menu",
-        "ic-step",
-        "ic-toast"
-      ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependents": ["ic-button", "ic-menu", "ic-step", "ic-toast"],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator"
-        ],
-        "ic-menu": [
-          "ic-loading-indicator"
-        ],
-        "ic-step": [
-          "ic-loading-indicator"
-        ],
-        "ic-toast": [
-          "ic-loading-indicator"
-        ]
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator"],
+        "ic-menu": ["ic-loading-indicator"],
+        "ic-step": ["ic-loading-indicator"],
+        "ic-toast": ["ic-loading-indicator"]
       }
     },
     {
@@ -7717,37 +7448,15 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-search-bar",
-        "ic-select"
-      ],
-      "dependencies": [
-        "ic-loading-indicator",
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependents": ["ic-search-bar", "ic-select"],
+      "dependencies": ["ic-loading-indicator", "ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-menu": [
-          "ic-loading-indicator",
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-search-bar": [
-          "ic-menu"
-        ],
-        "ic-select": [
-          "ic-menu"
-        ]
+        "ic-menu": ["ic-loading-indicator", "ic-typography", "ic-button"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-search-bar": ["ic-menu"],
+        "ic-select": ["ic-menu"]
       }
     },
     {
@@ -7788,13 +7497,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-menu-group": [
-          "ic-typography"
-        ]
+        "ic-menu-group": ["ic-typography"]
       }
     },
     {
@@ -8114,31 +7819,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-popover-menu"
-      ],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependents": ["ic-popover-menu"],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-menu-item": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-popover-menu": [
-          "ic-menu-item"
-        ]
+        "ic-menu-item": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-popover-menu": ["ic-menu-item"]
       }
     },
     {
@@ -8406,23 +8094,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-button"
-      ],
+      "dependencies": ["ic-button"],
       "dependencyGraph": {
-        "ic-navigation-button": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-navigation-button": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -8531,13 +8208,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-navigation-group": [
-          "ic-typography"
-        ]
+        "ic-navigation-group": ["ic-typography"]
       }
     },
     {
@@ -8823,18 +8496,10 @@
         }
       ],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-tooltip"
-      ],
+      "dependencies": ["ic-typography", "ic-tooltip"],
       "dependencyGraph": {
-        "ic-navigation-item": [
-          "ic-typography",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-navigation-item": ["ic-typography", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -8933,31 +8598,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-top-navigation"
-      ],
-      "dependencies": [
-        "ic-button",
-        "ic-typography"
-      ],
+      "dependents": ["ic-top-navigation"],
+      "dependencies": ["ic-button", "ic-typography"],
       "dependencyGraph": {
-        "ic-navigation-menu": [
-          "ic-button",
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-top-navigation": [
-          "ic-navigation-menu"
-        ]
+        "ic-navigation-menu": ["ic-button", "ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-top-navigation": ["ic-navigation-menu"]
       }
     },
     {
@@ -9288,19 +8936,10 @@
           "ic-typography",
           "ic-horizontal-scroll"
         ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -9654,28 +9293,13 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-button",
-        "ic-pagination-item"
-      ],
+      "dependencies": ["ic-button", "ic-pagination-item"],
       "dependencyGraph": {
-        "ic-pagination": [
-          "ic-button",
-          "ic-pagination-item"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-pagination-item": [
-          "ic-typography"
-        ]
+        "ic-pagination": ["ic-button", "ic-pagination-item"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-pagination-item": ["ic-typography"]
       }
     },
     {
@@ -9896,19 +9520,11 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-pagination"
-      ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependents": ["ic-pagination"],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-pagination-item": [
-          "ic-typography"
-        ],
-        "ic-pagination": [
-          "ic-pagination-item"
-        ]
+        "ic-pagination-item": ["ic-typography"],
+        "ic-pagination": ["ic-pagination-item"]
       }
     },
     {
@@ -10031,29 +9647,13 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-menu-item",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-menu-item", "ic-typography"],
       "dependencyGraph": {
-        "ic-popover-menu": [
-          "ic-menu-item",
-          "ic-typography"
-        ],
-        "ic-menu-item": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-popover-menu": ["ic-menu-item", "ic-typography"],
+        "ic-menu-item": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -10390,21 +9990,11 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-input-label",
-        "ic-input-validation"
-      ],
+      "dependencies": ["ic-input-label", "ic-input-validation"],
       "dependencyGraph": {
-        "ic-radio-group": [
-          "ic-input-label",
-          "ic-input-validation"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ]
+        "ic-radio-group": ["ic-input-label", "ic-input-validation"],
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"]
       }
     },
     {
@@ -10833,13 +10423,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-radio-option": [
-          "ic-typography"
-        ]
+        "ic-radio-option": ["ic-typography"]
       }
     },
     {
@@ -12063,17 +11649,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-text-field",
-        "ic-button",
-        "ic-menu"
-      ],
+      "dependencies": ["ic-text-field", "ic-button", "ic-menu"],
       "dependencyGraph": {
-        "ic-search-bar": [
-          "ic-text-field",
-          "ic-button",
-          "ic-menu"
-        ],
+        "ic-search-bar": ["ic-text-field", "ic-button", "ic-menu"],
         "ic-text-field": [
           "ic-input-container",
           "ic-input-label",
@@ -12081,27 +11659,12 @@
           "ic-input-validation",
           "ic-typography"
         ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-menu": [
-          "ic-loading-indicator",
-          "ic-typography",
-          "ic-button"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-menu": ["ic-loading-indicator", "ic-typography", "ic-button"]
       }
     },
     {
@@ -12188,21 +11751,11 @@
       ],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-footer": [
-          "ic-section-container"
-        ],
-        "ic-footer-link-group": [
-          "ic-section-container"
-        ],
-        "ic-hero": [
-          "ic-section-container"
-        ],
-        "ic-page-header": [
-          "ic-section-container"
-        ],
-        "ic-top-navigation": [
-          "ic-section-container"
-        ]
+        "ic-footer": ["ic-section-container"],
+        "ic-footer-link-group": ["ic-section-container"],
+        "ic-hero": ["ic-section-container"],
+        "ic-page-header": ["ic-section-container"],
+        "ic-top-navigation": ["ic-section-container"]
       }
     },
     {
@@ -13216,27 +12769,12 @@
           "ic-menu",
           "ic-input-validation"
         ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-menu": [
-          "ic-loading-indicator",
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-menu": ["ic-loading-indicator", "ic-typography", "ic-button"],
+        "ic-input-validation": ["ic-typography"]
       }
     },
     {
@@ -13484,7 +13022,28 @@
         }
       ],
       "methods": [],
-      "events": [],
+      "events": [
+        {
+          "event": "sideNavExpanded",
+          "detail": "IcExpandedDetail",
+          "bubbles": true,
+          "complexType": {
+            "original": "IcExpandedDetail",
+            "resolved": "IcExpandedDetail",
+            "references": {
+              "IcExpandedDetail": {
+                "location": "import",
+                "path": "./ic-side-navigation.types",
+                "id": "src/components/ic-side-navigation/ic-side-navigation.types.ts::IcExpandedDetail"
+              }
+            }
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Emitted when the side navigation is collapsed and expanded.",
+          "docsTags": []
+        }
+      ],
       "listeners": [
         {
           "event": "themeChange",
@@ -13520,27 +13079,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button",
-        "ic-divider"
-      ],
+      "dependencies": ["ic-typography", "ic-button", "ic-divider"],
       "dependencyGraph": {
-        "ic-side-navigation": [
-          "ic-typography",
-          "ic-button",
-          "ic-divider"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-side-navigation": ["ic-typography", "ic-button", "ic-divider"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -13888,13 +13432,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-status-tag": [
-          "ic-typography"
-        ]
+        "ic-status-tag": ["ic-typography"]
       }
     },
     {
@@ -14029,18 +13569,10 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-loading-indicator",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-loading-indicator", "ic-typography"],
       "dependencyGraph": {
-        "ic-step": [
-          "ic-loading-indicator",
-          "ic-typography"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ]
+        "ic-step": ["ic-loading-indicator", "ic-typography"],
+        "ic-loading-indicator": ["ic-typography"]
       }
     },
     {
@@ -14508,18 +14040,10 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-input-label",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-input-label", "ic-typography"],
       "dependencyGraph": {
-        "ic-switch": [
-          "ic-input-label",
-          "ic-typography"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ]
+        "ic-switch": ["ic-input-label", "ic-typography"],
+        "ic-input-label": ["ic-typography"]
       }
     },
     {
@@ -14602,13 +14126,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-tab": [
-          "ic-typography"
-        ]
+        "ic-tab": ["ic-typography"]
       }
     },
     {
@@ -14896,26 +14416,13 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-horizontal-scroll"
-      ],
+      "dependencies": ["ic-horizontal-scroll"],
       "dependencyGraph": {
-        "ic-tab-group": [
-          "ic-horizontal-scroll"
-        ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-tab-group": ["ic-horizontal-scroll"],
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -16101,9 +15608,7 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-search-bar"
-      ],
+      "dependents": ["ic-search-bar"],
       "dependencies": [
         "ic-input-container",
         "ic-input-label",
@@ -16119,15 +15624,9 @@
           "ic-input-validation",
           "ic-typography"
         ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-search-bar": [
-          "ic-text-field"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"],
+        "ic-search-bar": ["ic-text-field"]
       }
     },
     {
@@ -16434,27 +15933,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-loading-indicator",
-        "ic-button"
-      ],
+      "dependencies": ["ic-typography", "ic-loading-indicator", "ic-button"],
       "dependencyGraph": {
-        "ic-toast": [
-          "ic-typography",
-          "ic-loading-indicator",
-          "ic-button"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-toast": ["ic-typography", "ic-loading-indicator", "ic-button"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -16791,27 +16275,13 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-button",
-        "ic-chip",
-        "ic-navigation-item"
-      ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependents": ["ic-button", "ic-chip", "ic-navigation-item"],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-tooltip"
-        ],
-        "ic-chip": [
-          "ic-tooltip"
-        ],
-        "ic-navigation-item": [
-          "ic-tooltip"
-        ]
+        "ic-tooltip": ["ic-typography"],
+        "ic-button": ["ic-tooltip"],
+        "ic-chip": ["ic-tooltip"],
+        "ic-navigation-item": ["ic-tooltip"]
       }
     },
     {
@@ -17022,7 +16492,22 @@
         }
       ],
       "methods": [],
-      "events": [],
+      "events": [
+        {
+          "event": "topNavResized",
+          "detail": "{ size: number; }",
+          "bubbles": true,
+          "complexType": {
+            "original": "{ size: number }",
+            "resolved": "{ size: number; }",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Emitted when the top navigation is resized.",
+          "docsTags": []
+        }
+      ],
       "listeners": [
         {
           "event": "icNavigationMenuClose",
@@ -17094,23 +16579,11 @@
           "ic-horizontal-scroll",
           "ic-navigation-menu"
         ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-navigation-menu": [
-          "ic-button",
-          "ic-typography"
-        ]
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-navigation-menu": ["ic-button", "ic-typography"]
       }
     },
     {
@@ -17392,123 +16865,45 @@
       ],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-accordion": [
-          "ic-typography"
-        ],
-        "ic-accordion-group": [
-          "ic-typography"
-        ],
-        "ic-alert": [
-          "ic-typography"
-        ],
-        "ic-back-to-top": [
-          "ic-typography"
-        ],
-        "ic-badge": [
-          "ic-typography"
-        ],
-        "ic-card": [
-          "ic-typography"
-        ],
-        "ic-checkbox": [
-          "ic-typography"
-        ],
-        "ic-chip": [
-          "ic-typography"
-        ],
-        "ic-classification-banner": [
-          "ic-typography"
-        ],
-        "ic-data-entity": [
-          "ic-typography"
-        ],
-        "ic-data-row": [
-          "ic-typography"
-        ],
-        "ic-dialog": [
-          "ic-typography"
-        ],
-        "ic-empty-state": [
-          "ic-typography"
-        ],
-        "ic-footer": [
-          "ic-typography"
-        ],
-        "ic-footer-link-group": [
-          "ic-typography"
-        ],
-        "ic-hero": [
-          "ic-typography"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-menu": [
-          "ic-typography"
-        ],
-        "ic-menu-group": [
-          "ic-typography"
-        ],
-        "ic-menu-item": [
-          "ic-typography"
-        ],
-        "ic-navigation-group": [
-          "ic-typography"
-        ],
-        "ic-navigation-item": [
-          "ic-typography"
-        ],
-        "ic-navigation-menu": [
-          "ic-typography"
-        ],
-        "ic-page-header": [
-          "ic-typography"
-        ],
-        "ic-pagination-item": [
-          "ic-typography"
-        ],
-        "ic-popover-menu": [
-          "ic-typography"
-        ],
-        "ic-radio-option": [
-          "ic-typography"
-        ],
-        "ic-select": [
-          "ic-typography"
-        ],
-        "ic-side-navigation": [
-          "ic-typography"
-        ],
-        "ic-status-tag": [
-          "ic-typography"
-        ],
-        "ic-step": [
-          "ic-typography"
-        ],
-        "ic-switch": [
-          "ic-typography"
-        ],
-        "ic-tab": [
-          "ic-typography"
-        ],
-        "ic-text-field": [
-          "ic-typography"
-        ],
-        "ic-toast": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-top-navigation": [
-          "ic-typography"
-        ]
+        "ic-accordion": ["ic-typography"],
+        "ic-accordion-group": ["ic-typography"],
+        "ic-alert": ["ic-typography"],
+        "ic-back-to-top": ["ic-typography"],
+        "ic-badge": ["ic-typography"],
+        "ic-card": ["ic-typography"],
+        "ic-checkbox": ["ic-typography"],
+        "ic-chip": ["ic-typography"],
+        "ic-classification-banner": ["ic-typography"],
+        "ic-data-entity": ["ic-typography"],
+        "ic-data-row": ["ic-typography"],
+        "ic-dialog": ["ic-typography"],
+        "ic-empty-state": ["ic-typography"],
+        "ic-footer": ["ic-typography"],
+        "ic-footer-link-group": ["ic-typography"],
+        "ic-hero": ["ic-typography"],
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-menu": ["ic-typography"],
+        "ic-menu-group": ["ic-typography"],
+        "ic-menu-item": ["ic-typography"],
+        "ic-navigation-group": ["ic-typography"],
+        "ic-navigation-item": ["ic-typography"],
+        "ic-navigation-menu": ["ic-typography"],
+        "ic-page-header": ["ic-typography"],
+        "ic-pagination-item": ["ic-typography"],
+        "ic-popover-menu": ["ic-typography"],
+        "ic-radio-option": ["ic-typography"],
+        "ic-select": ["ic-typography"],
+        "ic-side-navigation": ["ic-typography"],
+        "ic-status-tag": ["ic-typography"],
+        "ic-step": ["ic-typography"],
+        "ic-switch": ["ic-typography"],
+        "ic-tab": ["ic-typography"],
+        "ic-text-field": ["ic-typography"],
+        "ic-toast": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-top-navigation": ["ic-typography"]
       }
     }
   ],
@@ -17712,6 +17107,11 @@
       "declaration": "export type IcMenuItemVariants = \"toggle\" | \"destructive\" | \"default\";",
       "docstring": "",
       "path": "src/components/ic-menu-item/ic-menu-item.types.ts"
+    },
+    "src/components/ic-side-navigation/ic-side-navigation.types.ts::IcExpandedDetail": {
+      "declaration": "export interface IcExpandedDetail {\n  sideNavExpanded: boolean;\n  sideNavMobile: boolean;\n}",
+      "docstring": "",
+      "path": "src/components/ic-side-navigation/ic-side-navigation.types.ts"
     },
     "src/components/ic-pagination/ic-pagination.types.ts::IcPaginationTypes": {
       "declaration": "export type IcPaginationTypes = \"simple\" | \"complex\";",

--- a/packages/react/src/stories/ic-side-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-side-navigation.stories.mdx
@@ -509,6 +509,88 @@ export const Controlled = () => {
   </Story>
 </Canvas>
 
+### Side nav expanded event
+
+<Canvas>
+  <Story name="Side nav expanded event">
+    <IcSideNavigation
+      appTitle="ACME"
+      version="v0.0.0"
+      status="BETA"
+      onSideNavExpanded={(event) => console.log(event.detail.sideNavExpanded)}
+    >
+      <svg
+        slot="app-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        fill="#000000"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+      </svg>
+      <IcNavigationItem
+        slot="primary-navigation"
+        href="/"
+        label="Home"
+        selected
+      >
+        <IcBadge text-label="1" slot="badge" variant="light" />
+        <svg
+          slot="icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+            fill="currentColor"
+          />
+        </svg>
+      </IcNavigationItem>
+      <IcNavigationGroup
+        slot="primary-navigation"
+        label="Navigation Group"
+        expandable="true"
+      >
+        <IcNavigationItem href="/" label="Item 1">
+          <svg
+            slot="icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+              fill="currentColor"
+            />
+          </svg>
+        </IcNavigationItem>
+      </IcNavigationGroup>
+      <IcNavigationItem slot="secondary-navigation" href="/" label="Settings">
+        <svg
+          slot="icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+            fill="currentColor"
+          />
+        </svg>
+      </IcNavigationItem>
+    </IcSideNavigation>
+  </Story>
+</Canvas>
+
 ### React Router
 
 export const HomePage = () => (

--- a/packages/react/src/stories/ic-top-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-top-navigation.stories.mdx
@@ -337,6 +337,29 @@ export const Controlled = () => {
   );
 };
 
+### Top nav resized event
+
+<Canvas>
+  <Story name="Top nav resized event" parameters={{ layout: "fullscreen" }}>
+    <IcTopNavigation
+      appTitle="ApplicationName"
+      onTopNavResized={() => console.log(event.detail.size)}
+    >
+      <svg
+        slot="app-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        fill="#000000"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+      </svg>
+    </IcTopNavigation>
+  </Story>
+</Canvas>
+
 ### Theming
 
 <Canvas>

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -22,6 +22,7 @@ import { IcMenuItemVariants } from "./components/ic-menu-item/ic-menu-item.types
 import { IcChangeEventDetail as IcChangeEventDetail1, IcPaginationTypes } from "./components/ic-pagination/ic-pagination.types";
 import { IcPaginationItemType } from "./components/ic-pagination-item/ic-pagination-item.types";
 import { IcChangeEventDetail as IcChangeEventDetail2 } from "./components/ic-radio-group/ic-radio-group.types";
+import { IcExpandedDetail } from "./components/ic-side-navigation/ic-side-navigation.types";
 import { IcSkeletonVariants } from "./components/ic-skeleton/ic-skeleton.types";
 import { IcStatusTagAppearance, IcStatusTagStatuses } from "./components/ic-status-tag/ic-status-tag.types";
 import { IcStepStatuses, IcStepTypes, IcStepVariants } from "./components/ic-step/ic-step.types";
@@ -47,6 +48,7 @@ export { IcMenuItemVariants } from "./components/ic-menu-item/ic-menu-item.types
 export { IcChangeEventDetail as IcChangeEventDetail1, IcPaginationTypes } from "./components/ic-pagination/ic-pagination.types";
 export { IcPaginationItemType } from "./components/ic-pagination-item/ic-pagination-item.types";
 export { IcChangeEventDetail as IcChangeEventDetail2 } from "./components/ic-radio-group/ic-radio-group.types";
+export { IcExpandedDetail } from "./components/ic-side-navigation/ic-side-navigation.types";
 export { IcSkeletonVariants } from "./components/ic-skeleton/ic-skeleton.types";
 export { IcStatusTagAppearance, IcStatusTagStatuses } from "./components/ic-status-tag/ic-status-tag.types";
 export { IcStepStatuses, IcStepTypes, IcStepVariants } from "./components/ic-step/ic-step.types";
@@ -2300,6 +2302,10 @@ export interface IcSelectCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLIcSelectElement;
 }
+export interface IcSideNavigationCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLIcSideNavigationElement;
+}
 export interface IcSwitchCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLIcSwitchElement;
@@ -2841,7 +2847,18 @@ declare global {
         prototype: HTMLIcSelectElement;
         new (): HTMLIcSelectElement;
     };
+    interface HTMLIcSideNavigationElementEventMap {
+        "sideNavExpanded": IcExpandedDetail;
+    }
     interface HTMLIcSideNavigationElement extends Components.IcSideNavigation, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLIcSideNavigationElementEventMap>(type: K, listener: (this: HTMLIcSideNavigationElement, ev: IcSideNavigationCustomEvent<HTMLIcSideNavigationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLIcSideNavigationElementEventMap>(type: K, listener: (this: HTMLIcSideNavigationElement, ev: IcSideNavigationCustomEvent<HTMLIcSideNavigationElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLIcSideNavigationElement: {
         prototype: HTMLIcSideNavigationElement;
@@ -3024,6 +3041,7 @@ declare global {
     interface HTMLIcTopNavigationElementEventMap {
         "icNavigationMenuClosed": void;
         "icNavigationMenuOpened": void;
+        "topNavResized": { size: number };
     }
     interface HTMLIcTopNavigationElement extends Components.IcTopNavigation, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIcTopNavigationElementEventMap>(type: K, listener: (this: HTMLIcTopNavigationElement, ev: IcTopNavigationCustomEvent<HTMLIcTopNavigationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4878,6 +4896,10 @@ declare namespace LocalJSX {
         "href"?: string;
         "inline"?: boolean;
         /**
+          * Emitted when the side navigation is collapsed and expanded.
+         */
+        "onSideNavExpanded"?: (event: IcSideNavigationCustomEvent<IcExpandedDetail>) => void;
+        /**
           * The short title of the app to be displayed at small screen sizes in place of the app title.
          */
         "shortAppTitle"?: string;
@@ -5340,6 +5362,10 @@ declare namespace LocalJSX {
         "inline"?: boolean;
         "onIcNavigationMenuClosed"?: (event: IcTopNavigationCustomEvent<void>) => void;
         "onIcNavigationMenuOpened"?: (event: IcTopNavigationCustomEvent<void>) => void;
+        /**
+          * Emitted when the top navigation is resized.
+         */
+        "onTopNavResized"?: (event: IcTopNavigationCustomEvent<{ size: number }>) => void;
         /**
           * The short title of the app to be displayed at small screen sizes in place of the app title.
          */

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.stories.mdx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.stories.mdx
@@ -1892,3 +1892,308 @@ import readme from "./readme.md";
     `}
   </Story>
 </Canvas>
+
+### Side nav expanded event
+
+<Canvas>
+  <Story
+    name="Side nav expanded event"
+    parameters={{ loki: { skip: true }, layout: "fullscreen" }}
+  >
+    {html`<script>
+        var sideNav = document.querySelector("ic-side-navigation");
+        sideNav.addEventListener("sideNavExpanded", function (event) {
+          console.log(event.detail.sideNavExpanded);
+        });
+      </script>
+      <div style="display:flex; height:100%;">
+        <ic-side-navigation
+          app-title="Application Name"
+          version="v0.0.0"
+          status="BETA"
+        >
+          <svg
+            slot="app-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            fill="#000000"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"
+            />
+          </svg>
+          <ic-navigation-item
+            slot="primary-navigation"
+            href="/"
+            label="Daily TippersDaily TippersDaily TippersDaily TippersDaily TippersDaily TippersDaily TippersDaily TippersDaily Tippers"
+          >
+            <svg
+              slot="icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </ic-navigation-item>
+          <ic-navigation-item
+            slot="primary-navigation"
+            href="/"
+            label="Search"
+            selected="true"
+          >
+            <svg
+              slot="icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </ic-navigation-item>
+          <ic-divider slot="primary-navigation"></ic-divider>
+          <ic-navigation-item
+            slot="primary-navigation"
+            href="/"
+            label="Aliquam facilisis eros dolor, id laoreet orci sagittis ut. Sed tempus, lacus in pretium molestie, lectus magna interdum risus, vel fringilla libero ex eu dui. Suspendisse ullamcorper vehicula lacinia. Phasellus congue velit nisl, vitae congue ligula rutrum id."
+          >
+            <svg
+              slot="icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </ic-navigation-item>
+          <ic-navigation-group
+            slot="primary-navigation"
+            label="Second navigation group"
+            expandable="true"
+          >
+            <ic-navigation-item label="Different navigation" href="/">
+              <svg
+                slot="icon"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M23 8C23 9.1 22.1 10 21 10C20.82 10 20.65 9.98 20.49 9.93L16.93 13.48C16.98 13.64 17 13.82 17 14C17 15.1 16.1 16 15 16C13.9 16 13 15.1 13 14C13 13.82 13.02 13.64 13.07 13.48L10.52 10.93C10.36 10.98 10.18 11 10 11C9.82 11 9.64 10.98 9.48 10.93L4.93 15.49C4.98 15.65 5 15.82 5 16C5 17.1 4.1 18 3 18C1.9 18 1 17.1 1 16C1 14.9 1.9 14 3 14C3.18 14 3.35 14.02 3.51 14.07L8.07 9.52C8.02 9.36 8 9.18 8 9C8 7.9 8.9 7 10 7C11.1 7 12 7.9 12 9C12 9.18 11.98 9.36 11.93 9.52L14.48 12.07C14.64 12.02 14.82 12 15 12C15.18 12 15.36 12.02 15.52 12.07L19.07 8.51C19.02 8.35 19 8.18 19 8C19 6.9 19.9 6 21 6C22.1 6 23 6.9 23 8Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </ic-navigation-item>
+            <ic-navigation-item label="Navigation" href="/">
+              <ic-badge
+                text-label="1"
+                slot="badge"
+                variant="light"
+                position="far"
+              ></ic-badge>
+              <svg
+                slot="icon"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M23 8C23 9.1 22.1 10 21 10C20.82 10 20.65 9.98 20.49 9.93L16.93 13.48C16.98 13.64 17 13.82 17 14C17 15.1 16.1 16 15 16C13.9 16 13 15.1 13 14C13 13.82 13.02 13.64 13.07 13.48L10.52 10.93C10.36 10.98 10.18 11 10 11C9.82 11 9.64 10.98 9.48 10.93L4.93 15.49C4.98 15.65 5 15.82 5 16C5 17.1 4.1 18 3 18C1.9 18 1 17.1 1 16C1 14.9 1.9 14 3 14C3.18 14 3.35 14.02 3.51 14.07L8.07 9.52C8.02 9.36 8 9.18 8 9C8 7.9 8.9 7 10 7C11.1 7 12 7.9 12 9C12 9.18 11.98 9.36 11.93 9.52L14.48 12.07C14.64 12.02 14.82 12 15 12C15.18 12 15.36 12.02 15.52 12.07L19.07 8.51C19.02 8.35 19 8.18 19 8C19 6.9 19.9 6 21 6C22.1 6 23 6.9 23 8Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </ic-navigation-item>
+          </ic-navigation-group>
+          <ic-navigation-item
+            slot="primary-navigation"
+            href="/"
+            label="This is a very very very long label for the navigation item"
+          >
+            <svg
+              slot="icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </ic-navigation-item>
+          <ic-navigation-item
+            slot="secondary-navigation"
+            href="/"
+            label="Settings"
+          >
+            <svg
+              slot="icon"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </ic-navigation-item>
+        </ic-side-navigation>
+        <div
+          class="content-wrapper"
+          style="display:flex; flex-direction: column; flex-grow: 1;"
+        >
+          <main>
+            <ic-section-container>
+              <ic-typography
+                >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+                vestibulum venenatis facilisis. Nam tortor felis, auctor vel
+                ante quis, tempor interdum libero. In dictum sodales velit, eu
+                egestas arcu dignissim ac. Aliquam facilisis eros dolor, id
+                laoreet orci sagittis ut. Sed tempus, lacus in pretium molestie,
+                lectus magna interdum risus, vel fringilla libero ex eu dui.
+                Suspendisse ullamcorper vehicula lacinia. Phasellus congue velit
+                nisl, vitae congue ligula rutrum id.</ic-typography
+              >
+              <ic-typography
+                >Etiam in suscipit metus. Duis semper, sapien a molestie semper,
+                ex nibh porttitor tellus, vel molestie justo odio vel purus.
+                Curabitur porttitor, tortor sed semper sollicitudin, odio odio
+                congue tortor, eget pulvinar tellus nisl ac lacus. In ultricies
+                commodo lorem, a laoreet diam. Ut a mauris at tellus tincidunt
+                ullamcorper sit amet in metus. Aenean facilisis placerat dictum.
+                Phasellus mattis ante sollicitudin luctus iaculis. Nam porttitor
+                lobortis rhoncus. Nam nec malesuada purus, at pulvinar mauris.
+                Nam non lorem ante.</ic-typography
+              >
+              <ic-typography
+                >Donec aliquam eget mauris condimentum cursus. Nullam tempus a
+                urna in commodo. Proin mauris augue, viverra id finibus id,
+                vulputate in ante. Aliquam volutpat hendrerit tellus vitae
+                tristique. Donec pellentesque enim arcu, at feugiat mauris
+                venenatis vitae. Sed iaculis ut elit et ultrices. Donec diam
+                eros, iaculis ac est nec, tempus feugiat nisl. Suspendisse eget
+                interdum lorem. Phasellus pretium urna id elit pharetra
+                hendrerit.</ic-typography
+              >
+              <ic-typography
+                >Mauris blandit, mi ut posuere dapibus, est ante porttitor sem,
+                quis pretium velit ante nec felis. Vivamus efficitur scelerisque
+                dapibus. Nunc lacinia finibus laoreet. Praesent commodo augue
+                orci, congue rutrum velit malesuada gravida. Nunc magna mauris,
+                ornare nec nisl vel, faucibus euismod orci. Proin in augue vitae
+                nunc gravida consectetur. Pellentesque id malesuada ex, sit amet
+                imperdiet est. Duis erat nibh, lacinia vitae faucibus non,
+                aliquam in dolor. Nam interdum felis vitae feugiat posuere. Cras
+                volutpat molestie ipsum, sed auctor quam volutpat vitae. Vivamus
+                lobortis scelerisque libero vel scelerisque.</ic-typography
+              >
+              <ic-typography
+                >Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Praesent eget orci condimentum, tempus tortor posuere, lacinia
+                ex. Curabitur bibendum suscipit turpis vitae mollis. Ut laoreet
+                orci a risus facilisis porta. Orci varius natoque penatibus et
+                magnis dis parturient montes, nascetur ridiculus mus. Curabitur
+                a porttitor neque, ac dignissim velit. Morbi quis malesuada
+                massa, vitae sodales tellus. Aenean laoreet mattis lobortis. In
+                mauris erat, tincidunt in placerat sed, pretium ac tortor. Morbi
+                blandit lacus a leo vehicula aliquet.</ic-typography
+              >
+              <ic-typography
+                >Pellentesque aliquam risus vel eros maximus, at pellentesque mi
+                pretium. Etiam nec velit at orci varius porttitor. Aliquam
+                facilisis, elit non cursus fringilla, metus metus malesuada
+                lacus, at blandit nibh augue aliquet orci. Duis aliquam, est
+                eget sodales ullamcorper, eros turpis euismod nulla, sed
+                sollicitudin diam massa semper purus. Vivamus vel turpis ipsum.
+                Interdum et malesuada fames ac ante ipsum primis in faucibus.
+                Morbi euismod turpis dapibus quam fermentum condimentum. Mauris
+                ex orci, consequat quis tempor eu, finibus vitae eros. Ut eu
+                erat eu ipsum pulvinar cursus vel at dui. Etiam tincidunt quam
+                porta nulla suscipit vestibulum. Sed iaculis enim leo, et
+                aliquam justo feugiat in. Vivamus in ornare nulla, at tempor
+                massa. Sed et aliquam nisi.</ic-typography
+              >
+              <ic-typography
+                >Mauris tempus accumsan libero non tincidunt. Curabitur et leo
+                orci. Suspendisse molestie posuere leo vitae posuere. Cras
+                lacinia urna non erat gravida sagittis. Quisque dapibus arcu nec
+                sem pharetra convallis. Nullam sed arcu mollis, posuere elit at,
+                condimentum ligula. Nullam maximus nulla quam, ut euismod est
+                feugiat at. Quisque ut venenatis ex, in facilisis sapien.
+                Pellentesque in orci vitae metus iaculis venenatis. Nunc
+                porttitor tellus arcu, in posuere quam vulputate nec. Aenean in
+                venenatis ligula, non mollis quam. Suspendisse nec enim vel
+                massa finibus pretium et a urna. Etiam suscipit semper est, id
+                efficitur diam sollicitudin nec. Nullam nibh sapien, condimentum
+                ut laoreet et, euismod ac mi. Vestibulum tristique odio non
+                risus ullamcorper, et aliquam turpis varius. Nunc metus ex,
+                tempus a augue sit amet, interdum vulputate
+                libero.</ic-typography
+              >
+              <ic-typography
+                >Aenean convallis libero id magna congue pellentesque. Nulla
+                iaculis interdum porta. Aenean laoreet scelerisque nulla vel
+                molestie. Class aptent taciti sociosqu ad litora torquent per
+                conubia nostra, per inceptos himenaeos. Integer sollicitudin in
+                felis vitae rhoncus. Sed eu elementum massa. Cras ut accumsan
+                risus. Donec nec augue justo. Aenean sagittis luctus leo egestas
+                consectetur. Sed sit amet nisl quis felis volutpat facilisis ac
+                vitae tellus. Curabitur pharetra commodo consequat. Aliquam
+                consequat ipsum lacus, sed faucibus sapien mollis
+                vel.</ic-typography
+              >
+            </ic-section-container>
+          </main>
+          <ic-footer
+            description="The ICDS is maintained by the Design Practice Team. If you've got a question or want to feedback,
+              please get in touch."
+            caption="All content is available under the Open Government Licence v3.0, except source code and code examples which are available under the MIT Licence."
+          >
+            <ic-footer-link slot="link" href="/">Get Started</ic-footer-link>
+            <ic-footer-link slot="link" href="/">Accessibility</ic-footer-link>
+            <ic-footer-link slot="link" href="/">Styles</ic-footer-link>
+            <ic-footer-link slot="link" href="/">Components</ic-footer-link>
+            <ic-footer-link slot="link" href="/">Patterns</ic-footer-link>
+            <ic-footer-link slot="link" href="/">Design toolkit</ic-footer-link>
+            <div
+              slot="logo"
+              style="width:100px;height:100px;display:flex;align-items:center;justify-content:center;
+              background-color:var(--ic-theme-primary);color:var(--ic-theme-text);"
+            >
+              Logo
+            </div>
+          </ic-footer>
+          <ic-classification-banner
+            classification="official"
+          ></ic-classification-banner>
+        </div>
+      </div> `}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -6,6 +6,8 @@ import {
   State,
   Element,
   Listen,
+  Event,
+  EventEmitter,
 } from "@stencil/core";
 
 import menuIcon from "../../assets/hamburger-menu-icon.svg";
@@ -28,7 +30,7 @@ import {
   IcThemeForeground,
   IcThemeForegroundEnum,
 } from "../../utils/types";
-import { IcTopBar } from "./ic-side-navigation.types";
+import { IcTopBar, IcExpandedDetail } from "./ic-side-navigation.types";
 
 /**
  * @slot app-icon - Content will be rendered adjacent to the app title at the very top of the side navigation.
@@ -115,6 +117,11 @@ export class SideNavigation {
    */
   @Prop() version: string;
 
+  /**
+   * Emitted when the side navigation is collapsed and expanded.
+   */
+  @Event() sideNavExpanded: EventEmitter<IcExpandedDetail>;
+
   componentWillLoad(): void {
     if (this.expanded) {
       this.setMenuExpanded(true);
@@ -168,13 +175,10 @@ export class SideNavigation {
     sideNavExpanded: boolean;
     sideNavMobile?: boolean;
   }): void => {
-    const event = new CustomEvent("sideNavExpanded", {
-      detail: {
-        sideNavExpanded: objDetails.sideNavExpanded,
-        sideNavMobile: objDetails.sideNavMobile,
-      },
+    this.sideNavExpanded.emit({
+      sideNavExpanded: objDetails.sideNavExpanded,
+      sideNavMobile: objDetails.sideNavMobile,
     });
-    this.el.dispatchEvent(event);
   };
 
   private toggleMenu = (): void => {

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.types.ts
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.types.ts
@@ -8,3 +8,8 @@ export interface IcTopBar {
   isAppNameSubtitleVariant: boolean;
   appTitle: string;
 }
+
+export interface IcExpandedDetail {
+  sideNavExpanded: boolean;
+  sideNavMobile: boolean;
+}

--- a/packages/web-components/src/components/ic-side-navigation/readme.md
+++ b/packages/web-components/src/components/ic-side-navigation/readme.md
@@ -21,6 +21,13 @@
 | `version`                  | `version`                     | The version of the app to be displayed.                                                                             | `string`  | `undefined` |
 
 
+## Events
+
+| Event             | Description                                                 | Type                            |
+| ----------------- | ----------------------------------------------------------- | ------------------------------- |
+| `sideNavExpanded` | Emitted when the side navigation is collapsed and expanded. | `CustomEvent<IcExpandedDetail>` |
+
+
 ## Slots
 
 | Slot                     | Description                                                                                |

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.mdx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.mdx
@@ -870,3 +870,36 @@ import NavigationGroup from "../ic-navigation-group/readme.md";
     }
   </Story>
 </Canvas>
+
+### Top nav resized event
+
+<Canvas>
+  <Story
+    name="Top nav resized event"
+    parameters={{ loki: { skip: true }, layout: "fullscreen" }}
+  >
+    {(args) =>
+      html`<script>
+          var topNav = document.querySelector("ic-top-navigation");
+          topNav.addEventListener("topNavResized", function (event) {
+            console.log(event.detail.size);
+          });
+        </script>
+        <ic-top-navigation app-title="Application Name">
+          <svg
+            slot="app-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            fill="#000000"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"
+            />
+          </svg>
+        </ic-top-navigation>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -120,6 +120,11 @@ export class TopNavigation {
    */
   @Event() icNavigationMenuOpened: EventEmitter<void>;
 
+  /**
+   * Emitted when the top navigation is resized.
+   */
+  @Event() topNavResized: EventEmitter<{ size: number }>;
+
   disconnectedCallback(): void {
     if (this.resizeObserver !== null) {
       this.resizeObserver.disconnect();
@@ -218,11 +223,6 @@ export class TopNavigation {
     }
   }
 
-  private emitTopNavResized = (size: number): void => {
-    const event = new CustomEvent("topNavResized", { detail: { size: size } });
-    this.el.dispatchEvent(event);
-  };
-
   private menuButtonClick = () => {
     this.showNavMenu(true);
   };
@@ -258,7 +258,9 @@ export class TopNavigation {
           this.toggleSearchBar();
         }
       }
-      this.emitTopNavResized(currSize);
+      this.topNavResized.emit({
+        size: currSize,
+      });
       if (
         document.activeElement !== null &&
         document.activeElement !== undefined &&

--- a/packages/web-components/src/components/ic-top-navigation/readme.md
+++ b/packages/web-components/src/components/ic-top-navigation/readme.md
@@ -18,6 +18,13 @@
 | `version`        | `version`         | The version info to be displayed.                                                               | `string`                             | `""`           |
 
 
+## Events
+
+| Event           | Description                                 | Type                             |
+| --------------- | ------------------------------------------- | -------------------------------- |
+| `topNavResized` | Emitted when the top navigation is resized. | `CustomEvent<{ size: number; }>` |
+
+
 ## Slots
 
 | Slot                | Description                                                                                                             |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update sideNavExpanded and topNavResized to use event decorator in order to appear in docs.

## Related issue
#1348 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.