### PR TITLE
Fix Malformed Tooltips when label not provided

### DIFF
--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -172,38 +172,42 @@ export class Tooltip {
   };
 
   private show = () => {
-    this.toolTip.setAttribute("data-show", "");
+    if (this.label) {
+      this.toolTip.setAttribute("data-show", "");
 
-    if (this.onDialog) {
-      this.el.classList.add("on-dialog");
-      const dialogEl = this.icDialogEl.shadowRoot
-        .querySelector("dialog")
-        .getBoundingClientRect();
+      if (this.onDialog) {
+        this.el.classList.add("on-dialog");
+        const dialogEl = this.icDialogEl.shadowRoot
+          .querySelector("dialog")
+          .getBoundingClientRect();
 
-      this.getTooltipTranslate(dialogEl);
+        this.getTooltipTranslate(dialogEl);
+      }
+
+      this.popperInstance = createPopper(this.el, this.toolTip, {
+        placement: this.placement,
+        modifiers: [
+          {
+            name: "offset",
+            options: {
+              offset: [0, 10],
+            },
+          },
+          {
+            name: "arrow",
+            options: {
+              element: this.arrow,
+            },
+          },
+          {
+            name: "eventListeners",
+            options: { scroll: false, resize: false },
+          },
+        ],
+      });
+    } else {
+      console.warn(`Tooltip can't display without prop 'label' set`);
     }
-
-    this.popperInstance = createPopper(this.el, this.toolTip, {
-      placement: this.placement,
-      modifiers: [
-        {
-          name: "offset",
-          options: {
-            offset: [0, 10],
-          },
-        },
-        {
-          name: "arrow",
-          options: {
-            element: this.arrow,
-          },
-        },
-        {
-          name: "eventListeners",
-          options: { scroll: false, resize: false },
-        },
-      ],
-    });
   };
 
   private hide = () => {

--- a/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
@@ -136,6 +136,22 @@ describe("ic-tooltip component", () => {
     expect(page.rootInstance.toolTip.getAttribute("data-show")).toBeNull;
   });
 
+  it("should log warning to console and not render if label hasn't been set", async () => {
+    const page = await newSpecPage({
+      components: [Tooltip],
+      html: `<ic-tooltip target="test-button"><button id="test-button"></button></ic-tooltip>`,
+    });
+    jest.spyOn(console, "warn").mockImplementation();
+
+    await page.rootInstance.displayTooltip(true, true);
+    await page.waitForChanges();
+
+    expect(page.rootInstance.toolTip.getAttribute("data-show")).toBeNull;
+    expect(console.warn).toBeCalledWith(
+      "Tooltip can't display without prop 'label' set"
+    );
+  });
+
   it("should watch for label updates", async () => {
     const page = await newSpecPage({
       components: [Tooltip],


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Before, if a label wasn't provided to a tooltip component (or icon variant button, which internally renders a tooltip):
![Screenshot 2024-01-26 at 11 46 05](https://github.com/mi6/ic-ui-kit/assets/111292477/cb19e165-c7fa-4d8a-9795-a10efa7b6c9c)
(a malformed blob would appear - the tail and body of an empty tooltip)

Now, the tooltip won't 'show' if a label isn't provided, and a console warning will be logged. This is in addition to the existing error logged by onComponentRequiredPropUndefined()

How to replicate:
1. run branch locally
2. Edit the icon-only button story, deleting the 'aria-label' on one of the buttons
3. Hover over/tab onto the button.
4. Note that no tooltip appears

## Related issue
#1346 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 