### PR TITLE
fix(web-components): ic-toggle-button a11y fix

### DIFF
--- a/packages/web-components/src/components/ic-toggle-button/ic-toggle-button.tsx
+++ b/packages/web-components/src/components/ic-toggle-button/ic-toggle-button.tsx
@@ -133,8 +133,7 @@ export class ToggleButton {
         }}
       >
         <ic-button
-          role="checkbox"
-          aria-checked={this.toggleChecked ? "true" : "false"}
+          aria-pressed={this.toggleChecked.toString()}
           variant={this.variant === "icon" ? "icon" : "secondary"}
           onClick={this.handleClick}
           title={this.accessibleLabel}

--- a/packages/web-components/src/components/ic-toggle-button/test/basic/__snapshots__/ic-toggle-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-toggle-button/test/basic/__snapshots__/ic-toggle-button.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ic-toggle-button component should render 1`] = `
 <ic-toggle-button class="default" label="Toggle" variant="default">
   <mock:shadow-root>
-    <ic-button appearance="default" aria-checked="false" aria-disabled="false" aria-label="Toggle, unticked" role="checkbox" size="default" variant="secondary">
+    <ic-button appearance="default" aria-disabled="false" aria-label="Toggle, unticked" aria-pressed="false" size="default" variant="secondary">
       Toggle
       <slot></slot>
     </ic-button>
@@ -14,7 +14,7 @@ exports[`ic-toggle-button component should render 1`] = `
 exports[`ic-toggle-button component should render icon variant 1`] = `
 <ic-toggle-button accessible-label="Refresh the page" class="default icon" variant="icon">
   <mock:shadow-root>
-    <ic-button appearance="default" aria-checked="false" aria-disabled="false" aria-label="Refresh the page, unticked" role="checkbox" size="default" title="Refresh the page" variant="icon">
+    <ic-button appearance="default" aria-disabled="false" aria-label="Refresh the page, unticked" aria-pressed="false" size="default" title="Refresh the page" variant="icon">
       <slot></slot>
     </ic-button>
   </mock:shadow-root>
@@ -28,7 +28,7 @@ exports[`ic-toggle-button component should render icon variant 1`] = `
 exports[`ic-toggle-button component should render slotted badge 1`] = `
 <ic-toggle-button class="default" label="Toggle" variant="default">
   <mock:shadow-root>
-    <ic-button appearance="default" aria-checked="false" aria-disabled="false" aria-label="Toggle, unticked" role="checkbox" size="default" variant="secondary">
+    <ic-button appearance="default" aria-disabled="false" aria-label="Toggle, unticked" aria-pressed="false" size="default" variant="secondary">
       Toggle
       <slot></slot>
       <slot name="badge" slot="badge"></slot>
@@ -41,7 +41,7 @@ exports[`ic-toggle-button component should render slotted badge 1`] = `
 exports[`ic-toggle-button component should render slotted icon 1`] = `
 <ic-toggle-button class="default" label="Toggle" variant="default">
   <mock:shadow-root>
-    <ic-button appearance="default" aria-checked="false" aria-disabled="false" aria-label="Toggle, unticked" role="checkbox" size="default" variant="secondary">
+    <ic-button appearance="default" aria-disabled="false" aria-label="Toggle, unticked" aria-pressed="false" size="default" variant="secondary">
       Toggle
       <slot></slot>
       <slot name="icon" slot="icon"></slot>
@@ -57,7 +57,7 @@ exports[`ic-toggle-button component should render slotted icon 1`] = `
 exports[`ic-toggle-button component should render slotted icon with icon placement 1`] = `
 <ic-toggle-button class="default" icon-placement="right" label="Toggle" variant="default">
   <mock:shadow-root>
-    <ic-button appearance="default" aria-checked="false" aria-disabled="false" aria-label="Toggle, unticked" role="checkbox" size="default" variant="secondary">
+    <ic-button appearance="default" aria-disabled="false" aria-label="Toggle, unticked" aria-pressed="false" size="default" variant="secondary">
       Toggle
       <slot></slot>
       <slot name="icon" slot="right-icon"></slot>


### PR DESCRIPTION
## Summary of the changes
role='checkbox' removed from button and aria-pressed used to indicate state

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Related issue
#1502 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.