### PR TITLE
1121 test mutating attributes

### DIFF
--- a/packages/react/cypress.config.ts
+++ b/packages/react/cypress.config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { defineConfig } from "cypress";
 
-export const config = {
+export const config: Cypress.ConfigOptions = {
   component: {
     devServer: {
       framework: "react",
@@ -24,4 +24,4 @@ export const config = {
   },
 }
 
-export default defineConfig(config as Cypress.ConfigOptions);
+export default defineConfig(config);

--- a/packages/react/src/component-tests/IcLink/IcLink.cy.tsx
+++ b/packages/react/src/component-tests/IcLink/IcLink.cy.tsx
@@ -4,6 +4,7 @@
 import React from "react";
 import { IcLink } from "../../components";
 import { mount } from "cypress/react";
+import { HAVE_ATTR } from "../utils/constants";
 
 const DEFAULT_TEST_THRESHOLD = 0.05;
 
@@ -122,5 +123,26 @@ describe("IcLink e2e, A11y and visual regression tests", () => {
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.05,
     });
     cy.checkA11yWithWait();
+  });
+
+  it("should update any attributes that are inherited from the root element", () => {
+    const ARIA_LABEL_ATTR = "aria-label";
+    mount(
+      <IcLink href="/components/link/code" aria-label="first-label">
+        About our coffees
+      </IcLink>
+    );
+    cy.findShadowEl("ic-link", "a").should(
+      HAVE_ATTR,
+      ARIA_LABEL_ATTR,
+      "first-label"
+    );
+
+    cy.get("ic-link").invoke("attr", ARIA_LABEL_ATTR, "second-label");
+    cy.findShadowEl("ic-link", "a").should(
+      HAVE_ATTR,
+      ARIA_LABEL_ATTR,
+      "second-label"
+    );
   });
 });

--- a/packages/react/src/component-tests/IcTopNavigation/IcTopNavigation.cy.tsx
+++ b/packages/react/src/component-tests/IcTopNavigation/IcTopNavigation.cy.tsx
@@ -16,11 +16,13 @@ import {
 import { SlottedSVG } from "../../react-component-lib/slottedSVG";
 import {
   BE_VISIBLE,
+  HAVE_ATTR,
   HAVE_CLASS,
   HAVE_CSS,
   HAVE_FOCUS,
   NOT_BE_VISIBLE,
   NOT_EXIST,
+  NOT_HAVE_ATTR,
   NOT_HAVE_CLASS,
 } from "../utils/constants";
 import {
@@ -78,51 +80,92 @@ describe("IcTopNavigation", () => {
       cy.get(SEARCH_BAR_SELECTOR).should(HAVE_CSS, "height", "0px");
     });
   });
+
+  describe("desktop", () => {
+    beforeEach(() => {
+      cy.viewport(1024, 750);
+    });
+
+    it("renders", () => {
+      mount(<SimpleTopNav />);
+      cy.get(TOP_NAV_SELECTOR).shadow().contains("ApplicationName");
+    });
+
+    it("should hide dropdown menu when nav item clicked", () => {
+      mount(<TopNavWithNavItems />);
+      cy.checkHydrated("ic-navigation-group");
+      cy.get(TOP_NAV_SELECTOR)
+        .find("ic-navigation-group")
+        .trigger("mouseenter");
+      cy.get(TOP_NAV_SELECTOR).find(NAV_ITEM_SELECTOR).should(BE_VISIBLE);
+      cy.get(TOP_NAV_SELECTOR).find(NAV_ITEM_SELECTOR).click();
+      cy.get(TOP_NAV_SELECTOR).find(NAV_ITEM_SELECTOR).should(NOT_BE_VISIBLE);
+    });
+
+    it("should toggle to short title at small screen sizes", () => {
+      mount(<SimpleTopNav />);
+      cy.viewport(1024, 750);
+      cy.findShadowEl(TOP_NAV_SELECTOR, "h1").contains("ApplicationName");
+      cy.viewport("iphone-6");
+      cy.findShadowEl(TOP_NAV_SELECTOR, "h1").contains("AppName");
+    });
+
+    it("should switch to mobile mode at a different breakpoint when customMobileBreakpoint is set", () => {
+      mount(
+        <IcTopNavigation
+          app-title="ApplicationName"
+          status="alpha"
+          version="v0.0.7"
+          shortAppTitle="AppName"
+          customMobileBreakpoint={768} // Medium
+        >
+          <IcSearchBar slot="search" label="Search" placeholder="Search" />
+        </IcTopNavigation>
+      );
+      cy.get(TOP_NAV_SELECTOR).should(NOT_HAVE_CLASS, MOBILE_CSS_CLASS);
+      cy.viewport(992, 750);
+      cy.get(TOP_NAV_SELECTOR).should(NOT_HAVE_CLASS, MOBILE_CSS_CLASS);
+      cy.viewport(768, 750);
+      cy.get(TOP_NAV_SELECTOR).should(HAVE_CLASS, MOBILE_CSS_CLASS);
+    });
+  });
 });
-describe("desktop", () => {
-  beforeEach(() => {
-    cy.viewport(1024, 750);
-  });
 
-  it("renders", () => {
-    mount(<SimpleTopNav />);
-    cy.get(TOP_NAV_SELECTOR).shadow().contains("ApplicationName");
-  });
-
-  it("should hide dropdown menu when nav item clicked", () => {
-    mount(<TopNavWithNavItems />);
-    cy.checkHydrated("ic-navigation-group");
-    cy.get(TOP_NAV_SELECTOR).find("ic-navigation-group").trigger("mouseenter");
-    cy.get(TOP_NAV_SELECTOR).find(NAV_ITEM_SELECTOR).should(BE_VISIBLE);
-    cy.get(TOP_NAV_SELECTOR).find(NAV_ITEM_SELECTOR).click();
-    cy.get(TOP_NAV_SELECTOR).find(NAV_ITEM_SELECTOR).should(NOT_BE_VISIBLE);
-  });
-
-  it("should toggle to short title at small screen sizes", () => {
-    mount(<SimpleTopNav />);
-    cy.viewport(1024, 750);
-    cy.findShadowEl(TOP_NAV_SELECTOR, "h1").contains("ApplicationName");
-    cy.viewport("iphone-6");
-    cy.findShadowEl(TOP_NAV_SELECTOR, "h1").contains("AppName");
-  });
-
-  it("should switch to mobile mode at a different breakpoint when customMobileBreakpoint is set", () => {
+describe("IcNavigationButton", () => {
+  it("should update any attributes inherited from the root element when they are mutated", () => {
+    const NAV_BUTTON_SELECTOR = "ic-navigation-button";
     mount(
       <IcTopNavigation
-        app-title="ApplicationName"
+        appTitle="ApplicationName"
         status="alpha"
         version="v0.0.7"
-        shortAppTitle="AppName"
-        customMobileBreakpoint={768} // Medium
       >
-        <IcSearchBar slot="search" label="Search" placeholder="Search" />
+        <IcNavigationButton label="Button One" slot="buttons">
+          <SlottedSVG
+            slot="icon"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            fill="#000000"
+          >
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path d="M21 6h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1zm-4 6V3c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1z"></path>
+          </SlottedSVG>
+        </IcNavigationButton>
       </IcTopNavigation>
     );
-    cy.get(TOP_NAV_SELECTOR).should(NOT_HAVE_CLASS, MOBILE_CSS_CLASS);
-    cy.viewport(992, 750);
-    cy.get(TOP_NAV_SELECTOR).should(NOT_HAVE_CLASS, MOBILE_CSS_CLASS);
-    cy.viewport(768, 750);
-    cy.get(TOP_NAV_SELECTOR).should(HAVE_CLASS, MOBILE_CSS_CLASS);
+    cy.findShadowEl(NAV_BUTTON_SELECTOR, "ic-button").should(
+      NOT_HAVE_ATTR,
+      "title"
+    );
+
+    cy.get(NAV_BUTTON_SELECTOR).invoke("attr", "title", "new-title");
+    cy.findShadowEl(NAV_BUTTON_SELECTOR, "ic-button").should(
+      HAVE_ATTR,
+      "title",
+      "new-title"
+    );
   });
 });
 

--- a/packages/web-components/src/components/ic-dialog/test/basic/__snapshots__/ic-dialog.spec.ts.snap
+++ b/packages/web-components/src/components/ic-dialog/test/basic/__snapshots__/ic-dialog.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`ic-dialog component should render 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-0">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -61,7 +61,7 @@ exports[`ic-dialog component should render as large size 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-14">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -101,7 +101,7 @@ exports[`ic-dialog component should render as medium size 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-12">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -141,7 +141,7 @@ exports[`ic-dialog component should render with a destructive default button 1`]
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-44">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -195,7 +195,7 @@ exports[`ic-dialog component should render with a label 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-2">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -235,7 +235,7 @@ exports[`ic-dialog component should render with a single default button 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-16">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -287,7 +287,7 @@ exports[`ic-dialog component should render with an alert 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-50">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -362,7 +362,7 @@ exports[`ic-dialog component should render with no more than three default butto
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-36">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -430,7 +430,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-6">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -509,7 +509,7 @@ exports[`ic-dialog component should render with slotted controls 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-102">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -560,7 +560,7 @@ exports[`ic-dialog component should render with the close button 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-174">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -620,7 +620,7 @@ exports[`ic-dialog component should render with three default buttons 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-28">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -688,7 +688,7 @@ exports[`ic-dialog component should render with two default buttons 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-22">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>
@@ -798,7 +798,7 @@ exports[`should render as large size and disableWidthConstraint is set 1`] = `
         </div>
         <ic-button class="button-size-default button-variant-icon close-icon" data-gets-focus exportparts="button">
           <mock:shadow-root>
-            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-">
+            <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-198">
               <button aria-label="Dismiss" class="button" part="button" type="button">
                 <slot></slot>
               </button>

--- a/packages/web-components/src/components/ic-link/test/basic/ic-link.spec.ts
+++ b/packages/web-components/src/components/ic-link/test/basic/ic-link.spec.ts
@@ -228,4 +228,23 @@ describe("ic-link component", () => {
     //Can't expect anything in this test - this is to increase code coverage only
     await page.rootInstance.setFocus().toHaveBeenCalled;
   });
+
+  it("should update any attributes that are inherited from the root element", async () => {
+    const page = await newSpecPage({
+      components: [Link],
+      html: `<ic-link>IC Link Test</ic-link>`,
+    });
+    expect(
+      page.root.shadowRoot.querySelector("a").getAttribute("aria-label")
+    ).toBeNull();
+
+    page.root.setAttribute("aria-label", "new-label");
+    page.rootInstance.hostMutationCallback([{ attributeName: "aria-label" }]);
+    await page.waitForChanges();
+
+    expect(
+      page.root.shadowRoot.querySelector("a").getAttribute("aria-label")
+    ).toBe("new-label");
+    page.rootInstance.disconnectedCallback();
+  });
 });

--- a/packages/web-components/src/components/ic-navigation-button/test/basic/ic-navigation-button.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-button/test/basic/ic-navigation-button.spec.ts
@@ -94,4 +94,22 @@ describe("ic-navigation-button", () => {
 
     await page.rootInstance.setFocus();
   });
+
+  it("should update any attributes that are inherited from the root element", async () => {
+    const page = await newSpecPage({
+      components: [NavigationButton, Button],
+      html: `<ic-navigation-button label="button1"></ic-navigation-button>`,
+    });
+    expect(
+      page.root.shadowRoot.querySelector("ic-button").getAttribute("aria-label")
+    ).toBeNull();
+
+    page.root.setAttribute("aria-label", "new-label");
+    page.rootInstance.hostMutationCallback([{ attributeName: "aria-label" }]);
+    await page.waitForChanges();
+
+    expect(
+      page.root.shadowRoot.querySelector("ic-button").getAttribute("aria-label")
+    ).toBe("new-label");
+  });
 });

--- a/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
@@ -82,7 +82,7 @@ exports[`ic-navigation-menu should test slotted buttons: renders-with-slotted-bu
     <mock:shadow-root>
       <ic-button class="button-size-large button-variant-icon light" exportparts="button">
         <mock:shadow-root>
-          <ic-tooltip label="button1" placement="bottom" silent="" target="ic-button-with-tooltip-">
+          <ic-tooltip label="button1" placement="bottom" silent="" target="ic-button-with-tooltip-2">
             <button aria-label="button1" class="button" part="button" type="button">
               <div class="icon-container">
                 <slot name="left-icon"></slot>
@@ -187,7 +187,7 @@ exports[`ic-navigation-menu should test slotted navigation and buttons: renders-
     <mock:shadow-root>
       <ic-button class="button-size-large button-variant-icon light" exportparts="button">
         <mock:shadow-root>
-          <ic-tooltip label="button1" placement="bottom" silent="" target="ic-button-with-tooltip-">
+          <ic-tooltip label="button1" placement="bottom" silent="" target="ic-button-with-tooltip-6">
             <button aria-label="button1" class="button" part="button" type="button">
               <div class="icon-container">
                 <slot name="left-icon"></slot>

--- a/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
@@ -65,12 +65,12 @@ exports[`ic-select searchable should render as required: required-searchable 1`]
 <ic-select class="searchable" label="IC Select Test" required="true" searchable="true">
   <mock:shadow-root>
     <ic-input-container>
-      <ic-input-label for="ic-select-input-27" helpertext="" label="IC Select Test" required=""></ic-input-label>
+      <ic-input-label for="ic-select-input-28" helpertext="" label="IC Select Test" required=""></ic-input-label>
       <ic-input-component-container class="default">
         <!---->
         <div class="focus-indicator">
           <div class="searchable-select-container">
-            <input aria-autocomplete="list" aria-controls="ic-select-input-27-menu" aria-describedby="" aria-expanded="false" aria-invalid="false" aria-label="IC Select Test" aria-required="true" autocomplete="off" class="select-input" id="ic-select-input-27" placeholder="Select an option" role="combobox">
+            <input aria-autocomplete="list" aria-controls="ic-select-input-28-menu" aria-describedby="" aria-expanded="false" aria-invalid="false" aria-label="IC Select Test" aria-required="true" autocomplete="off" class="select-input" id="ic-select-input-28" placeholder="Select an option" role="combobox">
             <span aria-hidden="true" class="expand-icon">
               svg
             </span>
@@ -79,8 +79,8 @@ exports[`ic-select searchable should render as required: required-searchable 1`]
         </div>
       </ic-input-component-container>
       <ic-menu class="default no-results">
-        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-27-menu" role="listbox" tabindex="-1">
-          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-27-menu-" role="option" tabindex="-1">
+        <ul aria-activedescendant="" aria-label="IC Select Test" class="menu" id="ic-select-input-28-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" class="option" data-label="No results found" data-value id="ic-select-input-28-menu-" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -95,7 +95,7 @@ exports[`ic-select searchable should render as required: required-searchable 1`]
       </ic-menu>
     </ic-input-container>
   </mock:shadow-root>
-  <input class="ic-input" name="ic-select-input-27" type="hidden" value="">
+  <input class="ic-input" name="ic-select-input-28" type="hidden" value="">
 </ic-select>
 `;
 

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
@@ -773,6 +773,24 @@ describe("ic-select native", () => {
 
     expect(page.rootInstance.open).toBeFalsy;
   });
+
+  it("should update any attributes that are inherited from the root element", async () => {
+    const page = await newSpecPage({
+      components: [Select],
+      html: `<ic-select label="IC Select Test"></ic-select>`,
+    });
+    expect(
+      page.root.shadowRoot.querySelector("select").getAttribute("title")
+    ).toBeNull();
+
+    page.root.setAttribute("title", "new-label");
+    page.rootInstance.hostMutationCallback([{ attributeName: "title" }]);
+    await page.waitForChanges();
+
+    expect(
+      page.root.shadowRoot.querySelector("select").getAttribute("title")
+    ).toBe("new-label");
+  });
 });
 
 describe("ic-select searchable", () => {

--- a/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.e2e.ts
+++ b/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.e2e.ts
@@ -151,4 +151,20 @@ describe("ic-text-field", () => {
     value = await input.getProperty("value");
     expect(value).toBe("");
   });
+
+  it("should update any attributes inherited from the root element when they are mutated", async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ic-text-field label="Test label">');
+    await page.waitForChanges();
+
+    let input = await page.find("ic-text-field >>> input");
+    expect(input.getAttribute("title")).toBeNull();
+
+    const textField = await page.find("ic-text-field");
+    textField.setAttribute("title", "new-input-title");
+    await page.waitForChanges();
+
+    input = await page.find("ic-text-field >>> input");
+    expect(input.getAttribute("title")).toBe("new-input-title");
+  });
 });

--- a/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.input.spec.tsx
+++ b/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.input.spec.tsx
@@ -311,3 +311,21 @@ it("should test minCharacters method", async () => {
   page.rootInstance.getMinCharactersUnattained("testing");
   expect(page.rootInstance.minCharactersUnattained).toBe(false);
 });
+
+it("should update any attributes that are inherited from the root element", async () => {
+  const page = await newSpecPage({
+    components: [TextField],
+    html: `<ic-text-field label="Test label"></ic-text-field>`,
+  });
+  expect(
+    page.root.shadowRoot.querySelector("input").getAttribute("title")
+  ).toBeNull();
+
+  page.root.setAttribute("title", "new-label");
+  page.rootInstance.hostMutationCallback([{ attributeName: "title" }]);
+  await page.waitForChanges();
+
+  expect(
+    page.root.shadowRoot.querySelector("input").getAttribute("title")
+  ).toBe("new-label");
+});


### PR DESCRIPTION
## Summary of the changes
Added mutation observers to components that inherit attributes from its host element, to ensure that the are updated when a host element updates its attributes.

Added tests to various files for the mutation observer, in cypress for e2e testing and in spec tests to boost code coverage. Also updated some snapshots for some components

## Related issue
#1121

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.