### PR TITLE
1413 ic popover menu popover menu button not closing open popover menu

### DIFF
--- a/packages/react/src/stories/ic-popover-menu.stories.mdx
+++ b/packages/react/src/stories/ic-popover-menu.stories.mdx
@@ -27,7 +27,8 @@ import menuGroupReadme from "../../../web-components/src/components/ic-menu-grou
   <Story name="Default">
     {() => {
       function buttonClick() {
-        document.querySelector("ic-popover-menu").open = true;
+        document.querySelector("ic-popover-menu").open =
+          !document.querySelector("ic-popover-menu").open;
       }
       return (
         <>
@@ -79,7 +80,8 @@ import menuGroupReadme from "../../../web-components/src/components/ic-menu-grou
   <Story name="Left placement">
     {() => {
       function buttonClick() {
-        document.querySelector("ic-popover-menu").open = true;
+        document.querySelector("ic-popover-menu").open =
+          !document.querySelector("ic-popover-menu").open;
       }
       return (
         <>
@@ -133,7 +135,8 @@ import menuGroupReadme from "../../../web-components/src/components/ic-menu-grou
   <Story name="Top placement">
     {() => {
       function buttonClick() {
-        document.querySelector("ic-popover-menu").open = true;
+        document.querySelector("ic-popover-menu").open =
+          !document.querySelector("ic-popover-menu").open;
       }
       return (
         <>

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
@@ -28,7 +28,7 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
         <script>
           var icPopover = document.querySelector("ic-popover-menu");
           function buttonClick() {
-            icPopover.open = true;
+            icPopover.open = !icPopover.open;
           }
         </script>
         <div>
@@ -111,7 +111,7 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
         <script>
           var icPopover = document.querySelector("ic-popover-menu");
           function buttonClick() {
-            icPopover.open = true;
+            icPopover.open = !icPopover.open;
           }
         </script>
         <div>
@@ -184,7 +184,7 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
           <script>
             var icPopover = document.querySelector("ic-popover-menu");
             function buttonClick() {
-              icPopover.open = true;
+              icPopover.open = !icPopover.open;
             }
           </script>
           <div>
@@ -258,7 +258,7 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
           <script>
             var icPopover = document.querySelector("ic-popover-menu");
             function buttonClick() {
-              icPopover.open = true;
+              icPopover.open = !icPopover.open;
             }
           </script>
           <div>
@@ -336,7 +336,7 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
         <script>
           function buttonClick(pos) {
             var icPopover = document.querySelector("#popover" + pos);
-            icPopover.open = true;
+            icPopover.open = !icPopover.open;
           }
         </script>
         <div>


### PR DESCRIPTION
## Summary of the changes
This ticket fixes the react and web-component IcPopoverMenu storybook empty and closed states.

## Related issue

#1413 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.