### PR TITLE
fix(root): updated e2e tests to fix the build step for canary components

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -122,7 +122,12 @@ jobs:
 
       - name: E2E core tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
+        id: core_e2e_tests
         run: npm run test-e2e
+
+      - name: Build core components
+        if: ${{ steps.core_e2e_tests.outcome == 'skipped' && needs.check-updates.outputs.canary == 'true' }}
+        run: npm run build
 
       - name: E2E canary tests
         if: ${{ needs.check-updates.outputs.canary == 'true' }}

--- a/.github/workflows/ic-ui-kit-develop.yml
+++ b/.github/workflows/ic-ui-kit-develop.yml
@@ -97,7 +97,12 @@ jobs:
 
       - name: E2E core tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
+        id: core_e2e_tests
         run: npm run test-e2e
+
+      - name: Build core components
+        if: ${{ steps.core_e2e_tests.outcome == 'skipped' && needs.check-updates.outputs.canary == 'true' }}
+        run: npm run build
 
       - name: E2E canary tests
         if: ${{ needs.check-updates.outputs.canary == 'true' }}

--- a/.github/workflows/ic-ui-kit-main.yml
+++ b/.github/workflows/ic-ui-kit-main.yml
@@ -93,7 +93,12 @@ jobs:
 
       - name: E2E core tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
+        id: core_e2e_tests
         run: npm run test-e2e
+
+      - name: Build core components
+        if: ${{ steps.core_e2e_tests.outcome == 'skipped' && needs.check-updates.outputs.canary == 'true' }}
+        run: npm run build
 
       - name: E2E canary tests
         if: ${{ needs.check-updates.outputs.canary == 'true' }}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updated the e2e steps for building component for canary tests. If the core e2e tests were skipped, canary e2e tests would fail. An additional step has been added so if core e2e tests (which includes a build) are skipped, a separate build command is run in place.

## Related issue
N/A

## Checklist
N/A