### PR TITLE
Remove storybook dark theme

### DIFF
--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -1,7 +1,6 @@
 import "../dist/core/normalize.css";
 import "@ukic/fonts/dist/fonts.css";
 import "../dist/core/core.css";
-import "./storybook.css";
 
 export const parameters = {
     controls: { 

--- a/packages/react/.storybook/storybook.css
+++ b/packages/react/.storybook/storybook.css
@@ -1,3 +1,0 @@
-:root {
-    color-scheme: light dark;
-}

--- a/packages/web-components/.storybook/preview.js
+++ b/packages/web-components/.storybook/preview.js
@@ -1,7 +1,6 @@
 import "../src/global/normalize.css"
 import "@ukic/fonts/dist/fonts.css";
 import "../src/global/icds.css";
-import "./storybook.css";
 
 import { defineCustomElements } from '../dist/esm/loader';
 

--- a/packages/web-components/.storybook/storybook.css
+++ b/packages/web-components/.storybook/storybook.css
@@ -1,3 +1,0 @@
-:root {
-    color-scheme: light dark;
-}


### PR DESCRIPTION
## Summary of the changes
Initially, dark color-scheme was implemented to allow us to spot where our components don't work with dark mode. However, since we don't support dark mode, this change gives the impression that our components now support this feature, which would subsequently cause confusion for users who view our components not working in our own storybook. I have documented which components are most affected in dark mode, and following conversation with design, it has become clear that a technical review needs to be done of our component library as to how we can smoothly implement a fully researched dark mode colour scheme, that maintains appropriate colour contrast and follows best practises, before we can begin making changes to our components. 

Until this research has been done, the dark color-scheme is being reverted back to just light mode. A [ticket](https://github.com/mi6/ic-ui-kit/issues/1654) has been raised for this research spike.

## Related issue
#991 
#1510 