### PR TITLE
Fix Pagination bar not updating

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-04-09T09:35:30",
+  "timestamp": "2024-04-16T14:21:00",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.9.0",
@@ -2386,7 +2386,7 @@
             "resolved": "{ label: string; value: string; }[]",
             "references": {}
           },
-          "mutable": true,
+          "mutable": false,
           "reflectToAttr": false,
           "docs": "The options which will be displayed for 'items per page' select input. Set a maximum of 4 options including a required 'All' option with value equal to total number of items.",
           "docsTags": [],

--- a/packages/canary-react/src/stories/ic-data-table.stories.mdx
+++ b/packages/canary-react/src/stories/ic-data-table.stories.mdx
@@ -1378,3 +1378,137 @@ const DataTable = () => (
 
 export default DataTable;
 ```
+
+### Updating data
+
+export const UpdatingData = () => {
+  const [data, setData] = useState([]);
+  const [pageOptions, setPageOptions] = useState([{ label: '5', value: '5' }]);
+  
+  const addData = () => {
+    setData([...data, ...LONG_DATA]);
+  }
+
+  const clearData = () => {
+    setData([]);
+  }
+
+  const updatePageOptions = () => {
+    setPageOptions([
+      { label: '10', value: '10' },
+      { label: '20', value: '20' },
+      { label: '50', value: '50' }
+    ]);
+  }
+
+  const resetPageOptions = () => {
+    setPageOptions([{ label: '5', value: '5' }]);
+  }
+
+  return (
+    <>
+      <IcDataTable
+        caption="Updating Data"
+        columns={COLS}
+        data={data}
+        showPagination
+        paginationOptions={{
+          itemsPerPage: pageOptions,
+          itemsPerPageControl: true,
+          goToPageControl: true,
+          type: "page",
+        }}
+      />
+      <div style={{ display: "flex", gap: "8px", marginTop: "8px" }}>
+        <IcButton onClick={addData}>Add data</IcButton>
+        <IcButton onClick={updatePageOptions}>Update page lengths</IcButton>
+        <IcButton onClick={clearData}>Reset data</IcButton>
+        <IcButton onClick={resetPageOptions}>Reset page lengths</IcButton>
+      </div>
+    </>
+  );
+};
+
+<Canvas withSource="none">
+  <Story name="Updating data example">
+    <UpdatingData />
+  </Story>
+</Canvas>
+
+#### Updating data code example
+
+```jsx
+import * as React from "react";
+import { IcDataTable } from "@ukic/canary-react";
+import { IcDataTableColumnObject } from "@ukic/canary-web-components";
+
+const columns: IcDataTableColumnObject[] = [
+  {
+    key: "firstName",
+    title: "First name",
+    dataType: "string",
+  },
+  ...
+];
+
+const data = [
+  {
+    firstName: "Joe",
+    lastName: "Bloggs",
+    age: 30,
+    jobTitle: "Developer",
+    address: "1 Main Street, Town, County, Postcode",
+  },
+  ...
+];
+
+const DataTable = () => {
+  const [data, setData] = useState([]);
+  const [pageOptions, setPageOptions] = useState([{ label: '5', value: '5' }]);
+
+  const addData = () => {
+    setData([...data, ...LONG_DATA]);
+  }
+
+  const clearData = () => {
+    setData([]);
+  }
+
+  const updatePageOptions = () => {
+    setPageOptions([
+      { label: '10', value: '10' },
+      { label: '20', value: '20' },
+      { label: '50', value: '50' }
+    ]);
+  }
+
+  const resetPageOptions = () => {
+    setPageOptions([{ label: '5', value: '5' }]);
+  }
+
+ return (
+    <>
+      <IcDataTable
+        caption="Updating Data"
+        columns={COLS}
+        data={data}
+        showPagination
+        paginationOptions={{
+          itemsPerPage: pageOptions,
+          itemsPerPageControl: true,
+          goToPageControl: true,
+          type: "page"
+        }}
+      />
+      <div style={{ display: "flex", gap: "8px", marginTop: "8px" }}>
+        <IcButton onClick={addData}>Add data</IcButton>
+        <IcButton onClick={updatePageOptions}>Update page lengths</IcButton>
+        <IcButton onClick={clearData}>Clear data</IcButton>
+        <IcButton onClick={resetPageOptions}>Reset page lengths</IcButton>
+      </div>
+    </>
+  );
+};
+
+export default DataTable;
+```

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.mdx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.mdx
@@ -28,6 +28,7 @@ import {
   CustomIcons,
   CustomRowHeights,
   CustomTitleBar,
+  UpdatingData,
 } from "./story-data";
 import readme from "./readme.md";
 
@@ -1110,5 +1111,85 @@ Full documentation for this component can be found in the code examples located 
   ];
   dataTable.columns = columns;
   dataTable.data = data;
+</script>
+```
+
+### Updating data
+
+<Canvas withSource="none">
+  <Story name="Updating data" parameters={{ loki: { skip: true } }}>
+    {UpdatingData()}
+  </Story>
+</Canvas>
+
+#### Updating data code example
+
+```html
+<ic-data-table id="data-table" caption="Updating Data"></ic-data-table>
+<div style="display:flex; gap:8px; margin-top:8px;">
+  <ic-button onClick="updateData()">Add data</ic-button>
+  <ic-button onClick="updatePageOptions()">Update page lengths</ic-button>
+  <ic-button onClick="clearData()">Reset data</ic-button>
+  <ic-button onClick="resetPageOptions()">Reset page lengths</ic-button>
+</div>
+<script>
+  const dataTable = document.querySelector("#data-table");
+  const pageOptions = [{ label: '5', value: '5' }];
+
+  const columns = [
+    {
+      key: "firstName",
+      title: "First name",
+      dataType: "string",
+    },
+    ...
+  ];
+
+  const data = [
+    {
+      firstName: "Joe",
+      lastName: "Bloggs",
+      age: 30,
+      jobTitle: "Developer",
+      address: "1 Main Street, Town, County, Postcode",
+    },
+    ...
+  ];
+
+  const updateData = () => {
+    dataTable.data = [...dataTable.data, ...data];
+  }
+
+  const clearData = () => {
+    dataTable.data = [];
+  }
+
+  const updatePageOptions = () => {
+    dataTable.paginationOptions = {
+      ...dataTable.paginationOptions,
+      itemsPerPage: [
+        { label: '10', value: '10' },
+        { label: '20', value: '20' },
+        { label: '50', value: '50' }
+      ]
+    };
+  }
+
+  const resetPageOptions = () => {
+    dataTable.paginationOptions = {
+      ...dataTable.paginationOptions,
+      itemsPerPage: pageOptions
+    };
+  }
+
+  dataTable.columns = columns;
+  dataTable.data = data;
+  dataTable.showPagination = true;
+  dataTable.paginationOptions = {
+    itemsPerPage: pageOptions,
+    itemsPerPageControl: true,
+    goToPageControl: true,
+    type: "page"
+  }
 </script>
 ```

--- a/packages/canary-web-components/src/components/ic-data-table/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/story-data.ts
@@ -842,3 +842,64 @@ export const CustomTitleBar = (): HTMLIcDataTableElement => {
 
   return dataTable;
 };
+
+export const UpdatingData = (): HTMLElement => {
+  const dataTable = createDataTableElement("Updating Data", COLS, []);
+  const pageOptions = [{ label: "5", value: "5" }];
+
+  dataTable.showPagination = true;
+  dataTable.paginationOptions = {
+    itemsPerPage: pageOptions,
+    itemsPerPageControl: true,
+    goToPageControl: true,
+    type: "page",
+  };
+
+  const updateDataButton = document.createElement("ic-button");
+  updateDataButton.addEventListener("click", () => {
+    dataTable.data = [...dataTable.data, ...LONG_DATA];
+  });
+  updateDataButton.innerHTML = "Update data";
+
+  const clearDataButton = document.createElement("ic-button");
+  clearDataButton.addEventListener("click", () => {
+    dataTable.data = [];
+  });
+  clearDataButton.innerHTML = "Clear data";
+
+  const updatePaginationButton = document.createElement("ic-button");
+  updatePaginationButton.addEventListener("click", () => {
+    dataTable.paginationOptions = {
+      ...dataTable.paginationOptions,
+      itemsPerPage: [
+        { label: "10", value: "10" },
+        { label: "20", value: "20" },
+        { label: "50", value: "50" },
+      ],
+    };
+  });
+  updatePaginationButton.innerHTML = "Update page lengths";
+
+  const resetPaginationButton = document.createElement("ic-button");
+  resetPaginationButton.addEventListener("click", () => {
+    dataTable.paginationOptions = {
+      ...dataTable.paginationOptions,
+      itemsPerPage: pageOptions,
+    };
+  });
+  resetPaginationButton.innerHTML = "Reset page lengths";
+
+  const buttonWrapper = document.createElement("div");
+  buttonWrapper.style["display"] = "flex";
+  buttonWrapper.style["paddingTop"] = "10px";
+  buttonWrapper.style["gap"] = "8px";
+  buttonWrapper.insertAdjacentElement("afterbegin", updateDataButton);
+  buttonWrapper.insertAdjacentElement("beforeend", clearDataButton);
+  buttonWrapper.insertAdjacentElement("beforeend", updatePaginationButton);
+  buttonWrapper.insertAdjacentElement("beforeend", resetPaginationButton);
+
+  const wrapper = document.createElement("div");
+  wrapper.insertAdjacentElement("afterbegin", dataTable);
+  wrapper.insertAdjacentElement("beforeend", buttonWrapper);
+  return wrapper;
+};

--- a/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.tsx
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.tsx
@@ -7,6 +7,7 @@ import {
   State,
   Listen,
   h,
+  Watch,
 } from "@stencil/core";
 import { IcThemeForeground } from "@ukic/web-components/dist/types/interface";
 import { checkResizeObserver } from "../../utils/helpers";
@@ -22,24 +23,30 @@ import {
   shadow: true,
 })
 export class PaginationBar {
-  private PAGINATION = "ic-pagination";
-  private TEXT_FIELD = "ic-text-field";
-  private TOOLTIP = "ic-tooltip";
   private PAGE_INPUT_FIELD_ID = "go-to-page-input";
 
   private INVALID_PAGE_ERROR = "Please enter a valid page";
   private NAN_ERROR = "Please enter a number";
 
   private resizeObserver: ResizeObserver = null;
+  private pageDropdownEl: HTMLIcSelectElement;
+  private pageInputEl: HTMLIcTextFieldElement;
+  private pageInputTooltipEl: HTMLIcTooltipElement;
   private paginationBarEl: HTMLElement;
+  private paginationEl: HTMLIcPaginationElement;
 
   @Element() el: HTMLIcPaginationBarElement;
 
   @State() currentPage: number = 1;
 
+  @State() displayedItemsPerPageOptions?: {
+    label: string;
+    value: string;
+  }[];
+
   @State() inputError: string = "Please enter a valid page";
 
-  @State() itemsPerPage: string;
+  @State() itemsPerPage: number = 0;
 
   @State() lowerBound: number = 1;
 
@@ -69,10 +76,15 @@ export class PaginationBar {
   /**
    * The options which will be displayed for 'items per page' select input. Set a maximum of 4 options including a required 'All' option with value equal to total number of items.
    */
-  @Prop({ mutable: true }) itemsPerPageOptions?: {
+  @Prop() itemsPerPageOptions?: {
     label: string;
     value: string;
   }[];
+
+  @Watch("itemsPerPageOptions")
+  watchItemsPerPageOptionsHandler(): void {
+    this.setPaginationBarContent();
+  }
 
   /**
    * Whether the displayed pagination is simple or complex.
@@ -109,6 +121,11 @@ export class PaginationBar {
    */
   @Prop() totalItems!: number;
 
+  @Watch("totalItems")
+  watchTotalItemsHandler(): void {
+    this.setPaginationBarContent();
+  }
+
   /**
    * Emitted when a page is navigated to via the 'go to' input.
    */
@@ -126,16 +143,7 @@ export class PaginationBar {
   }
 
   componentWillLoad(): void {
-    if (
-      this.itemsPerPageOptions === undefined ||
-      this.itemsPerPageOptions === null
-    ) {
-      this.setDefaultItemsPerPageOptions();
-    }
-    this.trimItemsPerPageOptions();
-    this.setDefaultItemsPerPage();
-    this.setNumberPages();
-    this.setUpperBound();
+    this.setPaginationBarContent();
   }
 
   componentDidLoad(): void {
@@ -152,60 +160,33 @@ export class PaginationBar {
   }
 
   private changeItemsPerPage = () => {
-    const select = this.el.shadowRoot.querySelector("ic-select");
-    const value = select.value;
-    this.itemsPerPage = value;
-    this.setNumberPages();
-    this.setUpperBound();
-    const pagination = this.el.shadowRoot.querySelector(
-      this.PAGINATION
-    ) as HTMLIcPaginationElement;
-    if (this.currentPage > this.totalPages) {
-      pagination.setCurrentPage(this.totalPages);
-      this.currentPage = this.totalPages;
-    }
-    this.icItemsPerPageChange.emit({ value: Number(this.itemsPerPage) });
-    this.icPageChange.emit({ value: this.currentPage });
+    this.setItemsPerPage(Number(this.pageDropdownEl.value));
   };
 
   private changePage = (page: number) => {
     this.currentPage = page;
-    this.lowerBound =
-      page !== 1 ? (page - 1) * Number(this.itemsPerPage) + 1 : page;
+    this.lowerBound = page !== 1 ? (page - 1) * this.itemsPerPage + 1 : page;
     this.setUpperBound();
   };
 
   private goToPage = () => {
-    const input = this.el.shadowRoot.querySelector(
-      this.TEXT_FIELD
-    ) as HTMLIcTextFieldElement;
+    const input = this.pageInputEl;
     const page = Number(input.value);
-    const tooltip = this.el.shadowRoot.querySelector("ic-tooltip");
     if (page <= this.totalPages && page > 0) {
       this.changePage(page);
-      const pagination = this.el.shadowRoot.querySelector(
-        this.PAGINATION
-      ) as HTMLIcPaginationElement;
-      pagination.setCurrentPage(page);
+      this.paginationEl.setCurrentPage(page);
       this.currentPage = page;
       input.value = "";
       this.icPageChange.emit({ value: page });
-      tooltip.displayTooltip(false, false);
+      this.pageInputTooltipEl.displayTooltip(false, false);
       input.validationStatus = "";
     } else {
-      this.inputError = this.INVALID_PAGE_ERROR;
-      input.validationStatus = "error";
-      input.setFocus();
+      this.setInputError(input, this.INVALID_PAGE_ERROR);
     }
   };
 
   private handleBlur = () => {
-    const textField = this.el.shadowRoot?.querySelector(
-      this.TEXT_FIELD
-    ) as HTMLIcTextFieldElement;
-    const tooltip = this.el.shadowRoot?.querySelector(
-      this.TOOLTIP
-    ) as HTMLIcTooltipElement;
+    const textField = this.pageInputEl;
     if (
       (Number(textField.value) <= this.totalPages &&
         Number(textField.value) > 0) ||
@@ -213,45 +194,28 @@ export class PaginationBar {
     ) {
       textField.validationStatus = "";
     }
-    tooltip.displayTooltip(false, false);
+    this.pageInputTooltipEl.displayTooltip(false, false);
   };
 
   private handleFocus = () => {
-    const textField = this.el.shadowRoot?.querySelector(
-      this.TEXT_FIELD
-    ) as HTMLIcTextFieldElement;
-    const tooltip = this.el.shadowRoot?.querySelector(
-      this.TOOLTIP
-    ) as HTMLIcTooltipElement;
-    if (textField.validationStatus === "error") {
-      tooltip.displayTooltip(true, true);
+    if (this.pageInputEl.validationStatus === "error") {
+      this.pageInputTooltipEl.displayTooltip(true, true);
     }
   };
 
   private handleInputChange = () => {
-    const tooltip = this.el.shadowRoot.querySelector(
-      this.TOOLTIP
-    ) as HTMLIcTooltipElement;
-    const textField = this.el.shadowRoot.querySelector(
-      this.TEXT_FIELD
-    ) as HTMLIcTextFieldElement;
+    const textField = this.pageInputEl;
     const inputValue = parseInt(textField.value);
 
     if (inputValue > this.totalPages || inputValue <= 0) {
-      this.inputError = this.INVALID_PAGE_ERROR;
-      tooltip.displayTooltip(true, true);
-      textField.validationStatus = "error";
-      textField.focus();
+      this.setInputError(textField, this.INVALID_PAGE_ERROR);
+      this.pageInputTooltipEl.displayTooltip(true, true);
     }
   };
 
   private handleKeydown = (ev: KeyboardEvent) => {
-    const tooltip = this.el.shadowRoot.querySelector(
-      this.TOOLTIP
-    ) as HTMLIcTooltipElement;
-    const textField = this.el.shadowRoot.querySelector(
-      this.TEXT_FIELD
-    ) as HTMLIcTextFieldElement;
+    const tooltip = this.pageInputTooltipEl;
+    const textField = this.pageInputEl;
 
     if (ev.key === "Enter") {
       if (textField.validationStatus === "error") {
@@ -266,12 +230,7 @@ export class PaginationBar {
   };
 
   private handleKeyUp = (ev: KeyboardEvent) => {
-    const tooltip = this.el.shadowRoot.querySelector(
-      this.TOOLTIP
-    ) as HTMLIcTooltipElement;
-    const textField = this.el.shadowRoot.querySelector(
-      this.TEXT_FIELD
-    ) as HTMLIcTextFieldElement;
+    const textField = this.pageInputEl;
     const inputValue = parseInt(textField.value);
 
     if (
@@ -281,18 +240,14 @@ export class PaginationBar {
       ev.key !== "Tab" &&
       ev.key !== "Shift"
     ) {
-      this.inputError = this.NAN_ERROR;
-      tooltip.displayTooltip(true, false);
-      textField.validationStatus = "error";
+      this.setInputError(textField, this.NAN_ERROR, false);
+      this.pageInputTooltipEl.displayTooltip(true, false);
     }
   };
 
   private paginationShouldWrap = () => {
-    const pagination = this.el.shadowRoot.querySelector(
-      this.PAGINATION
-    ) as HTMLIcPaginationElement;
     if (this.paginationControl === "simple") {
-      if (pagination.clientHeight > 63) {
+      if (this.paginationEl.clientHeight > 63) {
         this.paginationWrapped = true;
       } else {
         this.paginationWrapped = false;
@@ -319,25 +274,26 @@ export class PaginationBar {
     this.resizeObserver.observe(this.paginationBarEl);
   };
 
-  private setDefaultItemsPerPage = () => {
-    this.itemsPerPage = this.itemsPerPageOptions[0].value;
-  };
-
-  private setDefaultItemsPerPageOptions = () => {
-    this.itemsPerPageOptions =
-      this.totalItems <= 100
-        ? [
-            { label: "10", value: "10" },
-            { label: "25", value: "25" },
-            { label: "50", value: "50" },
-            { label: "All", value: String(this.totalItems) },
-          ]
-        : [
-            { label: "25", value: "25" },
-            { label: "100", value: "100" },
-            { label: "1000", value: "1000" },
-            { label: "All", value: String(this.totalItems) },
-          ];
+  private setDisplayedItemsPerPageOptions = () => {
+    if (
+      this.itemsPerPageOptions === undefined ||
+      this.itemsPerPageOptions === null
+    ) {
+      this.displayedItemsPerPageOptions =
+        this.totalItems <= 100
+          ? [
+              { label: "10", value: "10" },
+              { label: "25", value: "25" },
+              { label: "50", value: "50" },
+            ]
+          : [
+              { label: "25", value: "25" },
+              { label: "100", value: "100" },
+              { label: "1000", value: "1000" },
+            ];
+    } else {
+      this.displayedItemsPerPageOptions = this.itemsPerPageOptions.slice(0, 3);
+    }
   };
 
   private setGoToPageInputStyles = () => {
@@ -353,39 +309,93 @@ export class PaginationBar {
     }
   };
 
+  private setInputError = (
+    el: HTMLIcTextFieldElement,
+    error: string,
+    focus = true
+  ) => {
+    this.inputError = error;
+    el.validationStatus = "error";
+    if (focus) el.setFocus();
+  };
+
+  private setItemsPerPage = (newValue: number) => {
+    if (this.itemsPerPage !== newValue) {
+      this.itemsPerPage = newValue;
+      this.icItemsPerPageChange.emit({ value: this.itemsPerPage });
+    }
+    this.setNumberPages();
+    this.setUpperBound();
+    if (this.currentPage > this.totalPages) {
+      this.paginationEl.setCurrentPage(this.totalPages);
+      this.currentPage = this.totalPages;
+    }
+    this.icPageChange.emit({ value: this.currentPage });
+  };
+
   private setNumberPages = () => {
-    this.totalPages = Math.ceil(this.totalItems / Number(this.itemsPerPage));
+    const numItemsPerPage = this.itemsPerPage;
+    if (this.totalItems <= numItemsPerPage) {
+      this.totalPages = 1;
+    } else {
+      this.totalPages = Math.ceil(this.totalItems / numItemsPerPage);
+    }
+  };
+
+  private setPaginationBarContent = (): void => {
+    this.setDisplayedItemsPerPageOptions();
+    this.trimItemsPerPageOptions();
+    this.updateItemsPerPage();
   };
 
   private setUpperBound = () => {
     this.upperBound = Math.min(
-      this.lowerBound + Number(this.itemsPerPage) - 1,
+      this.lowerBound + this.itemsPerPage - 1,
       this.totalItems
     );
   };
 
   private trimItemsPerPageOptions = () => {
-    this.itemsPerPageOptions = this.itemsPerPageOptions.slice(0, 3);
-    this.itemsPerPageOptions.push({
+    this.displayedItemsPerPageOptions.push({
       label: "All",
       value: String(this.totalItems),
     });
 
-    for (let i = 0; i < this.itemsPerPageOptions.length - 1; i++) {
-      if (this.totalItems <= Number(this.itemsPerPageOptions[i].value)) {
-        this.itemsPerPageOptions.splice(
+    for (let i = 0; i < this.displayedItemsPerPageOptions.length - 1; i++) {
+      if (
+        this.totalItems <= Number(this.displayedItemsPerPageOptions[i].value)
+      ) {
+        this.displayedItemsPerPageOptions.splice(
           i,
-          this.itemsPerPageOptions.length - (i + 1)
+          this.displayedItemsPerPageOptions.length - (i + 1)
         );
       }
     }
+  };
+
+  private updateItemsPerPage = () => {
+    let newItemsPerPage = this.itemsPerPage;
+    let updated = false;
+    let lastOptionValue = 0;
+    for (let i = 0; i < this.displayedItemsPerPageOptions.length; i++) {
+      lastOptionValue = Number(this.displayedItemsPerPageOptions[i].value);
+      if (this.itemsPerPage <= lastOptionValue) {
+        newItemsPerPage = lastOptionValue;
+        updated = true;
+        i = this.displayedItemsPerPageOptions.length;
+      }
+    }
+    if (!updated && this.itemsPerPage > lastOptionValue) {
+      newItemsPerPage = lastOptionValue;
+    }
+    this.setItemsPerPage(newItemsPerPage);
   };
 
   render() {
     const {
       appearance,
       alignment,
-      itemsPerPageOptions,
+      displayedItemsPerPageOptions,
       PAGE_INPUT_FIELD_ID,
       paginationControl,
       paginationType,
@@ -425,9 +435,10 @@ export class PaginationBar {
                   label="items-per-page-input"
                   class="items-per-page-input"
                   hideLabel
-                  options={itemsPerPageOptions}
-                  value={this.itemsPerPage}
+                  options={displayedItemsPerPageOptions}
+                  value={this.itemsPerPage.toString()}
                   onIcChange={() => this.changeItemsPerPage()}
+                  ref={(el: HTMLIcSelectElement) => (this.pageDropdownEl = el)}
                 ></ic-select>
               </div>
             )}
@@ -440,9 +451,13 @@ export class PaginationBar {
                 variant="label"
                 aria-live="polite"
               >
-                {this.lowerBound} - {this.upperBound} of {this.totalItems}{" "}
-                {this.itemLabel.toLowerCase()}
-                {this.totalItems > 1 ? "s" : ""}
+                {this.upperBound === 0 && `0 ${this.itemLabel.toLowerCase()}s`}
+                {this.upperBound > 0 &&
+                  `${this.lowerBound} - ${this.upperBound} of ${
+                    this.totalItems
+                  } ${this.itemLabel.toLowerCase()}${
+                    this.totalItems > 1 ? "s" : ""
+                  }`}
               </ic-typography>
             ) : (
               showItemsPerPage && (
@@ -471,6 +486,7 @@ export class PaginationBar {
               appearance={appearance}
               type={paginationControl}
               pages={this.totalPages}
+              ref={(el: HTMLIcPaginationElement) => (this.paginationEl = el)}
             ></ic-pagination>
           </div>
           {showGoToPageControl && (
@@ -487,6 +503,9 @@ export class PaginationBar {
                 target={`#${PAGE_INPUT_FIELD_ID}`}
                 disableHover
                 disableClick
+                ref={(el: HTMLIcTooltipElement) =>
+                  (this.pageInputTooltipEl = el)
+                }
               >
                 <ic-text-field
                   type="number"
@@ -503,6 +522,7 @@ export class PaginationBar {
                   validationInlineInternal
                   onBlur={() => this.handleBlur()}
                   onFocus={() => this.handleFocus()}
+                  ref={(el: HTMLIcTextFieldElement) => (this.pageInputEl = el)}
                 ></ic-text-field>
               </ic-tooltip>
               <ic-button

--- a/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/__snapshots__/ic-pagination-bar.spec.ts.snap
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/__snapshots__/ic-pagination-bar.spec.ts.snap
@@ -25,31 +25,6 @@ exports[`ic-pagination-bar should only allow a maximum of 4 custom items per pag
 </ic-pagination-bar>
 `;
 
-exports[`ic-pagination-bar should remove items per page options larger than the maximum number of items 1`] = `
-<ic-pagination-bar show-items-per-page-control="true" total-items="100">
-  <mock:shadow-root>
-    <div class="pagination-bar pagination-bar-right">
-      <div class="item-controls">
-        <div class="items-per-page-holder">
-          <ic-typography class="items-per-page-control-label pagination-text-default" variant="label">
-            Items per page
-          </ic-typography>
-          <ic-select class="items-per-page-input" hidelabel="" label="items-per-page-input" small="" value="10"></ic-select>
-        </div>
-        <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
-          Page 1 of 10
-        </ic-typography>
-      </div>
-      <div class="pagination-controls">
-        <div class="pagination-holder">
-          <ic-pagination appearance="default" pages="10" type="simple"></ic-pagination>
-        </div>
-      </div>
-    </div>
-  </mock:shadow-root>
-</ic-pagination-bar>
-`;
-
 exports[`ic-pagination-bar should render 1`] = `
 <ic-pagination-bar total-items="100">
   <mock:shadow-root>
@@ -135,15 +110,15 @@ exports[`ic-pagination-bar should render with custom items per page options 1`] 
           <ic-typography class="items-per-page-control-label pagination-text-default" variant="label">
             Items per page
           </ic-typography>
-          <ic-select class="items-per-page-input" hidelabel="" label="items-per-page-input" small="" value="10"></ic-select>
+          <ic-select class="items-per-page-input" hidelabel="" label="items-per-page-input" small="" value="15"></ic-select>
         </div>
         <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
-          Page 1 of 10
+          Page 1 of 7
         </ic-typography>
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" pages="7" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -207,7 +182,7 @@ exports[`ic-pagination-bar should render with go to page controls 1`] = `
             Go to page
           </ic-typography>
           <ic-tooltip disableclick="" disablehover="" label="Please enter a valid page" target="#go-to-page-input">
-            <ic-text-field class="go-to-page-input" hidelabel="" id="go-to-page-input" label="go-to-page-input" max="10" min="1" small="" type="number" validationinlineinternal=""></ic-text-field>
+            <ic-text-field class="go-to-page-input" hidelabel="" id="go-to-page-input" label="go-to-page-input" max="10" min="1" size="small" type="number" validationinlineinternal=""></ic-text-field>
           </ic-tooltip>
           <ic-button appearance="default" class="go-to-page-button" size="small" variant="secondary">
             Go
@@ -301,6 +276,63 @@ exports[`ic-pagination-bar should render with space between alignment 1`] = `
 </ic-pagination-bar>
 `;
 
+exports[`ic-pagination-bar should update pagination when number of item changes 1`] = `
+<ic-pagination-bar total-items="0">
+  <mock:shadow-root>
+    <div class="pagination-bar pagination-bar-right">
+      <div class="item-controls">
+        <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
+          Page 1 of 1
+        </ic-typography>
+      </div>
+      <div class="pagination-controls">
+        <div class="pagination-holder">
+          <ic-pagination appearance="default" pages="1" type="simple"></ic-pagination>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+</ic-pagination-bar>
+`;
+
+exports[`ic-pagination-bar should update pagination when number of item changes 2`] = `
+<ic-pagination-bar total-items="0">
+  <mock:shadow-root>
+    <div class="pagination-bar pagination-bar-right">
+      <div class="item-controls">
+        <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
+          Page 1 of 10
+        </ic-typography>
+      </div>
+      <div class="pagination-controls">
+        <div class="pagination-holder">
+          <ic-pagination appearance="default" pages="10" type="simple"></ic-pagination>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+</ic-pagination-bar>
+`;
+
+exports[`ic-pagination-bar should update pagination when number of item changes 3`] = `
+<ic-pagination-bar total-items="0">
+  <mock:shadow-root>
+    <div class="pagination-bar pagination-bar-right">
+      <div class="item-controls">
+        <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
+          Page 1 of 5
+        </ic-typography>
+      </div>
+      <div class="pagination-controls">
+        <div class="pagination-holder">
+          <ic-pagination appearance="default" pages="5" type="simple"></ic-pagination>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+</ic-pagination-bar>
+`;
+
 exports[`ic-pagination-bar should wrap pagination when the device size is small 1`] = `
 Object {
   "body": <body>
@@ -339,7 +371,7 @@ Object {
               Go to page
             </ic-typography>
             <ic-tooltip disableclick="" disablehover="" label="Please enter a valid page" target="#go-to-page-input">
-              <ic-text-field class="go-to-page-input" hidelabel="" id="go-to-page-input" label="go-to-page-input" max="10" min="1" small="" type="number" validationinlineinternal=""></ic-text-field>
+              <ic-text-field class="go-to-page-input" hidelabel="" id="go-to-page-input" label="go-to-page-input" max="10" min="1" size="small" type="number" validationinlineinternal=""></ic-text-field>
             </ic-tooltip>
             <ic-button appearance="default" class="go-to-page-button" size="small" variant="secondary">
               Go
@@ -372,6 +404,9 @@ Object {
     "disconnectedCallback": true,
     "element": true,
     "event": true,
+    "experimentalScopedSlotChanges": false,
+    "experimentalSlotFixes": false,
+    "formAssociated": true,
     "hasRenderFn": true,
     "hostListener": true,
     "hostListenerTarget": true,
@@ -396,7 +431,6 @@ Object {
     "method": true,
     "mode": true,
     "observeAttribute": true,
-    "patchPseudoShadowDom": false,
     "profile": true,
     "prop": true,
     "propBoolean": true,

--- a/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/ic-pagination-bar.spec.ts
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/ic-pagination-bar.spec.ts
@@ -126,6 +126,13 @@ describe("ic-pagination-bar", () => {
 
     await page.waitForChanges();
 
+    expect(page.rootInstance.displayedItemsPerPageOptions).toEqual([
+      { label: "15", value: "15" },
+      { label: "30", value: "30" },
+      { label: "60", value: "60" },
+      { label: "All", value: "100" },
+    ]);
+
     expect(page.root).toMatchSnapshot();
   });
 
@@ -149,6 +156,13 @@ describe("ic-pagination-bar", () => {
 
     await page.waitForChanges();
 
+    expect(page.rootInstance.displayedItemsPerPageOptions).toEqual([
+      { label: "25", value: "25" },
+      { label: "50", value: "50" },
+      { label: "75", value: "75" },
+      { label: "All", value: "150" },
+    ]);
+
     expect(page.root).toMatchSnapshot();
   });
 
@@ -169,7 +183,11 @@ describe("ic-pagination-bar", () => {
 
     await page.waitForChanges();
 
-    expect(page.root).toMatchSnapshot();
+    expect(page.rootInstance.displayedItemsPerPageOptions).toEqual([
+      { label: "25", value: "25" },
+      { label: "50", value: "50" },
+      { label: "All", value: "100" },
+    ]);
   });
 
   it("should wrap pagination when the device size is small", async () => {
@@ -321,7 +339,7 @@ describe("ic-pagination-bar", () => {
 
   it("should error immediately when an invalid page is entered before it is submitted", async () => {
     const page = await newSpecPage({
-      components: [PaginationBar, IcPagination, IcTooltip],
+      components: [PaginationBar, IcPagination, IcTooltip, IcTextField],
       html: `<ic-pagination-bar total-items="100" show-go-to-page-control="true"></ic-pagination-bar>`,
     });
 
@@ -329,7 +347,7 @@ describe("ic-pagination-bar", () => {
 
     const input = paginationBar.shadowRoot.querySelector("ic-text-field");
 
-    expect(input.validationStatus).toBeUndefined();
+    expect(input.validationStatus).toBe("");
 
     input.value = "15";
 
@@ -344,7 +362,7 @@ describe("ic-pagination-bar", () => {
 
   it("should remain in error state if enter is pressed while in error state", async () => {
     const page = await newSpecPage({
-      components: [PaginationBar, IcPagination, IcTooltip],
+      components: [PaginationBar, IcPagination, IcTooltip, IcTextField],
       html: `<ic-pagination-bar total-items="100" show-go-to-page-control="true"></ic-pagination-bar>`,
     });
 
@@ -354,7 +372,7 @@ describe("ic-pagination-bar", () => {
 
     const event = new KeyboardEvent("keydown", { key: "Enter" });
 
-    expect(input.validationStatus).toBeUndefined();
+    expect(input.validationStatus).toBe("");
 
     input.value = "15";
 
@@ -649,5 +667,26 @@ describe("ic-pagination-bar", () => {
     await page.waitForChanges();
 
     expect(event).toHaveBeenCalled();
+  });
+
+  it("should update pagination when number of item changes", async () => {
+    const page = await newSpecPage({
+      components: [PaginationBar],
+      html: `<ic-pagination-bar total-items="0"></ic-pagination-bar>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.root.totalItems = "100";
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+
+    page.root.totalItems = "50";
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes Pagination bar not updating when props change

replaces #1725 

## Related issue
#1337 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.