### PR TITLE
1394 icalert cannot use message slot when titleabove is set to true

### DIFF
--- a/packages/react/src/stories/ic-alert.stories.mdx
+++ b/packages/react/src/stories/ic-alert.stories.mdx
@@ -124,6 +124,8 @@ import readme from "../../../web-components/src/components/ic-alert/readme.md";
   </Story>
 </Canvas>
 
+### Custom message
+
 <Canvas>
   <Story name="Custom message">
     <IcAlert heading="This alert uses a custom message slot">
@@ -134,6 +136,18 @@ import readme from "../../../web-components/src/components/ic-alert/readme.md";
         </IcLink>
         within the text.
       </p>
+    </IcAlert>
+  </Story>
+</Canvas>
+
+### Custom message and title above
+
+<Canvas>
+  <Story name="Custom message and title above">
+    <IcAlert heading="Want to know more about our coffee?" titleAbove>
+      <span slot="message" style={{ font: "var(--ic-font-body)" }}>
+        Go to our <IcLink href="/">coffee page</IcLink> to learn more.
+      </span>
     </IcAlert>
   </Story>
 </Canvas>

--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -113,7 +113,6 @@
 
 .alert-message-title-above {
   display: inline;
-  font-size: 0;
 }
 
 .alert-title {

--- a/packages/web-components/src/components/ic-alert/ic-alert.stories.mdx
+++ b/packages/web-components/src/components/ic-alert/ic-alert.stories.mdx
@@ -136,3 +136,21 @@ import Button from "../ic-button/readme.md";
     </ic-alert>`}
   </Story>
 </Canvas>
+
+### Custom message and title above
+
+<Canvas>
+  <Story
+    name="Custom message and title above"
+    parameters={{ loki: { skip: true } }}
+  >
+    {html`<ic-alert
+      heading="Want to know more about our coffee?"
+      title-above="true"
+    >
+      <span slot="message" style="font:var(--ic-font-body)">
+        Go to our <ic-link href="/">coffee page</ic-link> to learn more.
+      </ic-typography>
+    </ic-alert>`}
+  </Story>
+</Canvas>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update alert to not set font size to 0 so that slotted message and title above can be used at the same time.

## Related issue
#1394 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.