### PR TITLE
chore(react): update React version to be the same as the web componen…

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.16.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.15.1...@ukic/react@2.16.0) (2024-04-08)
+
+
+### Features
+
+* **react:** add examples of components with type="dot" badge ([0215a0d](https://github.com/mi6/ic-ui-kit/commit/0215a0d15d72b6ef0f27443a44ff144edd5802fe)), closes [.#1391](https://github.com/./issues/1391)
+
+
+
+
+
 ## [2.15.1](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.15.0...@ukic/react@2.15.1) (2024-03-28)
 
 **Note:** Version bump only for package @ukic/react

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@ukic/react",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukic/react",
-      "version": "2.15.1",
+      "version": "2.16.0",
       "license": "MIT",
       "dependencies": {
-        "@ukic/web-components": "^2.16.0"
+        "@ukic/web-components": "^2.17.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "sideEffects": [
     "*.css"
   ],
-  "version": "2.15.1",
+  "version": "2.16.0",
   "description": "React-wrapped web components compiled using StencilJS",
   "author": "mi6",
   "bugs": {
@@ -40,7 +40,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@ukic/web-components": "^2.16.0"
+    "@ukic/web-components": "^2.17.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",


### PR DESCRIPTION
## Summary of the changes
Ran `npm run release-check` and committed the changes for the React package only in an attempt to bring the version number back in sync with the web components version.

## Related issue
N/A