### PR TITLE
Add auto height to `ic-navigation-item` when it's in the side menu

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -141,6 +141,7 @@ svg {
 :host(.navigation-item-side-menu) .link,
 :host(.navigation-item-side-menu) ::slotted(a) {
   min-height: 2.5rem;
+  height: auto;
   width: 100%;
   box-sizing: border-box;
   color: var(--ic-color-primary-text);

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -326,7 +326,7 @@ slot[name="app-title"]::slotted(a) {
 ::slotted(ic-navigation-group) {
   --navigation-item-justify-content: flex-start;
   --navigation-item-min-height: 56px;
-  --navigation-item-height: 100%;
+  --navigation-item-height: auto;
 }
 
 /* Toggle Chevron */
@@ -588,7 +588,7 @@ slot[name="app-title"]::slotted(a) {
 :host(.sm-expanded.side-display) ::slotted(ic-navigation-item),
 :host(.sm-expanded.side-display) ::slotted(ic-navigation-group) {
   --navigation-item-label-opacity: 1;
-  --navigation-item-height: 100%;
+  --navigation-item-height: auto;
   --navigation-item-min-height: 56px;
   --navigation-item-width: 320px;
   --navigation-item-side-nav-right: var(--ic-space-xl);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add auto height to `ic-navigation-item` when it's in the side menu to prevent it stretching when used in Stackblitz

## Related issue
https://github.com/mi6/ic-design-system/issues/760 https://github.com/mi6/ic-design-system/issues/764  https://github.com/mi6/ic-design-system/issues/751
