### PR TITLE
ic-date-input required prop change

### DIFF
--- a/packages/canary-react/src/component-tests/IcDatePicker/IcDatePicker.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDatePicker/IcDatePicker.cy.tsx
@@ -1362,11 +1362,10 @@ describe("IcDatePickers", () => {
     cy.findShadowEl(DATE_PICKER, DATE_INPUT).shadow().find("ic-input-label").should(CONTAIN_TEXT, text);
     cy.findShadowEl(DATE_PICKER, DATE_INPUT).shadow().find("ic-input-label").should(CONTAIN_TEXT, DEFAULT_LABEL+" *");
 
-    // does not currently work as ic-date-input does not respond to prop changing
-    // change prop to allow future dates
-    // cy.get(DATE_PICKER).invoke("prop", "required", false).then(() => {
-    //   cy.findShadowEl(DATE_PICKER, DATE_INPUT).shadow().find("ic-input-label").should("not."+CONTAIN_TEXT, "*");
-    // });
+    // change prop to not be required
+    cy.get(DATE_PICKER).invoke("prop", "required", false).then(() => {
+      cy.findShadowEl(DATE_PICKER, DATE_INPUT).shadow().find("ic-input-label").should(`not.${CONTAIN_TEXT}`, "*");
+    });
   });
 
   it("should test 'showDaysOutsideMonth' and 'startOfWeek' props", () => {

--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
@@ -218,6 +218,25 @@ export class DateInput {
    */
   @Prop() required?: boolean = false;
 
+  @Watch("required")
+  watchRequiredHandler(): void {
+    // Prevent asterisk being read out after the label by screen reader (by applying aria-hidden)
+    // Needed because label is included in 'aria-labelledby' instead of using 'aria-label'
+    const labelEl = this.el.shadowRoot.querySelector("label");
+    if (this.required) {
+      const asteriskSpan = document.createElement("span");
+      asteriskSpan.setAttribute("id", "asterisk-span");
+      asteriskSpan.setAttribute("aria-hidden", "true");
+      asteriskSpan.textContent = " *";
+      labelEl?.appendChild(asteriskSpan);
+    } else {
+      const asteriskSpan = this.el.shadowRoot.querySelector("#asterisk-span");
+      if (asteriskSpan) {
+        asteriskSpan.remove();
+      }
+    }
+  }
+
   /**
    * @internal If `true`, a button which displays the calendar view when clicked will be displayed.
    */
@@ -328,15 +347,7 @@ export class DateInput {
       input.addEventListener("blur", this.handleBlur);
     });
 
-    // Prevent asterisk being read out after the label by screen reader (by applying aria-hidden)
-    // Needed because label is included in 'aria-labelledby' instead of using 'aria-label'
-    const labelEl = this.el.shadowRoot.querySelector("label");
-    if (this.required) {
-      const asteriskSpan = document.createElement("span");
-      asteriskSpan.setAttribute("aria-hidden", "true");
-      asteriskSpan.textContent = " *";
-      labelEl?.appendChild(asteriskSpan);
-    }
+    this.watchRequiredHandler();
   }
 
   componentWillUpdate(): void {

--- a/packages/canary-web-components/src/components/ic-date-input/test/basic/__snapshots__/ic-date-input.spec.tsx.snap
+++ b/packages/canary-web-components/src/components/ic-date-input/test/basic/__snapshots__/ic-date-input.spec.tsx.snap
@@ -454,7 +454,7 @@ exports[`ic-date-input component should render as required 1`] = `
         <ic-typography variant="label">
           <label htmlfor="ic-date-input-1" id="ic-date-input-1-label">
             Test label
-            <span aria-hidden="true">
+            <span aria-hidden="true" id="asterisk-span">
               *
             </span>
           </label>
@@ -480,6 +480,54 @@ exports[`ic-date-input component should render as required 1`] = `
             <input aria-label="month" class="month-input" id="month-input" inputmode="number" pattern="[0-9]*" placeholder="MM">
             /
             <input aria-label="year" class="year-input" id="year-input" inputmode="number" maxlength="4" pattern="[0-9]*" placeholder="YYYY">
+          </div>
+          <div class="action-buttons">
+            <ic-button appearance="dark" aria-label="Clear input" class="clear-button hidden" id="clear-button" size="default" variant="icon">
+              svg
+            </ic-button>
+          </div>
+        </div>
+      </ic-input-component-container>
+      <span aria-live="polite" class="sr-only" id="ic-date-input-1-selected-date-info">
+        <span role="status"></span>
+      </span>
+    </ic-input-container>
+  </mock:shadow-root>
+  <input class="ic-input" name="ic-date-input-1" type="hidden" value="">
+</ic-date-input>
+`;
+
+exports[`ic-date-input component should render as required: required-prop-false 1`] = `
+<ic-date-input label="Test label" required="">
+  <mock:shadow-root>
+    <ic-input-container>
+      <ic-input-label class="with-helper">
+        <ic-typography variant="label">
+          <label htmlfor="ic-date-input-1" id="ic-date-input-1-label">
+            Test label
+          </label>
+        </ic-typography>
+        <ic-typography class="helpertext helpertext-normal" variant="caption">
+          <span id="ic-date-input-1-helper-text">
+            Use format DD/MM/YYYY
+          </span>
+        </ic-typography>
+      </ic-input-label>
+      <span aria-hidden="true" class="sr-only" id="ic-date-input-1-screen-reader-info">
+        Use format DD/MM/YYYY.
+      </span>
+      <span aria-hidden="true" class="sr-only" id="ic-date-input-1-assistive-hint">
+        Type or use the up and down arrow keys to change the values for the day, month, and year.
+      </span>
+      <span aria-live="assertive" class="sr-only" id="live-region"></span>
+      <ic-input-component-container aria-labelledby="ic-date-input-1-label ic-date-input-1-screen-reader-info   ic-date-input-1-assistive-hint" id="ic-date-input-1" role="group" size="default" validationstatus="">
+        <div class="input-container">
+          <div class="date-inputs">
+            <input aria-label="day" class="day-input" id="day-input" inputmode="number" pattern="[0-9]*" placeholder="DD" value="null">
+            /
+            <input aria-label="month" class="month-input" id="month-input" inputmode="number" pattern="[0-9]*" placeholder="MM" value="null">
+            /
+            <input aria-label="year" class="year-input" id="year-input" inputmode="number" maxlength="4" pattern="[0-9]*" placeholder="YYYY" value="null">
           </div>
           <div class="action-buttons">
             <ic-button appearance="dark" aria-label="Clear input" class="clear-button hidden" id="clear-button" size="default" variant="icon">

--- a/packages/canary-web-components/src/components/ic-date-input/test/basic/ic-date-input.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-date-input/test/basic/ic-date-input.spec.tsx
@@ -32,6 +32,11 @@ describe("ic-date-input component", () => {
     });
 
     expect(page.root).toMatchSnapshot();
+
+    page.root.required = false;
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot("required-prop-false");
   });
 
   it("should render as disabled", async () => {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
fixes issue where change the `required` prop did not update the label to show\hide the asterisk. Also enables Cypress test in ic-date-picker which previously failed due to this issue

#1751 

## Checklist

### Testing

- [x] Relevant unit tests and visual regression tests added. 

