### PR TITLE
fix(canary-web-components): make focus indicator in data-input more specific

### DIFF
--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.css
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.css
@@ -24,7 +24,7 @@ ic-input-component-container:hover {
   color: var(--ic-color-tertiary-text);
 }
 
-.focus-indicator {
+ic-input-component-container .focus-indicator {
   padding: var(--ic-space-xxxs) var(--ic-space-xs);
   align-items: center;
 }


### PR DESCRIPTION
Add container class to focus-indcator css in ic-date-input to stop it being overriden in gatsby

This relates to a [comment on PR899 on design system](https://github.com/mi6/ic-design-system/pull/899#issuecomment-2066505495)