### PR TITLE
fix(web-components): remove role on ic-alert when "announced" prop is false.

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.stories.mdx
+++ b/packages/web-components/src/components/ic-alert/ic-alert.stories.mdx
@@ -154,3 +154,34 @@ import Button from "../ic-button/readme.md";
     </ic-alert>`}
   </Story>
 </Canvas>
+
+### Announced
+
+<Canvas>
+  <Story name="Announced" parameters={{ loki: { skip: true } }}>
+    {html`
+      <ic-alert
+        id="alert"
+        heading="Neutral"
+        message="This alert is for displaying miscellaneous messages"
+        announced="false"
+      ></ic-alert>
+      <br />
+      <br />
+      <ic-button variant="primary" size="small" onClick="onClick()" id="btn"
+        >Toggle announced prop</ic-button
+      >
+      <script>
+        const alert = document.getElementById("alert");
+        const btn = document.getElementById("btn");
+        btn.addEventListener("click", onClick);
+        function onClick(e) {
+          e.preventDefault();
+          alert.announced
+            ? (alert.announced = "false")
+            : (alert.announced = "true");
+        }
+      </script>
+    `}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-alert/ic-alert.tsx
+++ b/packages/web-components/src/components/ic-alert/ic-alert.tsx
@@ -103,7 +103,7 @@ export class Alert {
     return (
       visible && (
         <Host
-          role={announced && "alert"}
+          role={announced ? "alert" : null}
           class={{
             [IcThemeForegroundEnum.Dark]: true,
           }}


### PR DESCRIPTION
## Summary of the changes
Tiny change to remove `role` attribute on ic-alert when `announced` prop is "false". This was causing an Accessibility Insights error with the alerts used in the guidance on the ICDS website because it was causing `role` to be set to "false" which is an invalid value for that attribute.

## Related issue
N/A

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.