### PR TITLE
popover menu not displaying items in safari

### DIFF
--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.css
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.css
@@ -5,7 +5,7 @@ li {
   padding: 0;
 }
 
-:host::part(button) {
+:host ::part(button) {
   color: var(--ic-color-primary-text);
   padding: calc(var(--ic-space-xxxs) / 2);
   display: flex;
@@ -28,7 +28,7 @@ li {
   --icon-height: auto;
 }
 
-:host(.disabled)::part(button) {
+:host(.disabled) ::part(button) {
   color: var(--ic-architectural-200) !important;
   pointer-events: none;
 }
@@ -39,28 +39,28 @@ li {
   color: var(--ic-architectural-200) !important;
 }
 
-:host([variant="destructive"])::part(button) {
+:host([variant="destructive"]) ::part(button) {
   color: var(--ic-action-destructive);
 }
 
-:host::part(button):hover {
+:host ::part(button):hover {
   background-color: var(--ic-action-dark-bg-hover);
 }
 
-:host::part(button):focus-visible,
-:host::part(button):focus {
+:host ::part(button):focus-visible,
+:host ::part(button):focus {
   color: var(--ic-color-white-text);
   background-color: var(--ic-focus-blue);
   box-shadow: none;
 }
 
-:host(.disabled)::part(button):focus-visible,
-:host(.disabled)::part(button):focus {
+:host(.disabled) ::part(button):focus-visible,
+:host(.disabled) ::part(button):focus {
   color: var(--ic-theme-lighten-40) !important;
 }
 
-:host([variant="destructive"])::part(button):focus-visible,
-:host([variant="destructive"])::part(button):focus {
+:host([variant="destructive"]) ::part(button):focus-visible,
+:host([variant="destructive"]) ::part(button):focus {
   background-color: var(--ic-action-destructive);
 }
 
@@ -80,12 +80,12 @@ ic-button:focus-within .menu-item-description {
   color: var(--ic-theme-lighten-40) !important;
 }
 
-:host::part(button):active {
+:host ::part(button):active {
   background-color: var(--ic-action-dark-bg-active);
   color: var(--ic-color-primary-text) !important;
 }
 
-:host([variant="destructive"])::part(button):active {
+:host([variant="destructive"]) ::part(button):active {
   background-color: var(--ic-action-dark-bg-active);
   color: var(--ic-action-destructive) !important;
 }
@@ -153,11 +153,11 @@ ic-button:active .shortcut {
 
 /** High Contrast **/
 @media (forced-colors: active) {
-  :host::part(button) {
+  :host ::part(button) {
     border: canvas;
   }
 
-  :host::part(button):focus-visible {
+  :host ::part(button):focus-visible {
     outline: var(--ic-space-xxxs) solid transparent;
   }
 
@@ -180,8 +180,8 @@ ic-button:active .shortcut {
     color: GrayText !important;
   }
 
-  :host(.disabled)::part(button):focus-visible,
-  :host(.disabled)::part(button):focus {
+  :host(.disabled) ::part(button):focus-visible,
+  :host(.disabled) ::part(button):focus {
     outline-color: GrayText !important;
   }
 }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update css for menu item so that css parts works in safari for hover, active and focus states

## Related issue
719 in design system repo

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.