### PR TITLE
fix(web-components): conditionally render description block for footer

### DIFF
--- a/packages/web-components/src/components/ic-back-to-top/test/basic/__snapshots__/ic-back-to-top.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-back-to-top/test/basic/__snapshots__/ic-back-to-top.spec.tsx.snap
@@ -21,15 +21,6 @@ exports[`ic-back-to-top should render with footer: should render with footer 1`]
 <ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">

--- a/packages/web-components/src/components/ic-footer-link-group/test/basic/__snapshots__/ic-footer-link-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-footer-link-group/test/basic/__snapshots__/ic-footer-link-group.spec.ts.snap
@@ -4,15 +4,6 @@ exports[`ic-footer-link-group should render small: footer-link-group-small 1`] =
 <ic-footer breakpoint="extra large" class="footer footer-light footer-small footer-ungrouped light">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -59,15 +50,6 @@ exports[`ic-footer-link-group should render within footer: footer-link-group-in-
 <ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -104,15 +86,6 @@ exports[`ic-footer-link-group should render within footer: footer-link-group-in-
   <ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
     <mock:shadow-root>
       <footer>
-        <div class="footer-description">
-          <ic-section-container aligned="left" fullheight="">
-            <div class="footer-description-inner">
-              <ic-typography variant="body">
-                <slot name="description"></slot>
-              </ic-typography>
-            </div>
-          </ic-section-container>
-        </div>
         <div class="footer-compliance">
           <ic-section-container aligned="left" fullheight="">
             <div class="footer-compliance-inner">

--- a/packages/web-components/src/components/ic-footer/ic-footer.tsx
+++ b/packages/web-components/src/components/ic-footer/ic-footer.tsx
@@ -160,15 +160,17 @@ export class Footer {
       >
         <footer ref={(footerEl) => (this.footerEl = footerEl)}>
           {/* Description */}
-          <div class="footer-description">
-            <ic-section-container aligned={aligned} fullHeight={true}>
-              <div class="footer-description-inner">
-                <ic-typography variant="body">
-                  <slot name="description">{description}</slot>
-                </ic-typography>
-              </div>
-            </ic-section-container>
-          </div>
+          {description && (
+            <div class="footer-description">
+              <ic-section-container aligned={aligned} fullHeight={true}>
+                <div class="footer-description-inner">
+                  <ic-typography variant="body">
+                    <slot name="description">{description}</slot>
+                  </ic-typography>
+                </div>
+              </ic-section-container>
+            </div>
+          )}
 
           {/* Links */}
           {isSlotUsed(this.el, "link") && (

--- a/packages/web-components/src/components/ic-footer/test/basic/__snapshots__/ic-footer.spec.ts.snap
+++ b/packages/web-components/src/components/ic-footer/test/basic/__snapshots__/ic-footer.spec.ts.snap
@@ -4,15 +4,6 @@ exports[`ic-footer should render 1`] = `
 <ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -110,18 +101,6 @@ exports[`ic-footer should render with a description via the description slot 1`]
 <ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography class="ic-typography-body">
-              <mock:shadow-root>
-                <slot></slot>
-              </mock:shadow-root>
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -151,15 +130,6 @@ exports[`ic-footer should render with classification banner: footer-classificati
 <ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -284,15 +254,6 @@ exports[`ic-footer should render with the correct small breakpoint at extra larg
 <ic-footer breakpoint="extra large" caption="caption" class="footer footer-light footer-small footer-ungrouped light" id="ic-footer">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -320,15 +281,6 @@ exports[`ic-footer should render with the correct small breakpoint at extra smal
 <ic-footer breakpoint="extra small" caption="caption" class="footer footer-light footer-sparse footer-ungrouped light" id="ic-footer">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -356,15 +308,6 @@ exports[`ic-footer should render with the correct small breakpoint at large devi
 <ic-footer breakpoint="large" caption="caption" class="footer footer-light footer-sparse footer-ungrouped light" id="ic-footer">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -392,15 +335,6 @@ exports[`ic-footer should render with the correct small breakpoint at medium dev
 <ic-footer breakpoint="medium" caption="caption" class="footer footer-light footer-sparse footer-ungrouped light" id="ic-footer">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">
@@ -428,15 +362,6 @@ exports[`ic-footer should render with the correct small breakpoint at small devi
 <ic-footer breakpoint="small" caption="caption" class="footer footer-light footer-sparse footer-ungrouped light" id="ic-footer">
   <mock:shadow-root>
     <footer>
-      <div class="footer-description">
-        <ic-section-container aligned="left" fullheight="">
-          <div class="footer-description-inner">
-            <ic-typography variant="body">
-              <slot name="description"></slot>
-            </ic-typography>
-          </div>
-        </ic-section-container>
-      </div>
       <div class="footer-compliance">
         <ic-section-container aligned="left" fullheight="">
           <div class="footer-compliance-inner">


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Conditionally render description block for footer so less space is taken up if no description is provided

## Related issue
#1491

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.