### PR TITLE
fix(web-components): fixes aria-hidden a11y issue

### DIFF
--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -181,7 +181,14 @@ exports[`button component should render correct HTML with right icon 1`] = `
 exports[`button component should render icon variant with a tooltip 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" placement="bottom" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip class="ic-tooltip" id="ic-tooltip-ic-button-with-tooltip-test-button" target="ic-button-with-tooltip-test-button">
+      <mock:shadow-root>
+        <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+          <ic-typography variant="caption"></ic-typography>
+          <div class="ic-tooltip-arrow"></div>
+        </div>
+        <slot></slot>
+      </mock:shadow-root>
       <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
         <slot></slot>
       </button>
@@ -194,7 +201,16 @@ exports[`button component should render icon variant with a tooltip 1`] = `
 exports[`button component should render icon variant with a tooltip based on aria-label 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" tooltip-placement="top" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip label="Tooltip text" placement="top" silent="" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip class="ic-tooltip" target="ic-button-with-tooltip-test-button">
+      <mock:shadow-root>
+        <div aria-hidden="true" class="ic-tooltip-container" role="tooltip">
+          <ic-typography variant="caption">
+            Tooltip text
+          </ic-typography>
+          <div class="ic-tooltip-arrow"></div>
+        </div>
+        <slot></slot>
+      </mock:shadow-root>
       <button aria-label="Tooltip text" class="button" part="button" type="button">
         <slot></slot>
       </button>
@@ -207,7 +223,16 @@ exports[`button component should render icon variant with a tooltip based on ari
 exports[`button component should render icon variant with a tooltip based on title 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip class="ic-tooltip" id="ic-tooltip-ic-button-with-tooltip-test-button" target="ic-button-with-tooltip-test-button">
+      <mock:shadow-root>
+        <div aria-hidden="true" class="ic-tooltip-container" role="tooltip">
+          <ic-typography variant="caption">
+            Tooltip text
+          </ic-typography>
+          <div class="ic-tooltip-arrow"></div>
+        </div>
+        <slot></slot>
+      </mock:shadow-root>
       <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
         <slot></slot>
       </button>
@@ -344,7 +369,16 @@ exports[`button component should update aria-expanded when attribute changed 2`]
 exports[`button component should update aria-label when attribute changed 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip label="Tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip class="ic-tooltip" target="ic-button-with-tooltip-test-button">
+      <mock:shadow-root>
+        <div aria-hidden="true" class="ic-tooltip-container" role="tooltip">
+          <ic-typography variant="caption">
+            Tooltip text
+          </ic-typography>
+          <div class="ic-tooltip-arrow"></div>
+        </div>
+        <slot></slot>
+      </mock:shadow-root>
       <button aria-label="Tooltip text" class="button" part="button" type="button">
         <slot></slot>
       </button>
@@ -357,7 +391,16 @@ exports[`button component should update aria-label when attribute changed 1`] = 
 exports[`button component should update aria-label when attribute changed 2`] = `
 <ic-button aria-label="New tooltip text" class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip label="New tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip class="ic-tooltip" target="ic-button-with-tooltip-test-button">
+      <mock:shadow-root>
+        <div aria-hidden="true" class="ic-tooltip-container" role="tooltip">
+          <ic-typography variant="caption">
+            New tooltip text
+          </ic-typography>
+          <div class="ic-tooltip-arrow"></div>
+        </div>
+        <slot></slot>
+      </mock:shadow-root>
       <button aria-label="New tooltip text" class="button" part="button" type="button">
         <slot></slot>
       </button>

--- a/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
+++ b/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
@@ -1,6 +1,7 @@
 import { Button } from "../../ic-button";
 import { newSpecPage } from "@stencil/core/testing";
 import * as helpers from "../../../../utils/helpers";
+import { Tooltip } from "../../../ic-tooltip/ic-tooltip";
 
 beforeAll(() => {
   jest.spyOn(console, "warn").mockImplementation(jest.fn());
@@ -174,7 +175,7 @@ describe("button component", () => {
 
   it("should render icon variant with a tooltip", async () => {
     const page = await newSpecPage({
-      components: [Button],
+      components: [Button, Tooltip],
       html: "<ic-button variant='icon' id='test-button'>Button</ic-button>",
     });
     expect(page.root).toMatchSnapshot();
@@ -182,7 +183,7 @@ describe("button component", () => {
 
   it("should render icon variant with a tooltip based on title", async () => {
     const page = await newSpecPage({
-      components: [Button],
+      components: [Button, Tooltip],
       html: "<ic-button variant='icon' id='test-button' title='Tooltip text'>Button</ic-button>",
     });
     expect(page.root).toMatchSnapshot();
@@ -190,7 +191,7 @@ describe("button component", () => {
 
   it("should render icon variant with a tooltip based on aria-label", async () => {
     const page = await newSpecPage({
-      components: [Button],
+      components: [Button, Tooltip],
       html: "<ic-button variant='icon' id='test-button' aria-label='Tooltip text' tooltip-placement='top'>Button</ic-button>",
     });
     expect(page.root).toMatchSnapshot();
@@ -198,7 +199,7 @@ describe("button component", () => {
 
   it("should disable tooltip when prop set", async () => {
     const page = await newSpecPage({
-      components: [Button],
+      components: [Button, Tooltip],
       html: "<ic-button variant='icon' aria-label='Tooltip text' id='test-button' disable-tooltip>Button</ic-button>",
     });
     expect(page.root).toMatchSnapshot();
@@ -206,7 +207,7 @@ describe("button component", () => {
 
   it("should update aria-label when attribute changed", async () => {
     const page = await newSpecPage({
-      components: [Button],
+      components: [Button, Tooltip],
       html: "<ic-button variant='icon' aria-label='Tooltip text' id='test-button'>Button</ic-button>",
     });
 

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -273,7 +273,7 @@ export class Tooltip {
           ref={(el) => (this.toolTip = el as HTMLDivElement)}
           role="tooltip"
           class="ic-tooltip-container"
-          aria-hidden={silent}
+          aria-hidden={`${silent}`}
         >
           <ic-typography maxLines={maxLines} variant="caption">
             {label}

--- a/packages/web-components/src/components/ic-tooltip/test/basic/__snapshots__/ic-tooltip.spec.ts.snap
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/__snapshots__/ic-tooltip.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ic-tooltip component getTooltipTranslate should update for bottom 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -20,7 +20,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for bottom 1`] =
 exports[`ic-tooltip component getTooltipTranslate should update for bottom-end 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="bottom-end" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -100px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -37,7 +37,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for bottom-end 1
 exports[`ic-tooltip component getTooltipTranslate should update for bottom-start 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="bottom-start" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -54,7 +54,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for bottom-start
 exports[`ic-tooltip component getTooltipTranslate should update for left 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="left" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -100px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -71,7 +71,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for left 1`] = `
 exports[`ic-tooltip component getTooltipTranslate should update for left-end 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="left-end" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -132px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -132px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -88,7 +88,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for left-end 1`]
 exports[`ic-tooltip component getTooltipTranslate should update for right 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="right" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -105,7 +105,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for right 1`] = 
 exports[`ic-tooltip component getTooltipTranslate should update for right-end 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="right-end" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -122,7 +122,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for right-end 1`
 exports[`ic-tooltip component getTooltipTranslate should update for top 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="top" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -139,7 +139,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for top 1`] = `
 exports[`ic-tooltip component getTooltipTranslate should update for top-end 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="top-end" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -132px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: -40px; --tooltip-translate-y: -132px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -156,7 +156,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for top-end 1`] 
 exports[`ic-tooltip component getTooltipTranslate should update for top-start 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="top-start" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -132px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -173,7 +173,7 @@ exports[`ic-tooltip component getTooltipTranslate should update for top-start 1`
 exports[`ic-tooltip component getTooltipTranslate should update when tooltip is outside of dialog 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip" placement="left" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip" style="--tooltip-translate-x: 0px; --tooltip-translate-y: -100px;">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -190,7 +190,7 @@ exports[`ic-tooltip component getTooltipTranslate should update when tooltip is 
 exports[`ic-tooltip component should render: ic-tooltip-render 1`] = `
 <ic-tooltip class="ic-tooltip" label="tooltip">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
       <ic-typography variant="caption">
         tooltip
       </ic-typography>
@@ -204,7 +204,7 @@ exports[`ic-tooltip component should render: ic-tooltip-render 1`] = `
 exports[`ic-tooltip component should truncate text and pass the maxLines value to ic-typography if maxLines prop has been set 1`] = `
 <ic-tooltip class="ic-tooltip" label="This is a body of text that is truncated to three lines within a tooltip. It has been truncated based on the max-lines property. The number of lines in the text is clamped to the number passed through the max-lines property." max-lines="2" target="test-button">
   <mock:shadow-root>
-    <div class="ic-tooltip-container" role="tooltip">
+    <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
       <ic-typography class="ic-typography-caption" style="--truncation-max-lines: 2;">
         <mock:shadow-root>
           <div class="trunc-wrapper">


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes aria-hidden a11y issue on tooltips. Was previously setting aria-hidden="" when silent prop was set to false. this was causing a failure in the a11y testing.

## Related issue
N\A

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.