### PR TITLE
1485 footer link active state

### DIFF
--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -105,7 +105,7 @@ a:link:visited > ::slotted(svg) {
 
 :host(.footer-link) a:link:focus,
 :host(.footer-link) a ::slotted(a:link:focus) {
-  outline: var(--ic-hc-focus-outline);
+  outline: none;
 }
 
 :host(.footer-link) a:link:focus > ::slotted(svg),
@@ -118,8 +118,7 @@ a:link:visited > ::slotted(svg) {
 
 :host(.footer-link) a:focus,
 :host(.footer-link) a ::slotted(a:focus) {
-  border-radius: var(--ic-border-radius);
-  outline: var(--ic-hc-focus-outline);
+  outline: none;
   transition: var(--ic-transition-duration-fast);
 }
 


### PR DESCRIPTION
## Summary of the changes
This ticket fixes the footer link active state, it was previously quickly flashing a border when active- this behaviour was different to the IcLink. Now the IcFooterLink is aligned with the IcLink. This PR should then also fix the issues with the guidance sites footer links active state.

## Related issue

#1485 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.