### PR TITLE
Bugfix/date input validation

### DIFF
--- a/packages/canary-react/src/component-tests/IcDateInput/IcDateInput.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDateInput/IcDateInput.cy.tsx
@@ -673,30 +673,80 @@ describe("IcDateInput", () => {
 
   it("should clear input when clear button pressed", () => {
     mount(
-      <IcDateInput
-        label="Test Label"
-        value="20/01/2000"
-        showClearButton
-      />
+      <IcDateInput label="Test Label" value="20/01/2000" showClearButton />
     );
 
     cy.checkHydrated(DATE_INPUT);
 
-    cy.get(DATE_INPUT).invoke(
-      "on",
-      "icChange",
-      cy.stub().as("icDateChanged")
-    );
+    cy.get(DATE_INPUT).invoke("on", "icChange", cy.stub().as("icDateChanged"));
 
-    cy.findShadowEl(DATE_INPUT, "#clear-button").shadow().find("button").focus().click()
-    
+    cy.findShadowEl(DATE_INPUT, "#clear-button")
+      .shadow()
+      .find("button")
+      .focus()
+      .click();
+
     cy.findShadowEl(DATE_INPUT, MONTH_INPUT_ARIA_LABEL).should(
       "have.value",
       ""
-    ); 
+    );
 
     cy.get("@icDateChanged").should((stub) => {
       expect(stub.getCall(0).args[0].detail.value).to.equal(null);
     });
+  });
+
+  it("should display validation styling and svg with empty validation message when validation message set to empty string for disable past", () => {
+    mount(
+      <IcDateInput label="Test Label" disablePast disablePastMessage={""} />
+    );
+
+    cy.checkHydrated(DATE_INPUT);
+
+    cy.findShadowEl(DATE_INPUT, DAY_INPUT_ARIA_LABEL).type("18");
+    cy.findShadowEl(DATE_INPUT, MONTH_INPUT_ARIA_LABEL).type("02");
+    cy.findShadowEl(DATE_INPUT, YEAR_INPUT_ARIA_LABEL).type("1990");
+
+    cy.findShadowEl(DATE_INPUT, "ic-input-validation").should(
+      "have.class",
+      "error"
+    );
+
+    cy.findShadowEl(DATE_INPUT, "ic-input-validation svg").should(
+      "have.attr",
+      "aria-labelledby",
+      "error-title"
+    );
+
+    cy.findShadowEl(DATE_INPUT, "ic-input-validation ic-typography").should(
+      "not.have.text"
+    );
+  });
+
+  it("should display validation styling and svg with empty validation message when validation message set to empty string for disable future", () => {
+    mount(
+      <IcDateInput label="Test Label" disableFuture disableFutureMessage={""} />
+    );
+
+    cy.checkHydrated(DATE_INPUT);
+
+    cy.findShadowEl(DATE_INPUT, DAY_INPUT_ARIA_LABEL).type("18");
+    cy.findShadowEl(DATE_INPUT, MONTH_INPUT_ARIA_LABEL).type("02");
+    cy.findShadowEl(DATE_INPUT, YEAR_INPUT_ARIA_LABEL).type("4000");
+
+    cy.findShadowEl(DATE_INPUT, "ic-input-validation").should(
+      "have.class",
+      "error"
+    );
+
+    cy.findShadowEl(DATE_INPUT, "ic-input-validation svg").should(
+      "have.attr",
+      "aria-labelledby",
+      "error-title"
+    );
+
+    cy.findShadowEl(DATE_INPUT, "ic-input-validation ic-typography").should(
+      "not.have.text"
+    );
   });
 });

--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
@@ -877,7 +877,7 @@ export class DateInput {
         }
       }
     } else {
-      this.invalidDateText = "";
+      this.invalidDateText = undefined;
     }
   };
 
@@ -1343,7 +1343,7 @@ export class DateInput {
 
   private setPasteInvalidText() {
     if (this.isPasteValidationDisplayed) {
-      this.invalidDateText = this.previousInvalidDateTest ?? "";
+      this.invalidDateText = this.previousInvalidDateTest ?? undefined;
       this.isPasteValidationDisplayed = false;
 
       // This is to prevent setDate from triggering within componentWillUpdate
@@ -1517,7 +1517,7 @@ export class DateInput {
 
     const validationStatus = hasCustomValidation
       ? this.validationStatus
-      : !isEmptyString(this.invalidDateText)
+      : this.invalidDateText !== undefined
       ? IcInformationStatus.Error
       : "";
 
@@ -1624,7 +1624,7 @@ export class DateInput {
               role="status"
             ></span>
           </span>
-          {(hasCustomValidation || !isEmptyString(this.invalidDateText)) && (
+          {(hasCustomValidation || this.invalidDateText !== undefined) && (
             <ic-input-validation
               status={validationStatus}
               message={


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update to validation functionality so that empty strings passed through to `disablePastMessage`, `disableFutureMessage` or `disableDaysMessage`, the validation styling will still appear but there will be no validation message. 

## Related issue
N/A

## Checklist

### General 

N/A

### Testing

- [x] Relevant unit tests and visual regression tests added. 

### Accessibility 

N/A

### Resize/zoom behaviour 

N/A

### System modes

- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] All prop combinations work without issue. 
