### PR TITLE
991 add color scheme css property to storybook

### DIFF
--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -1,6 +1,7 @@
 import "../dist/core/normalize.css";
 import "@ukic/fonts/dist/fonts.css";
 import "../dist/core/core.css";
+import "./storybook.css";
 
 export const parameters = {
     controls: { 

--- a/packages/react/.storybook/storybook.css
+++ b/packages/react/.storybook/storybook.css
@@ -1,0 +1,3 @@
+:root {
+    color-scheme: light dark;
+}

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -1,6 +1,7 @@
 import "../src/global/normalize.css"
 import "@ukic/fonts/dist/fonts.css";
 import "../src/global/icds.css";
+import "./storybook.css";
 
 import { defineCustomElements } from '../dist/esm/loader';
 

--- a/packages/web-components/.storybook/storybook.css
+++ b/packages/web-components/.storybook/storybook.css
@@ -1,0 +1,3 @@
+:root {
+    color-scheme: light dark;
+}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Grabs the current appearance preference of the user with 2 .storybook.cc files, and changes the component environment in Storybook to reflect this. Will aid users wanting to test components in dark mode.


## Related issue
991

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.