### PR TITLE
chore(canary-web-components): excludes toggle button from canary package

### DIFF
--- a/packages/canary-web-components/stencil.config.ts
+++ b/packages/canary-web-components/stencil.config.ts
@@ -73,6 +73,7 @@ export const config: Config = {
         'ic-theme',
         'ic-toast',
         'ic-toast-region',
+        'ic-toggle-button',
         'ic-tooltip',
         'ic-top-navigation',
         'ic-typography',


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Excludes new IcToggleButton from canary package

## Related issue
N/A

