### PR TITLE
fix(web-components): changed ic-select icBlur to confirm menu exists before using querySelector

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -47,7 +47,6 @@ let inputIds = 0;
     delegatesFocus: true,
   },
 })
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export class Select {
   private anchorEl: HTMLElement;
   private blurredBecauseButtonPressed: boolean;
@@ -57,7 +56,7 @@ export class Select {
   private debounceAria: number;
   private hasSetDefaultValue = false;
   private hasTimedOut: boolean;
-  private inheritedAttributes: { [k: string]: unknown } = {};
+  private inheritedAttributes: { [k: string]: string } = {};
   private initialOptionsEmpty = false;
   private inputId = `ic-select-input-${inputIds++}`;
   private menu: HTMLIcMenuElement;
@@ -916,8 +915,8 @@ export class Select {
     this.icFocus.emit();
   };
 
-  private onBlur = (event: FocusEvent): void => {
-    const target = event.relatedTarget as HTMLElement;
+  private onBlur = ({ relatedTarget }: FocusEvent): void => {
+    const target = relatedTarget as HTMLElement;
     if (
       target !== null &&
       ((target.tagName === "UL" && target.className.includes("menu")) ||
@@ -929,12 +928,13 @@ export class Select {
     const retryButton = this.menu?.querySelector("#retry-button");
     const isSearchableAndNoFocusedInternalElements =
       this.searchable &&
-      event.relatedTarget !== this.menu &&
+      !!this.menu &&
+      target !== this.menu &&
       !Array.from(this.menu.querySelectorAll("[role='option']")).includes(
-        event.relatedTarget as Element
+        target
       ) &&
-      !(this.clearButton && event.relatedTarget === this.clearButton) &&
-      !(retryButton && event.relatedTarget === retryButton);
+      !(this.clearButton && target === this.clearButton) &&
+      !(retryButton && target === retryButton);
 
     if (isSearchableAndNoFocusedInternalElements) {
       if (!this.retryButtonClick) {

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -33,14 +33,14 @@ const linkIcInput = "input.ic-input";
 export const inheritAttributes = (
   element: HTMLElement,
   attributes: string[] = []
-): { [key: string]: unknown } => {
-  const attributeObject: { [key: string]: unknown } = {};
+): { [key: string]: string } => {
+  const attributeObject: { [key: string]: string } = {};
 
   attributes.forEach((attr) => {
     if (element.hasAttribute(attr)) {
       const value = element.getAttribute(attr);
       if (value !== null) {
-        attributeObject[attr] = element.getAttribute(attr);
+        attributeObject[attr] = value;
       }
       element.removeAttribute(attr);
     }


### PR DESCRIPTION
## Summary of the changes
added check to icBlur to ensure that ic-menu element exists before using querySelector on it

## Related issue
#1458 

## Checklist
- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] All acceptance criteria reviewed and met. 
- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.
- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
- [x] All prop combinations work without issue. 
- [x] Changes to docs package checked and committed.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.