### PR TITLE
fix(web-components): removed role of cell on the end-adornment in ic-data-entity

### DIFF
--- a/packages/react/src/component-tests/IcDataEntity/IcDataEntity.cy.tsx
+++ b/packages/react/src/component-tests/IcDataEntity/IcDataEntity.cy.tsx
@@ -23,6 +23,13 @@ import { CYPRESS_AXE_OPTIONS } from "../../../cypress/utils/a11y";
 
 const DEFAULT_TEST_THRESHOLD = 0.05;
 
+const DATA_ENTITY_SELECTOR = "ic-data-entity";
+const ORDER_DETAILS_HEADING_SELECTOR = '[heading="Order details"]';
+const DATA_ROW_SELECTOR = "ic-data-row";
+const TYPOGRAPHY_SELECTOR = "ic-typography";
+const TEXT_FIELD_SELECTOR = "ic-text-field";
+const LARGE_SPACING_CSS = "var(--ic-space-lg)";
+
 describe("IcDataEntity E2E ,visual and a11y testing", () => {
   beforeEach(() => {
     cy.injectAxe();
@@ -97,11 +104,12 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
         </IcDataEntity>
       </div>
     );
-    cy.checkHydrated("ic-data-entity");
-    cy.get('[heading="Order details"]').should(BE_VISIBLE);
+    cy.checkHydrated(DATA_ENTITY_SELECTOR);
+    cy.get(ORDER_DETAILS_HEADING_SELECTOR).should(BE_VISIBLE);
     cy.get('[label="Order name"]').should(BE_VISIBLE);
-    cy.get("ic-data-row").should(HAVE_VALUE, "Michael");
+    cy.get(DATA_ROW_SELECTOR).should(HAVE_VALUE, "Michael");
     cy.get("ic-link").should(BE_VISIBLE).should(HAVE_TEXT, "Edit");
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "oneDataRow",
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.05,
@@ -125,15 +133,16 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
         </IcDataEntity>
       </div>
     );
-    cy.checkHydrated("ic-data-entity");
-    cy.get('[heading="Order details"]').should(BE_VISIBLE);
+    cy.checkHydrated(DATA_ENTITY_SELECTOR);
+    cy.get(ORDER_DETAILS_HEADING_SELECTOR).should(BE_VISIBLE);
     cy.get('[label="Download receipt"]').should(BE_VISIBLE);
-    cy.get("ic-data-row").should(HAVE_VALUE, "CoffeeOrder_X46w32.pdf");
+    cy.get(DATA_ROW_SELECTOR).should(HAVE_VALUE, "CoffeeOrder_X46w32.pdf");
     cy.get("ic-button").should(BE_VISIBLE);
     cy.get("ic-button")
       .shadow()
       .find('[aria-label="Download"]')
       .should(BE_VISIBLE);
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "downloadReceipt",
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.05,
@@ -190,14 +199,15 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
         </IcDataEntity>
       </div>
     );
-    cy.checkHydrated("ic-data-entity");
-    cy.get('[heading="Order details"]').should(BE_VISIBLE);
+    cy.checkHydrated(DATA_ENTITY_SELECTOR);
+    cy.get(ORDER_DETAILS_HEADING_SELECTOR).should(BE_VISIBLE);
     cy.get('[label="Drink"]').should(BE_VISIBLE);
-    cy.get("ic-data-row").should(HAVE_VALUE, "Americano");
-    cy.findShadowEl("ic-status-tag", "ic-typography").should(
+    cy.get(DATA_ROW_SELECTOR).should(HAVE_VALUE, "Americano");
+    cy.findShadowEl("ic-status-tag", TYPOGRAPHY_SELECTOR).should(
       HAVE_TEXT,
       "In Progress"
     );
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "inProgresssTag",
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.05,
@@ -226,7 +236,7 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
         </IcDataEntity>
       </div>
     );
-    cy.checkA11y(undefined, CYPRESS_AXE_OPTIONS);
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "sizeToSmall",
       testThreshold: DEFAULT_TEST_THRESHOLD,
@@ -257,20 +267,21 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
         </IcDataEntity>
       </div>
     );
-    cy.checkHydrated("ic-data-entity");
+    cy.checkHydrated(DATA_ENTITY_SELECTOR);
     cy.get('[heading="Personal details"]').should(BE_VISIBLE);
     cy.get('[label="Address"]').should(BE_VISIBLE);
-    cy.get("ic-typography").each(($el) => {
+    cy.get(TYPOGRAPHY_SELECTOR).each(($el) => {
       cy.wrap($el)
         .invoke("text")
         .then((address) => {
           cy.log(address);
         });
     });
-    cy.findShadowEl("ic-status-tag", "ic-typography").should(
+    cy.findShadowEl("ic-status-tag", TYPOGRAPHY_SELECTOR).should(
       HAVE_TEXT,
       "not confirmed"
     );
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "smallSizeLastRow",
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.05,
@@ -330,27 +341,27 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
           </IcDataEntity>
           <IcButton
             onClick={() => {
-              const textFields = document.querySelectorAll("ic-text-field");
+              const textFields = document.querySelectorAll(TEXT_FIELD_SELECTOR);
               textFields.forEach((textField) => {
                 textField.setAttribute("readonly", "");
               });
             }}
             style={{
               marginRight: "var(--ic-space-md)",
-              marginTop: "var(--ic-space-lg)",
+              marginTop: LARGE_SPACING_CSS,
             }}
           >
             Confirm
           </IcButton>
           <IcButton
             onClick={() => {
-              const textFields = document.querySelectorAll("ic-text-field");
+              const textFields = document.querySelectorAll(TEXT_FIELD_SELECTOR);
               textFields.forEach((textField) => {
                 textField.removeAttribute("readonly");
               });
             }}
             variant="secondary"
-            style={{ marginTop: "var(--ic-space-lg)" }}
+            style={{ marginTop: LARGE_SPACING_CSS }}
           >
             Edit
           </IcButton>
@@ -381,44 +392,45 @@ describe("IcDataEntity E2E ,visual and a11y testing", () => {
           </IcDataEntity>
           <IcButton
             onClick={() => {
-              const textFields = document.querySelectorAll("ic-text-field");
+              const textFields = document.querySelectorAll(TEXT_FIELD_SELECTOR);
               textFields.forEach((textField) => {
                 textField.setAttribute("readonly", "");
               });
             }}
             style={{
               marginRight: "var(--ic-space-md)",
-              marginTop: "var(--ic-space-lg)",
+              marginTop: LARGE_SPACING_CSS,
             }}
           >
             Confirm
           </IcButton>
           <IcButton
             onClick={() => {
-              const textFields = document.querySelectorAll("ic-text-field");
+              const textFields = document.querySelectorAll(TEXT_FIELD_SELECTOR);
               textFields.forEach((textField) => {
                 textField.removeAttribute("readonly");
               });
             }}
             variant="secondary"
-            style={{ marginTop: "var(--ic-space-lg)" }}
+            style={{ marginTop: LARGE_SPACING_CSS }}
           >
             Edit
           </IcButton>
         </>
       </div>
     );
-    cy.checkHydrated("ic-data-entity");
-    cy.get('[heading="Order details"]').should(BE_VISIBLE);
+    cy.checkHydrated(DATA_ENTITY_SELECTOR);
+    cy.get(ORDER_DETAILS_HEADING_SELECTOR).should(BE_VISIBLE);
     cy.get('[label="Order name"]').should(BE_VISIBLE);
     cy.get("input").should(HAVE_VALUE, "Michael");
     cy.get("ic-button").should(HAVE_LENGTH, "2");
     cy.get("ic-button").contains("Edit").click();
-    cy.findShadowEl("ic-text-field", "input")
+    cy.findShadowEl(TEXT_FIELD_SELECTOR, "input")
       .clear()
       .type("Matt")
       .should(HAVE_VALUE, "Matt");
     cy.get("ic-button").contains("Confirm").click();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "editableNameData",
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.05,

--- a/packages/web-components/src/components/ic-data-entity/ic-data-entity.tsx
+++ b/packages/web-components/src/components/ic-data-entity/ic-data-entity.tsx
@@ -28,18 +28,16 @@ export class DataEntity {
   @Prop() small?: boolean = false;
 
   render() {
-    const { heading, small, size } = this;
-
-    const children = this.el.children;
+    const { el, heading, small, size } = this;
 
     if (small || size === "small") {
-      for (let i = 0; i < children.length; i++) {
-        children[i].setAttribute("size", "small");
-      }
+      Array.from(el.children).forEach((child) =>
+        child.setAttribute("size", "small")
+      );
     }
 
     return (
-      <Host class={{ ["small"]: small || size === "small" }}>
+      <Host class={{ small: small || size === "small" }}>
         <div class="heading" id="data-entity-heading">
           <slot name="heading">
             <ic-typography variant="h3">{heading}</ic-typography>

--- a/packages/web-components/src/components/ic-data-row/test/basic/__snapshots__/ic-data-row.spec.ts.snap
+++ b/packages/web-components/src/components/ic-data-row/test/basic/__snapshots__/ic-data-row.spec.ts.snap
@@ -6,11 +6,9 @@ exports[`ic-data-row should not render label element if no label provided 1`] = 
     <div class="data">
       <div class="text-cells">
         <div class="value">
-          <slot name="value">
-            <ic-typography variant="body">
-              value
-            </ic-typography>
-          </slot>
+          <ic-typography variant="body">
+            value
+          </ic-typography>
         </div>
       </div>
     </div>
@@ -30,11 +28,9 @@ exports[`ic-data-row should render 1`] = `
           </ic-typography>
         </div>
         <div class="value">
-          <slot name="value">
-            <ic-typography variant="body">
-              value
-            </ic-typography>
-          </slot>
+          <ic-typography variant="body">
+            value
+          </ic-typography>
         </div>
       </div>
     </div>
@@ -54,17 +50,13 @@ exports[`ic-data-row should render slotted content in the end-component slot 1`]
           </ic-typography>
         </div>
         <div class="value">
-          <slot name="value">
-            <ic-typography variant="body">
-              test value
-            </ic-typography>
-          </slot>
+          <ic-typography variant="body">
+            test value
+          </ic-typography>
         </div>
       </div>
       <div class="end-component">
-        <div role="cell">
-          <slot aria-label="for label row" name="end-component"></slot>
-        </div>
+        <slot aria-label="for label row" name="end-component"></slot>
       </div>
     </div>
     <div class="divider"></div>
@@ -82,11 +74,9 @@ exports[`ic-data-row should render slotted content in the label slot 1`] = `
           <slot name="label"></slot>
         </div>
         <div class="value">
-          <slot name="value">
-            <ic-typography variant="body">
-              value
-            </ic-typography>
-          </slot>
+          <ic-typography variant="body">
+            value
+          </ic-typography>
         </div>
       </div>
     </div>
@@ -109,9 +99,7 @@ exports[`ic-data-row should render slotted content in the value slot 1`] = `
           </ic-typography>
         </div>
         <div class="value">
-          <slot name="value">
-            <ic-typography variant="body"></ic-typography>
-          </slot>
+          <slot name="value"></slot>
         </div>
       </div>
     </div>
@@ -132,9 +120,7 @@ exports[`ic-data-row should render the label variant of typography when entity s
           </ic-typography>
         </div>
         <div class="value">
-          <slot name="value">
-            <ic-typography variant="body"></ic-typography>
-          </slot>
+          <slot name="value"></slot>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary of the changes
Removed cell role from ic-data-entity

## Related issue
#1465 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.