### PR TITLE
1474 ic side navigation collapse and expand state

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-02-07T13:07:33",
+  "timestamp": "2024-02-08T14:59:27",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.10.0",
@@ -189,13 +189,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-accordion": [
-          "ic-typography"
-        ]
+        "ic-accordion": ["ic-typography"]
       }
     },
     {
@@ -361,25 +357,12 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-accordion-group": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-accordion-group": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -611,31 +594,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-dialog"
-      ],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependents": ["ic-dialog"],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-alert": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-dialog": [
-          "ic-alert"
-        ]
+        "ic-alert": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-dialog": ["ic-alert"]
       }
     },
     {
@@ -682,13 +648,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-back-to-top": [
-          "ic-typography"
-        ]
+        "ic-back-to-top": ["ic-typography"]
       }
     },
     {
@@ -1058,13 +1020,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-badge": [
-          "ic-typography"
-        ]
+        "ic-badge": ["ic-typography"]
       }
     },
     {
@@ -1180,19 +1138,11 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-breadcrumb-group"
-      ],
-      "dependencies": [
-        "ic-link"
-      ],
+      "dependents": ["ic-breadcrumb-group"],
+      "dependencies": ["ic-link"],
       "dependencyGraph": {
-        "ic-breadcrumb": [
-          "ic-link"
-        ],
-        "ic-breadcrumb-group": [
-          "ic-breadcrumb"
-        ]
+        "ic-breadcrumb": ["ic-link"],
+        "ic-breadcrumb-group": ["ic-breadcrumb"]
       }
     },
     {
@@ -1293,16 +1243,10 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-breadcrumb"
-      ],
+      "dependencies": ["ic-breadcrumb"],
       "dependencyGraph": {
-        "ic-breadcrumb-group": [
-          "ic-breadcrumb"
-        ],
-        "ic-breadcrumb": [
-          "ic-link"
-        ]
+        "ic-breadcrumb-group": ["ic-breadcrumb"],
+        "ic-breadcrumb": ["ic-link"]
       }
     },
     {
@@ -2100,69 +2044,27 @@
         "ic-toggle-button",
         "ic-top-navigation"
       ],
-      "dependencies": [
-        "ic-loading-indicator",
-        "ic-tooltip"
-      ],
+      "dependencies": ["ic-loading-indicator", "ic-tooltip"],
       "dependencyGraph": {
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-accordion-group": [
-          "ic-button"
-        ],
-        "ic-alert": [
-          "ic-button"
-        ],
-        "ic-card": [
-          "ic-button"
-        ],
-        "ic-dialog": [
-          "ic-button"
-        ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-menu": [
-          "ic-button"
-        ],
-        "ic-menu-item": [
-          "ic-button"
-        ],
-        "ic-navigation-button": [
-          "ic-button"
-        ],
-        "ic-navigation-menu": [
-          "ic-button"
-        ],
-        "ic-pagination": [
-          "ic-button"
-        ],
-        "ic-search-bar": [
-          "ic-button"
-        ],
-        "ic-select": [
-          "ic-button"
-        ],
-        "ic-side-navigation": [
-          "ic-button"
-        ],
-        "ic-toast": [
-          "ic-button"
-        ],
-        "ic-toggle-button": [
-          "ic-button"
-        ],
-        "ic-top-navigation": [
-          "ic-button"
-        ]
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-accordion-group": ["ic-button"],
+        "ic-alert": ["ic-button"],
+        "ic-card": ["ic-button"],
+        "ic-dialog": ["ic-button"],
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-menu": ["ic-button"],
+        "ic-menu-item": ["ic-button"],
+        "ic-navigation-button": ["ic-button"],
+        "ic-navigation-menu": ["ic-button"],
+        "ic-pagination": ["ic-button"],
+        "ic-search-bar": ["ic-button"],
+        "ic-select": ["ic-button"],
+        "ic-side-navigation": ["ic-button"],
+        "ic-toast": ["ic-button"],
+        "ic-toggle-button": ["ic-button"],
+        "ic-top-navigation": ["ic-button"]
       }
     },
     {
@@ -2602,25 +2504,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-card": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-card": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -3107,13 +2996,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-checkbox": [
-          "ic-typography"
-        ]
+        "ic-checkbox": ["ic-typography"]
       }
     },
     {
@@ -3422,21 +3307,11 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-input-label",
-        "ic-input-validation"
-      ],
+      "dependencies": ["ic-input-label", "ic-input-validation"],
       "dependencyGraph": {
-        "ic-checkbox-group": [
-          "ic-input-label",
-          "ic-input-validation"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ]
+        "ic-checkbox-group": ["ic-input-label", "ic-input-validation"],
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"]
       }
     },
     {
@@ -3733,18 +3608,10 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-tooltip"
-      ],
+      "dependencies": ["ic-typography", "ic-tooltip"],
       "dependencyGraph": {
-        "ic-chip": [
-          "ic-typography",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-chip": ["ic-typography", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -3903,13 +3770,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-classification-banner": [
-          "ic-typography"
-        ]
+        "ic-classification-banner": ["ic-typography"]
       }
     },
     {
@@ -4021,13 +3884,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-data-entity": [
-          "ic-typography"
-        ]
+        "ic-data-entity": ["ic-typography"]
       }
     },
     {
@@ -4176,13 +4035,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-data-row": [
-          "ic-typography"
-        ]
+        "ic-data-row": ["ic-typography"]
       }
     },
     {
@@ -4758,31 +4613,13 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button",
-        "ic-alert"
-      ],
+      "dependencies": ["ic-typography", "ic-button", "ic-alert"],
       "dependencyGraph": {
-        "ic-dialog": [
-          "ic-typography",
-          "ic-button",
-          "ic-alert"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-alert": [
-          "ic-typography",
-          "ic-button"
-        ]
+        "ic-dialog": ["ic-typography", "ic-button", "ic-alert"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-alert": ["ic-typography", "ic-button"]
       }
     },
     {
@@ -4807,14 +4644,10 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-side-navigation"
-      ],
+      "dependents": ["ic-side-navigation"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-side-navigation": [
-          "ic-divider"
-        ]
+        "ic-side-navigation": ["ic-divider"]
       }
     },
     {
@@ -5034,13 +4867,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-empty-state": [
-          "ic-typography"
-        ]
+        "ic-empty-state": ["ic-typography"]
       }
     },
     {
@@ -5269,15 +5098,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-section-container",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-section-container", "ic-typography"],
       "dependencyGraph": {
-        "ic-footer": [
-          "ic-section-container",
-          "ic-typography"
-        ]
+        "ic-footer": ["ic-section-container", "ic-typography"]
       }
     },
     {
@@ -5532,15 +5355,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-section-container"
-      ],
+      "dependencies": ["ic-typography", "ic-section-container"],
       "dependencyGraph": {
-        "ic-footer-link-group": [
-          "ic-typography",
-          "ic-section-container"
-        ]
+        "ic-footer-link-group": ["ic-typography", "ic-section-container"]
       }
     },
     {
@@ -5865,15 +5682,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-section-container",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-section-container", "ic-typography"],
       "dependencyGraph": {
-        "ic-hero": [
-          "ic-section-container",
-          "ic-typography"
-        ]
+        "ic-hero": ["ic-section-container", "ic-typography"]
       }
     },
     {
@@ -5929,37 +5740,16 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-page-header",
-        "ic-tab-group",
-        "ic-top-navigation"
-      ],
-      "dependencies": [
-        "ic-button"
-      ],
+      "dependents": ["ic-page-header", "ic-tab-group", "ic-top-navigation"],
+      "dependencies": ["ic-button"],
       "dependencyGraph": {
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-page-header": [
-          "ic-horizontal-scroll"
-        ],
-        "ic-tab-group": [
-          "ic-horizontal-scroll"
-        ],
-        "ic-top-navigation": [
-          "ic-horizontal-scroll"
-        ]
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-page-header": ["ic-horizontal-scroll"],
+        "ic-tab-group": ["ic-horizontal-scroll"],
+        "ic-top-navigation": ["ic-horizontal-scroll"]
       }
     },
     {
@@ -6260,18 +6050,11 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-select",
-        "ic-text-field"
-      ],
+      "dependents": ["ic-select", "ic-text-field"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-select": [
-          "ic-input-component-container"
-        ],
-        "ic-text-field": [
-          "ic-input-component-container"
-        ]
+        "ic-select": ["ic-input-component-container"],
+        "ic-text-field": ["ic-input-component-container"]
       }
     },
     {
@@ -6334,18 +6117,11 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-select",
-        "ic-text-field"
-      ],
+      "dependents": ["ic-select", "ic-text-field"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-select": [
-          "ic-input-container"
-        ],
-        "ic-text-field": [
-          "ic-input-container"
-        ]
+        "ic-select": ["ic-input-container"],
+        "ic-text-field": ["ic-input-container"]
       }
     },
     {
@@ -6578,28 +6354,14 @@
         "ic-switch",
         "ic-text-field"
       ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-checkbox-group": [
-          "ic-input-label"
-        ],
-        "ic-radio-group": [
-          "ic-input-label"
-        ],
-        "ic-select": [
-          "ic-input-label"
-        ],
-        "ic-switch": [
-          "ic-input-label"
-        ],
-        "ic-text-field": [
-          "ic-input-label"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-checkbox-group": ["ic-input-label"],
+        "ic-radio-group": ["ic-input-label"],
+        "ic-select": ["ic-input-label"],
+        "ic-switch": ["ic-input-label"],
+        "ic-text-field": ["ic-input-label"]
       }
     },
     {
@@ -6771,25 +6533,13 @@
         "ic-select",
         "ic-text-field"
       ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-checkbox-group": [
-          "ic-input-validation"
-        ],
-        "ic-radio-group": [
-          "ic-input-validation"
-        ],
-        "ic-select": [
-          "ic-input-validation"
-        ],
-        "ic-text-field": [
-          "ic-input-validation"
-        ]
+        "ic-input-validation": ["ic-typography"],
+        "ic-checkbox-group": ["ic-input-validation"],
+        "ic-radio-group": ["ic-input-validation"],
+        "ic-select": ["ic-input-validation"],
+        "ic-text-field": ["ic-input-validation"]
       }
     },
     {
@@ -7080,14 +6830,10 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-breadcrumb"
-      ],
+      "dependents": ["ic-breadcrumb"],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-breadcrumb": [
-          "ic-link"
-        ]
+        "ic-breadcrumb": ["ic-link"]
       }
     },
     {
@@ -7376,31 +7122,14 @@
           "docs": ""
         }
       ],
-      "dependents": [
-        "ic-button",
-        "ic-menu",
-        "ic-step",
-        "ic-toast"
-      ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependents": ["ic-button", "ic-menu", "ic-step", "ic-toast"],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator"
-        ],
-        "ic-menu": [
-          "ic-loading-indicator"
-        ],
-        "ic-step": [
-          "ic-loading-indicator"
-        ],
-        "ic-toast": [
-          "ic-loading-indicator"
-        ]
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator"],
+        "ic-menu": ["ic-loading-indicator"],
+        "ic-step": ["ic-loading-indicator"],
+        "ic-toast": ["ic-loading-indicator"]
       }
     },
     {
@@ -7822,37 +7551,15 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-search-bar",
-        "ic-select"
-      ],
-      "dependencies": [
-        "ic-loading-indicator",
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependents": ["ic-search-bar", "ic-select"],
+      "dependencies": ["ic-loading-indicator", "ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-menu": [
-          "ic-loading-indicator",
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-search-bar": [
-          "ic-menu"
-        ],
-        "ic-select": [
-          "ic-menu"
-        ]
+        "ic-menu": ["ic-loading-indicator", "ic-typography", "ic-button"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-search-bar": ["ic-menu"],
+        "ic-select": ["ic-menu"]
       }
     },
     {
@@ -7893,13 +7600,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-menu-group": [
-          "ic-typography"
-        ]
+        "ic-menu-group": ["ic-typography"]
       }
     },
     {
@@ -8219,31 +7922,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-popover-menu"
-      ],
-      "dependencies": [
-        "ic-typography",
-        "ic-button"
-      ],
+      "dependents": ["ic-popover-menu"],
+      "dependencies": ["ic-typography", "ic-button"],
       "dependencyGraph": {
-        "ic-menu-item": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-popover-menu": [
-          "ic-menu-item"
-        ]
+        "ic-menu-item": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-popover-menu": ["ic-menu-item"]
       }
     },
     {
@@ -8511,23 +8197,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-button"
-      ],
+      "dependencies": ["ic-button"],
       "dependencyGraph": {
-        "ic-navigation-button": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-navigation-button": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -8636,13 +8311,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-navigation-group": [
-          "ic-typography"
-        ]
+        "ic-navigation-group": ["ic-typography"]
       }
     },
     {
@@ -8928,18 +8599,10 @@
         }
       ],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-tooltip"
-      ],
+      "dependencies": ["ic-typography", "ic-tooltip"],
       "dependencyGraph": {
-        "ic-navigation-item": [
-          "ic-typography",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-navigation-item": ["ic-typography", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -9038,31 +8701,14 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-top-navigation"
-      ],
-      "dependencies": [
-        "ic-button",
-        "ic-typography"
-      ],
+      "dependents": ["ic-top-navigation"],
+      "dependencies": ["ic-button", "ic-typography"],
       "dependencyGraph": {
-        "ic-navigation-menu": [
-          "ic-button",
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-top-navigation": [
-          "ic-navigation-menu"
-        ]
+        "ic-navigation-menu": ["ic-button", "ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-top-navigation": ["ic-navigation-menu"]
       }
     },
     {
@@ -9393,19 +9039,10 @@
           "ic-typography",
           "ic-horizontal-scroll"
         ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -9759,28 +9396,13 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-button",
-        "ic-pagination-item"
-      ],
+      "dependencies": ["ic-button", "ic-pagination-item"],
       "dependencyGraph": {
-        "ic-pagination": [
-          "ic-button",
-          "ic-pagination-item"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-pagination-item": [
-          "ic-typography"
-        ]
+        "ic-pagination": ["ic-button", "ic-pagination-item"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-pagination-item": ["ic-typography"]
       }
     },
     {
@@ -10001,19 +9623,11 @@
       "styles": [],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-pagination"
-      ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependents": ["ic-pagination"],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-pagination-item": [
-          "ic-typography"
-        ],
-        "ic-pagination": [
-          "ic-pagination-item"
-        ]
+        "ic-pagination-item": ["ic-typography"],
+        "ic-pagination": ["ic-pagination-item"]
       }
     },
     {
@@ -10151,29 +9765,13 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-menu-item",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-menu-item", "ic-typography"],
       "dependencyGraph": {
-        "ic-popover-menu": [
-          "ic-menu-item",
-          "ic-typography"
-        ],
-        "ic-menu-item": [
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-popover-menu": ["ic-menu-item", "ic-typography"],
+        "ic-menu-item": ["ic-typography", "ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -10510,21 +10108,11 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-input-label",
-        "ic-input-validation"
-      ],
+      "dependencies": ["ic-input-label", "ic-input-validation"],
       "dependencyGraph": {
-        "ic-radio-group": [
-          "ic-input-label",
-          "ic-input-validation"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ]
+        "ic-radio-group": ["ic-input-label", "ic-input-validation"],
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"]
       }
     },
     {
@@ -10953,13 +10541,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-radio-option": [
-          "ic-typography"
-        ]
+        "ic-radio-option": ["ic-typography"]
       }
     },
     {
@@ -12183,17 +11767,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-text-field",
-        "ic-button",
-        "ic-menu"
-      ],
+      "dependencies": ["ic-text-field", "ic-button", "ic-menu"],
       "dependencyGraph": {
-        "ic-search-bar": [
-          "ic-text-field",
-          "ic-button",
-          "ic-menu"
-        ],
+        "ic-search-bar": ["ic-text-field", "ic-button", "ic-menu"],
         "ic-text-field": [
           "ic-input-container",
           "ic-input-label",
@@ -12201,27 +11777,12 @@
           "ic-input-validation",
           "ic-typography"
         ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-menu": [
-          "ic-loading-indicator",
-          "ic-typography",
-          "ic-button"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-menu": ["ic-loading-indicator", "ic-typography", "ic-button"]
       }
     },
     {
@@ -12308,21 +11869,11 @@
       ],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-footer": [
-          "ic-section-container"
-        ],
-        "ic-footer-link-group": [
-          "ic-section-container"
-        ],
-        "ic-hero": [
-          "ic-section-container"
-        ],
-        "ic-page-header": [
-          "ic-section-container"
-        ],
-        "ic-top-navigation": [
-          "ic-section-container"
-        ]
+        "ic-footer": ["ic-section-container"],
+        "ic-footer-link-group": ["ic-section-container"],
+        "ic-hero": ["ic-section-container"],
+        "ic-page-header": ["ic-section-container"],
+        "ic-top-navigation": ["ic-section-container"]
       }
     },
     {
@@ -13336,27 +12887,12 @@
           "ic-menu",
           "ic-input-validation"
         ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-menu": [
-          "ic-loading-indicator",
-          "ic-typography",
-          "ic-button"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-menu": ["ic-loading-indicator", "ic-typography", "ic-button"],
+        "ic-input-validation": ["ic-typography"]
       }
     },
     {
@@ -13483,7 +13019,7 @@
           "mutable": false,
           "attr": "expanded",
           "reflectToAttr": false,
-          "docs": "If `true`, the side navigation will load in an expanded state.",
+          "docs": "If `true`, the side navigation will display an expanded state.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -13661,27 +13197,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-button",
-        "ic-divider"
-      ],
+      "dependencies": ["ic-typography", "ic-button", "ic-divider"],
       "dependencyGraph": {
-        "ic-side-navigation": [
-          "ic-typography",
-          "ic-button",
-          "ic-divider"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-side-navigation": ["ic-typography", "ic-button", "ic-divider"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -14029,13 +13550,9 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-status-tag": [
-          "ic-typography"
-        ]
+        "ic-status-tag": ["ic-typography"]
       }
     },
     {
@@ -14170,18 +13687,10 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-loading-indicator",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-loading-indicator", "ic-typography"],
       "dependencyGraph": {
-        "ic-step": [
-          "ic-loading-indicator",
-          "ic-typography"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ]
+        "ic-step": ["ic-loading-indicator", "ic-typography"],
+        "ic-loading-indicator": ["ic-typography"]
       }
     },
     {
@@ -14649,18 +14158,10 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-input-label",
-        "ic-typography"
-      ],
+      "dependencies": ["ic-input-label", "ic-typography"],
       "dependencyGraph": {
-        "ic-switch": [
-          "ic-input-label",
-          "ic-typography"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ]
+        "ic-switch": ["ic-input-label", "ic-typography"],
+        "ic-input-label": ["ic-typography"]
       }
     },
     {
@@ -14743,13 +14244,9 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-tab": [
-          "ic-typography"
-        ]
+        "ic-tab": ["ic-typography"]
       }
     },
     {
@@ -15037,26 +14534,13 @@
       "slots": [],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-horizontal-scroll"
-      ],
+      "dependencies": ["ic-horizontal-scroll"],
       "dependencyGraph": {
-        "ic-tab-group": [
-          "ic-horizontal-scroll"
-        ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-tab-group": ["ic-horizontal-scroll"],
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -16286,9 +15770,7 @@
         }
       ],
       "parts": [],
-      "dependents": [
-        "ic-search-bar"
-      ],
+      "dependents": ["ic-search-bar"],
       "dependencies": [
         "ic-input-container",
         "ic-input-label",
@@ -16304,15 +15786,9 @@
           "ic-input-validation",
           "ic-typography"
         ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-search-bar": [
-          "ic-text-field"
-        ]
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"],
+        "ic-search-bar": ["ic-text-field"]
       }
     },
     {
@@ -16619,27 +16095,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-typography",
-        "ic-loading-indicator",
-        "ic-button"
-      ],
+      "dependencies": ["ic-typography", "ic-loading-indicator", "ic-button"],
       "dependencyGraph": {
-        "ic-toast": [
-          "ic-typography",
-          "ic-loading-indicator",
-          "ic-button"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-toast": ["ic-typography", "ic-loading-indicator", "ic-button"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -17059,23 +16520,12 @@
       ],
       "parts": [],
       "dependents": [],
-      "dependencies": [
-        "ic-button"
-      ],
+      "dependencies": ["ic-button"],
       "dependencyGraph": {
-        "ic-toggle-button": [
-          "ic-button"
-        ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ]
+        "ic-toggle-button": ["ic-button"],
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"]
       }
     },
     {
@@ -17312,27 +16762,13 @@
       ],
       "slots": [],
       "parts": [],
-      "dependents": [
-        "ic-button",
-        "ic-chip",
-        "ic-navigation-item"
-      ],
-      "dependencies": [
-        "ic-typography"
-      ],
+      "dependents": ["ic-button", "ic-chip", "ic-navigation-item"],
+      "dependencies": ["ic-typography"],
       "dependencyGraph": {
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-button": [
-          "ic-tooltip"
-        ],
-        "ic-chip": [
-          "ic-tooltip"
-        ],
-        "ic-navigation-item": [
-          "ic-tooltip"
-        ]
+        "ic-tooltip": ["ic-typography"],
+        "ic-button": ["ic-tooltip"],
+        "ic-chip": ["ic-tooltip"],
+        "ic-navigation-item": ["ic-tooltip"]
       }
     },
     {
@@ -17630,23 +17066,11 @@
           "ic-horizontal-scroll",
           "ic-navigation-menu"
         ],
-        "ic-button": [
-          "ic-loading-indicator",
-          "ic-tooltip"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-horizontal-scroll": [
-          "ic-button"
-        ],
-        "ic-navigation-menu": [
-          "ic-button",
-          "ic-typography"
-        ]
+        "ic-button": ["ic-loading-indicator", "ic-tooltip"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-horizontal-scroll": ["ic-button"],
+        "ic-navigation-menu": ["ic-button", "ic-typography"]
       }
     },
     {
@@ -17928,123 +17352,45 @@
       ],
       "dependencies": [],
       "dependencyGraph": {
-        "ic-accordion": [
-          "ic-typography"
-        ],
-        "ic-accordion-group": [
-          "ic-typography"
-        ],
-        "ic-alert": [
-          "ic-typography"
-        ],
-        "ic-back-to-top": [
-          "ic-typography"
-        ],
-        "ic-badge": [
-          "ic-typography"
-        ],
-        "ic-card": [
-          "ic-typography"
-        ],
-        "ic-checkbox": [
-          "ic-typography"
-        ],
-        "ic-chip": [
-          "ic-typography"
-        ],
-        "ic-classification-banner": [
-          "ic-typography"
-        ],
-        "ic-data-entity": [
-          "ic-typography"
-        ],
-        "ic-data-row": [
-          "ic-typography"
-        ],
-        "ic-dialog": [
-          "ic-typography"
-        ],
-        "ic-empty-state": [
-          "ic-typography"
-        ],
-        "ic-footer": [
-          "ic-typography"
-        ],
-        "ic-footer-link-group": [
-          "ic-typography"
-        ],
-        "ic-hero": [
-          "ic-typography"
-        ],
-        "ic-input-label": [
-          "ic-typography"
-        ],
-        "ic-input-validation": [
-          "ic-typography"
-        ],
-        "ic-loading-indicator": [
-          "ic-typography"
-        ],
-        "ic-menu": [
-          "ic-typography"
-        ],
-        "ic-menu-group": [
-          "ic-typography"
-        ],
-        "ic-menu-item": [
-          "ic-typography"
-        ],
-        "ic-navigation-group": [
-          "ic-typography"
-        ],
-        "ic-navigation-item": [
-          "ic-typography"
-        ],
-        "ic-navigation-menu": [
-          "ic-typography"
-        ],
-        "ic-page-header": [
-          "ic-typography"
-        ],
-        "ic-pagination-item": [
-          "ic-typography"
-        ],
-        "ic-popover-menu": [
-          "ic-typography"
-        ],
-        "ic-radio-option": [
-          "ic-typography"
-        ],
-        "ic-select": [
-          "ic-typography"
-        ],
-        "ic-side-navigation": [
-          "ic-typography"
-        ],
-        "ic-status-tag": [
-          "ic-typography"
-        ],
-        "ic-step": [
-          "ic-typography"
-        ],
-        "ic-switch": [
-          "ic-typography"
-        ],
-        "ic-tab": [
-          "ic-typography"
-        ],
-        "ic-text-field": [
-          "ic-typography"
-        ],
-        "ic-toast": [
-          "ic-typography"
-        ],
-        "ic-tooltip": [
-          "ic-typography"
-        ],
-        "ic-top-navigation": [
-          "ic-typography"
-        ]
+        "ic-accordion": ["ic-typography"],
+        "ic-accordion-group": ["ic-typography"],
+        "ic-alert": ["ic-typography"],
+        "ic-back-to-top": ["ic-typography"],
+        "ic-badge": ["ic-typography"],
+        "ic-card": ["ic-typography"],
+        "ic-checkbox": ["ic-typography"],
+        "ic-chip": ["ic-typography"],
+        "ic-classification-banner": ["ic-typography"],
+        "ic-data-entity": ["ic-typography"],
+        "ic-data-row": ["ic-typography"],
+        "ic-dialog": ["ic-typography"],
+        "ic-empty-state": ["ic-typography"],
+        "ic-footer": ["ic-typography"],
+        "ic-footer-link-group": ["ic-typography"],
+        "ic-hero": ["ic-typography"],
+        "ic-input-label": ["ic-typography"],
+        "ic-input-validation": ["ic-typography"],
+        "ic-loading-indicator": ["ic-typography"],
+        "ic-menu": ["ic-typography"],
+        "ic-menu-group": ["ic-typography"],
+        "ic-menu-item": ["ic-typography"],
+        "ic-navigation-group": ["ic-typography"],
+        "ic-navigation-item": ["ic-typography"],
+        "ic-navigation-menu": ["ic-typography"],
+        "ic-page-header": ["ic-typography"],
+        "ic-pagination-item": ["ic-typography"],
+        "ic-popover-menu": ["ic-typography"],
+        "ic-radio-option": ["ic-typography"],
+        "ic-select": ["ic-typography"],
+        "ic-side-navigation": ["ic-typography"],
+        "ic-status-tag": ["ic-typography"],
+        "ic-step": ["ic-typography"],
+        "ic-switch": ["ic-typography"],
+        "ic-tab": ["ic-typography"],
+        "ic-text-field": ["ic-typography"],
+        "ic-toast": ["ic-typography"],
+        "ic-tooltip": ["ic-typography"],
+        "ic-top-navigation": ["ic-typography"]
       }
     }
   ],

--- a/packages/react/src/component-tests/IcSideNavigation/IcSideNavigation.cy.tsx
+++ b/packages/react/src/component-tests/IcSideNavigation/IcSideNavigation.cy.tsx
@@ -15,6 +15,7 @@ import {
 } from "../utils/constants";
 import {
   BasicSideNav,
+  DynamicExpandedSideNav,
   ExpandedSideNav,
   GroupedSideNav,
   LongPropsSideNav,
@@ -260,6 +261,16 @@ describe("IcSideNavigation", () => {
       cy.checkSideNavSize(true);
 
       cy.clickOnShadowEl(SIDE_NAV_LABEL, EXPAND_BUTTON_SELECTOR);
+      cy.checkSideNavSize(false);
+    });
+
+    it("renders collapsed and expanded when expanded state is externally controlled", () => {
+      mount(<DynamicExpandedSideNav />);
+
+      cy.get("#expand-btn").click();
+      cy.checkSideNavSize(true);
+
+      cy.get("#collapse-btn").click();
       cy.checkSideNavSize(false);
     });
 

--- a/packages/react/src/component-tests/IcSideNavigation/IcSideNavigationTestData.tsx
+++ b/packages/react/src/component-tests/IcSideNavigation/IcSideNavigationTestData.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 import {
+  IcButton,
   IcNavigationGroup,
   IcNavigationItem,
   IcSideNavigation,
@@ -108,6 +109,89 @@ export const ExpandedSideNav = (): ReactElement => (
     <SideNavChildren />
   </IcSideNavigation>
 );
+
+export const DynamicExpandedSideNav = (): ReactElement => {
+  const [expanded, setExpanded] = useState(true);
+  const expandedClickHandler = () => {
+    setExpanded(true);
+  };
+  const collapsedButtonClickHandler = () => {
+    setExpanded(false);
+  };
+  return (
+    <div style={{ display: "flex", height: "100%" }}>
+      <IcSideNavigation
+        appTitle="ACME"
+        version="v0.0.0"
+        status="BETA"
+        expanded={expanded}
+      >
+        <SlottedSVG
+          slot="app-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </SlottedSVG>
+        <IcNavigationItem
+          slot="primary-navigation"
+          href="/"
+          label="Home"
+          selected
+        >
+          <SlottedSVG
+            slot="icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+              fill="currentColor"
+            />
+          </SlottedSVG>
+        </IcNavigationItem>
+        <IcNavigationItem slot="secondary-navigation" href="/" label="Settings">
+          <SlottedSVG
+            slot="icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+              fill="currentColor"
+            />
+          </SlottedSVG>
+        </IcNavigationItem>
+      </IcSideNavigation>
+      <main style={{ display: "flex", flexDirection: "column", width: "100%" }}>
+        <IcButton
+          id="expand-btn"
+          variant="primary"
+          onClick={expandedClickHandler}
+        >
+          Expand
+        </IcButton>
+        <IcButton
+          id="collapse-btn"
+          variant="primary"
+          onClick={collapsedButtonClickHandler}
+        >
+          Collapse
+        </IcButton>
+      </main>
+    </div>
+  );
+};
 
 export const GroupedSideNav = (): ReactElement => (
   <IcSideNavigation

--- a/packages/react/src/stories/ic-side-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-side-navigation.stories.mdx
@@ -103,63 +103,86 @@ import { NavLink, MemoryRouter, Route, Routes } from "react-router-dom";
   </Story>
 </Canvas>
 
-### Expanded / Navigation Group
+### Expanded
+
+export const ExpansionControl = () => {
+  const [expanded, setExpanded] = useState(true);
+  const expandedClickHandler = () => {
+    setExpanded(true);
+  };
+  const collapsedButtonClickHandler = () => {
+    setExpanded(false);
+  };
+  return (
+    <div style={{ display: "flex", height: "100%" }}>
+      <IcSideNavigation
+        appTitle="ACME"
+        version="v0.0.0"
+        status="BETA"
+        expanded={expanded}
+      >
+        <svg
+          slot="app-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </svg>
+        <IcNavigationItem
+          slot="primary-navigation"
+          href="/"
+          label="Home"
+          selected
+        >
+          <svg
+            slot="icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+              fill="currentColor"
+            />
+          </svg>
+        </IcNavigationItem>
+        <IcNavigationItem slot="secondary-navigation" href="/" label="Settings">
+          <svg
+            slot="icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+              fill="currentColor"
+            />
+          </svg>
+        </IcNavigationItem>
+      </IcSideNavigation>
+      <main style={{ display: "flex", flexDirection: "column" }}>
+        <IcButton variant="primary" onClick={expandedClickHandler}>
+          Expand
+        </IcButton>
+        <IcButton variant="primary" onClick={collapsedButtonClickHandler}>
+          Collapse
+        </IcButton>
+      </main>
+    </div>
+  );
+};
 
 <Canvas>
   <Story name="Expanded">
-    <IcSideNavigation
-      appTitle="ACME"
-      version="v0.0.0"
-      status="BETA"
-      expanded="true"
-    >
-      <svg
-        slot="app-icon"
-        xmlns="http://www.w3.org/2000/svg"
-        height="24px"
-        viewBox="0 0 24 24"
-        width="24px"
-        fill="#000000"
-      >
-        <path d="M0 0h24v24H0V0z" fill="none" />
-        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
-      </svg>
-      <IcNavigationItem
-        slot="primary-navigation"
-        href="/"
-        label="Home"
-        selected
-      >
-        <svg
-          slot="icon"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
-            fill="currentColor"
-          />
-        </svg>
-      </IcNavigationItem>
-      <IcNavigationItem slot="secondary-navigation" href="/" label="Settings">
-        <svg
-          slot="icon"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
-            fill="currentColor"
-          />
-        </svg>
-      </IcNavigationItem>
-    </IcSideNavigation>
+    <ExpansionControl />
   </Story>
 </Canvas>
 

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1758,7 +1758,7 @@ export namespace Components {
          */
         "disableTopBarBehaviour": boolean;
         /**
-          * If `true`, the side navigation will load in an expanded state.
+          * If `true`, the side navigation will display in an expanded state.
          */
         "expanded": boolean;
         /**
@@ -5014,7 +5014,7 @@ declare namespace LocalJSX {
          */
         "disableTopBarBehaviour"?: boolean;
         /**
-          * If `true`, the side navigation will load in an expanded state.
+          * If `true`, the side navigation will display in an expanded state.
          */
         "expanded"?: boolean;
         /**

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.stories.mdx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.stories.mdx
@@ -431,10 +431,22 @@ import readme from "./readme.md";
           class="content-wrapper"
           style="display:flex; flex-direction: column;"
         >
-          <main>This is the content</main>
+          <main>
+            <ic-button onclick="expandedClickHandler()">Expand</ic-button>
+            <ic-button onclick="collapsedClickHandler()">Collapse</ic-button>
+          </main>
           <footer>Footer</footer>
         </div>
       </div>
+      <script>
+        var icSideNav = document.querySelector("ic-side-navigation");
+        function expandedClickHandler() {
+          icSideNav.expanded = true;
+        }
+        function collapsedClickHandler() {
+          icSideNav.expanded = false;
+        }
+      </script>
     `}
   </Story>
 </Canvas>

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -8,6 +8,7 @@ import {
   Listen,
   Event,
   EventEmitter,
+  Watch,
 } from "@stencil/core";
 
 import menuIcon from "../../assets/hamburger-menu-icon.svg";
@@ -83,9 +84,14 @@ export class SideNavigation {
   @Prop() disableTopBarBehaviour: boolean = false;
 
   /**
-   * If `true`, the side navigation will load in an expanded state.
+   * If `true`, the side navigation will display in an expanded state.
    */
   @Prop() expanded: boolean = false;
+
+  @Watch("expanded")
+  watchExpandedHandler(): void {
+    this.setMenuExpanded(this.expanded);
+  }
 
   /**
    * The URL that the app title link points to.

--- a/packages/web-components/src/components/ic-side-navigation/readme.md
+++ b/packages/web-components/src/components/ic-side-navigation/readme.md
@@ -13,7 +13,7 @@
 | `collapsedIconLabels`      | `collapsed-icon-labels`       | If `true`, the icon and label will appear when side navigation is collapsed.                                        | `boolean` | `false`     |
 | `disableAutoParentStyling` | `disable-auto-parent-styling` | If `true`, automatic parent wrapper styling will be disabled.                                                       | `boolean` | `false`     |
 | `disableTopBarBehaviour`   | `disable-top-bar-behaviour`   | If `true`, the side navigation will not display as a top bar on small devices.                                      | `boolean` | `false`     |
-| `expanded`                 | `expanded`                    | If `true`, the side navigation will load in an expanded state.                                                      | `boolean` | `false`     |
+| `expanded`                 | `expanded`                    | If `true`, the side navigation will display in an expanded state.                                                   | `boolean` | `false`     |
 | `href`                     | `href`                        | The URL that the app title link points to.                                                                          | `string`  | `"/"`       |
 | `shortAppTitle`            | `short-app-title`             | The short title of the app to be displayed at small screen sizes in place of the app title.                         | `string`  | `""`        |
 | `static`                   | `static`                      | If `true`, the menu expand button will be removed (PLEASE NOTE: This takes effect on screen sizes 992px and above). | `boolean` | `false`     |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update expanded prop on side nav to allow state change programmatically.

## Related issue
#1474 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.