### PR TITLE
1349 ic selectic menu prevent icblur from being triggered

### DIFF
--- a/packages/react/src/component-tests/IcSelect/IcSelect.cy.tsx
+++ b/packages/react/src/component-tests/IcSelect/IcSelect.cy.tsx
@@ -18,6 +18,7 @@ import {
   HAVE_VALUE,
   NOT_BE_FOCUSED,
   NOT_BE_VISIBLE,
+  NOT_HAVE_BEEN_CALLED,
 } from "../utils/constants";
 import {
   ARIA_SELECTED,
@@ -1298,6 +1299,18 @@ describe("IcSelect", () => {
     cy.get("@icFocus").should(HAVE_BEEN_CALLED_ONCE);
     cy.get("ic-select").blur();
     cy.get("@icBlur").should(HAVE_BEEN_CALLED);
+  });
+
+  it("should not call icBlur when menu is focused", () => {
+    mount(
+      <IcSelect
+        label="What is your favourite coffee?"
+        options={coffeeOptions}
+      />
+    );
+    cy.get("ic-select").invoke("on", "icBlur", cy.stub().as("icBlur"));
+    cy.findShadowEl("ic-select", IC_INPUT_CONTAINER).type(TYPE_DOWN_ARROW);
+    cy.get("@icBlur").should(NOT_HAVE_BEEN_CALLED);
   });
 
   it("should set the 'placeholder' class name if no option is selected", () => {

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -920,8 +920,8 @@ export class Select {
     const target = event.relatedTarget as HTMLElement;
     if (
       target !== null &&
-      target.tagName === "UL" &&
-      target.className.includes("menu")
+      ((target.tagName === "UL" && target.className.includes("menu")) ||
+        (target.tagName === "LI" && target.className.includes("option")))
     ) {
       return;
     }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Improve select onBlur to not blur if focusing on a menu option rather than just menu

## Related issue
#1349 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.