### PR TITLE
ci(root): adding action permissions for cypress uploading

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -174,6 +174,8 @@ jobs:
     needs: [check-updates]
     name: "Cypress tests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added action permissions for failed cypress test uploads on feature builds.

## Related issue
N/A

## Checklist
N/A