### PR TITLE
1488 accordion group improve see all labelling accessibility

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-03-01T12:08:26",
+  "timestamp": "2024-03-05T07:06:36",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.10.0",
@@ -207,6 +207,28 @@
       "docsTags": [],
       "usage": {},
       "props": [
+        {
+          "name": "accessibleButtonLabel",
+          "type": "string",
+          "complexType": {
+            "original": "string",
+            "resolved": "string",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "accessible-button-label",
+          "reflectToAttr": false,
+          "docs": "The accessible button label to provide more context to the 'See all/Hide all' button for screen reader users.",
+          "docsTags": [],
+          "default": "\"accordions\"",
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
         {
           "name": "appearance",
           "type": "\"dark\" | \"default\" | \"light\"",

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -87,6 +87,10 @@ export namespace Components {
     }
     interface IcAccordionGroup {
         /**
+          * The accessible button label to provide more context to the 'See all/Hide all' button for screen reader users.
+         */
+        "accessibleButtonLabel": string;
+        /**
           * The appearance of the accordion group, e.g dark, or light.
          */
         "appearance": IcThemeForeground;
@@ -3286,6 +3290,10 @@ declare namespace LocalJSX {
         "size"?: IcSizes;
     }
     interface IcAccordionGroup {
+        /**
+          * The accessible button label to provide more context to the 'See all/Hide all' button for screen reader users.
+         */
+        "accessibleButtonLabel"?: string;
         /**
           * The appearance of the accordion group, e.g dark, or light.
          */

--- a/packages/web-components/src/components/ic-accordion-group/ic-accordion-group.tsx
+++ b/packages/web-components/src/components/ic-accordion-group/ic-accordion-group.tsx
@@ -25,6 +25,12 @@ export class AccordionGroup {
   @State() accordions: HTMLIcAccordionElement[];
 
   @State() areAllAccordionsOpen: boolean;
+
+  /**
+   * The accessible button label to provide more context to the 'See all/Hide all' button for screen reader users.
+   */
+  @Prop() accessibleButtonLabel: string = "accordions";
+
   /**
    * The appearance of the accordion group, e.g dark, or light.
    */
@@ -114,8 +120,18 @@ export class AccordionGroup {
     );
   };
 
+  private accordionOpenBtnText = () => {
+    return !this.areAllAccordionsOpen ? "See all" : "Hide all";
+  };
+
   render() {
-    const { appearance, size, groupTitle, singleExpansion } = this;
+    const {
+      appearance,
+      size,
+      groupTitle,
+      singleExpansion,
+      accessibleButtonLabel,
+    } = this;
     return (
       <Host
         context-id={this.accordionGroupId}
@@ -134,8 +150,9 @@ export class AccordionGroup {
               appearance={appearance === "light" ? "light" : "default"}
               onClick={this.handleExpanded}
               variant="tertiary"
+              aria-label={`${this.accordionOpenBtnText()} ${accessibleButtonLabel}`}
             >
-              {!this.areAllAccordionsOpen ? "See all" : "Hide all"}
+              {this.accordionOpenBtnText()}
             </ic-button>
           )}
         </div>

--- a/packages/web-components/src/components/ic-accordion-group/readme.md
+++ b/packages/web-components/src/components/ic-accordion-group/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property          | Attribute          | Description                                                | Type                              | Default     |
-| ----------------- | ------------------ | ---------------------------------------------------------- | --------------------------------- | ----------- |
-| `appearance`      | `appearance`       | The appearance of the accordion group, e.g dark, or light. | `"dark" \| "default" \| "light"`  | `"default"` |
-| `expanded`        | `expanded`         | If `true`, the accordion will load in an expanded state.   | `boolean`                         | `false`     |
-| `groupTitle`      | `group-title`      | The header for the accordion group.                        | `string`                          | `""`        |
-| `singleExpansion` | `single-expansion` | If `true`, only one accordion will open at a time.         | `boolean`                         | `false`     |
-| `size`            | `size`             | The size of the accordion.                                 | `"default" \| "large" \| "small"` | `"default"` |
+| Property                | Attribute                 | Description                                                                                                   | Type                              | Default        |
+| ----------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------- |
+| `accessibleButtonLabel` | `accessible-button-label` | The accessible button label to provide more context to the 'See all/Hide all' button for screen reader users. | `string`                          | `"accordions"` |
+| `appearance`            | `appearance`              | The appearance of the accordion group, e.g dark, or light.                                                    | `"dark" \| "default" \| "light"`  | `"default"`    |
+| `expanded`              | `expanded`                | If `true`, the accordion will load in an expanded state.                                                      | `boolean`                         | `false`        |
+| `groupTitle`            | `group-title`             | The header for the accordion group.                                                                           | `string`                          | `""`           |
+| `singleExpansion`       | `single-expansion`        | If `true`, only one accordion will open at a time.                                                            | `boolean`                         | `false`        |
+| `size`                  | `size`                    | The size of the accordion.                                                                                    | `"default" \| "large" \| "small"` | `"default"`    |
 
 
 ## Dependencies

--- a/packages/web-components/src/components/ic-accordion-group/test/basic/__snapshots__/ic-accordion-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-accordion-group/test/basic/__snapshots__/ic-accordion-group.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`ic-accordion-group snapshots should match default snapshot: renders as 
           Test heading
         </h3>
       </ic-typography>
-      <ic-button appearance="default" variant="tertiary">
+      <ic-button appearance="default" aria-label="Hide all accordions" variant="tertiary">
         Hide all
       </ic-button>
     </div>
@@ -27,7 +27,7 @@ exports[`ic-accordion-group snapshots should match light snapshot: renders as li
           Test heading
         </h3>
       </ic-typography>
-      <ic-button appearance="light" variant="tertiary">
+      <ic-button appearance="light" aria-label="Hide all accordions" variant="tertiary">
         Hide all
       </ic-button>
     </div>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add accessible title prop to accordion group to improve accessibility for screen reader users, and add aria label to see all/hide all button which utilises the new accessible title prop

## Related issue
#1488 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.