### PR TITLE
fix(web-components): updated accessible label for nav sections in page-header and top-nav

### DIFF
--- a/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
@@ -170,6 +170,10 @@ export class PageHeader {
       stickyDesktopOnly,
     } = this;
 
+    const navAriaLabel = heading
+      ? `${heading} page sections`
+      : "navigation-landmark-page-header";
+
     return (
       <Host
         class={{
@@ -239,7 +243,7 @@ export class PageHeader {
                 {isSlotUsed(this.el, "stepper") &&
                   !isSlotUsed(this.el, "tabs") && <slot name="stepper" />}
                 {isSlotUsed(this.el, "tabs") && (
-                  <nav aria-label="navigation-landmark-page-header">
+                  <nav aria-label={navAriaLabel}>
                     <ic-horizontal-scroll>
                       <ul class="tabs-slot">
                         <slot name="tabs" />

--- a/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
+++ b/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
@@ -126,7 +126,7 @@ exports[`ic-page-header component renders additional functionality should render
           </div>
         </div>
         <div class="navigation-area">
-          <nav aria-label="navigation-landmark-page-header">
+          <nav aria-label="Coffee recipes page sections">
             <ic-horizontal-scroll>
               <ul class="tabs-slot">
                 <slot name="tabs"></slot>
@@ -261,7 +261,7 @@ exports[`ic-page-header component renders additional functionality should render
           </div>
         </div>
         <div class="navigation-area">
-          <nav aria-label="navigation-landmark-page-header">
+          <nav aria-label="Coffee recipes page sections">
             <ic-horizontal-scroll>
               <ul class="tabs-slot">
                 <slot name="tabs"></slot>

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -491,7 +491,7 @@ export class TopNavigation {
                     class="navigation-landmark-text"
                     aria-hidden="true"
                   >
-                    Main navigation
+                    Main pages
                   </span>
                   <nav
                     aria-labelledby="navigation-landmark-text"

--- a/packages/web-components/src/components/ic-top-navigation/test/basic/__snapshots__/ic-top-navigation.spec.ts.snap
+++ b/packages/web-components/src/components/ic-top-navigation/test/basic/__snapshots__/ic-top-navigation.spec.ts.snap
@@ -200,7 +200,7 @@ exports[`ic-top-navigation renders with navigation: renders-with-navigation 1`] 
           </div>
           <div class="navigation-tabs">
             <span aria-hidden="true" class="navigation-landmark-text" id="navigation-landmark-text">
-              Main navigation
+              Main pages
             </span>
             <nav aria-labelledby="navigation-landmark-text" class="nav-panel-container">
               <ic-horizontal-scroll appearance="light">


### PR DESCRIPTION
## Summary of the changes
updated accessible labels for the nav sections of page header and top nav to be more descriptive of the page content and less confusing for SR users

## Related issue
[#610](https://github.com/mi6/ic-design-system/issues/610)

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.