### PR TITLE
feat(react): added tabbing and other interactions into cypress tests …

### DIFF
--- a/packages/react/cypress/support/index.ts
+++ b/packages/react/cypress/support/index.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import "./component";
+import "cypress-real-events";
 
 import Commands from "./commands";
 

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -38,6 +38,7 @@
         "cypress-axe": "^1.5.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-image-diff-js": "^2.1.3",
+        "cypress-real-events": "^1.12.0",
         "eslint-plugin-cypress": "^2.15.1",
         "mkdirp": "^1.0.4",
         "np": "^7.6.0",
@@ -11176,6 +11177,15 @@
       },
       "peerDependencies": {
         "cypress": ">=9.6.1"
+      }
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.12.0.tgz",
+      "integrity": "sha512-oiy+4kGKkzc2PT36k3GGQqkGxNiVypheWjMtfyi89iIk6bYmTzeqxapaLHS3pnhZOX1IEbTDUVxh8T4Nhs1tyQ==",
+      "dev": true,
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x"
       }
     },
     "node_modules/cypress-recurse": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,6 +69,7 @@
     "cypress-axe": "^1.5.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-image-diff-js": "^2.1.3",
+    "cypress-real-events": "^1.12.0",
     "eslint-plugin-cypress": "^2.15.1",
     "mkdirp": "^1.0.4",
     "np": "^7.6.0",

--- a/packages/react/src/component-tests/IcAccordion/IcAccordion.cy.tsx
+++ b/packages/react/src/component-tests/IcAccordion/IcAccordion.cy.tsx
@@ -162,6 +162,8 @@ describe("IcAccordionGroup", () => {
         <TwoAccordionsWithOneExpanded />
       </IcAccordionGroup>
     );
+    cy.checkHydrated(IC_ACCORDION_GROUP);
+
     cy.get(getAccordionSelector(1))
       .invoke("prop", "expanded")
       .should("eq", false);
@@ -169,13 +171,23 @@ describe("IcAccordionGroup", () => {
       .invoke("prop", "expanded")
       .should("eq", true);
 
-    cy.get(getAccordionSelector(1)).click();
+    cy.findShadowEl(getAccordionSelector(1), "button")
+      .focus()
+      .realPress("Space");
     cy.get(getAccordionSelector(1))
       .invoke("prop", "expanded")
       .should("eq", true);
     cy.get(getAccordionSelector(2))
       .invoke("prop", "expanded")
       .should("eq", false);
+
+    cy.realPress("Tab").realPress("Space");
+    cy.get(getAccordionSelector(1))
+      .invoke("prop", "expanded")
+      .should("eq", false);
+    cy.get(getAccordionSelector(2))
+      .invoke("prop", "expanded")
+      .should("eq", true);
   });
 
   it("both accordions should open when single expansion is false", () => {

--- a/packages/react/src/component-tests/IcSideNavigation/IcSideNavigation.cy.tsx
+++ b/packages/react/src/component-tests/IcSideNavigation/IcSideNavigation.cy.tsx
@@ -24,6 +24,7 @@ import {
   StaticSideNav,
   checkSideNavSize,
 } from "./IcSideNavigationTestData";
+import _ from "cypress/types/lodash";
 
 const DEFAULT_HEIGHT = 1171;
 const DEFAULT_TEST_THRESHOLD = 0.06;
@@ -279,6 +280,18 @@ describe("IcSideNavigation", () => {
       mount(<BasicSideNav />);
 
       cy.clickOnShadowEl(SIDE_NAV_LABEL, EXPAND_BUTTON_SELECTOR);
+      cy.checkSideNavSize(true);
+
+      cy.clickOnShadowEl(SIDE_NAV_LABEL, EXPAND_BUTTON_SELECTOR);
+      cy.checkSideNavSize(false);
+    });
+
+    it("expands when expand button is tabbed to and pressed", () => {
+      mount(<BasicSideNav />);
+      cy.checkHydrated(SIDE_NAV_LABEL);
+      cy.findShadowEl("ic-side-navigation", ".title-link").focus();
+      Cypress._.times(4, () => cy.realPress("Tab"));
+      cy.realPress("Enter");
       cy.checkSideNavSize(true);
 
       cy.clickOnShadowEl(SIDE_NAV_LABEL, EXPAND_BUTTON_SELECTOR);

--- a/packages/react/src/component-tests/IcToggleButtonGroup/IcToggleButtonGroup.cy.tsx
+++ b/packages/react/src/component-tests/IcToggleButtonGroup/IcToggleButtonGroup.cy.tsx
@@ -96,6 +96,13 @@ describe("IcToggleButtonGroup", () => {
       getToggle(1).click({ force: true });
       cy.get(WIN_CONSOLE_SPY).should(NOT_HAVE_BEEN_CALLED);
     });
+    it("should tab through toggles and check focus and selection state", () => {
+      mount(<ToggleGroupSingle />);
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
+
+      getToggle(2).focus().realPress(["Shift", "Tab"]);
+      cy.get(IC_TOGGLE_BUTTON_GROUP).should(HAVE_FOCUS);
+    });
   });
   describe("screenshots", () => {
     beforeEach(() => {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitAny": true,
     "jsx": "react",
     "allowJs": true,
-    "types": ["cypress", "node", "cypress-axe", "cypress-file-upload"]
+    "types": ["cypress", "node", "cypress-axe", "cypress-file-upload", "cypress-real-events"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["**/__tests__/**", "cypress/**", "src/component-tests/**/*"],


### PR DESCRIPTION
…suite

## Summary of the changes
Previously cypress did not support tabbing(keyboard), adding cypress-real-events allows us to test the components in a more comprehensive manner in which our users would interact with them

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Related issue
#1538 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.