### PR TITLE
1118 test controlled and uncontrolled

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,3 +47,4 @@ Tell us the issue number. If suggesting an improvement or component, please disc
 - [ ] Min/max content examples tested with no loss of content or overflow. 
 - [ ] All prop combinations work without issue. 
 - [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
+- [ ] Controlled and uncontrolled input components tested.

--- a/packages/react/src/component-tests/IcCheckbox/IcCheckbox.cy.tsx
+++ b/packages/react/src/component-tests/IcCheckbox/IcCheckbox.cy.tsx
@@ -2,7 +2,12 @@
 
 import React from "react";
 import { mount } from "cypress/react";
-import { Checkbox, CheckboxForm } from "./IcCheckboxTestData";
+import {
+  Checkbox,
+  CheckboxForm,
+  Controlled,
+  Uncontrolled,
+} from "./IcCheckboxTestData";
 import { IcCheckbox, IcCheckboxGroup, IcTextField } from "../../components";
 import {
   BE_DISABLED,
@@ -332,5 +337,22 @@ describe("A11y and visual regression tests", () => {
       testThreshold: DEFAULT_TEST_THRESHOLD,
     });
     cy.checkA11yWithWait();
+  });
+
+  it("renders as a controlled component", () => {
+    mount(<Controlled />);
+
+    cy.get("ic-button#uncheck-btn").click();
+    cy.get(CHECKBOX_SELECTOR).eq(0).should(HAVE_PROP, "checked", false);
+    cy.get("ic-button#check-btn").click();
+    cy.get(CHECKBOX_SELECTOR).eq(0).should(HAVE_PROP, "checked", true);
+  });
+
+  it("renders as an uncontrolled component", () => {
+    mount(<Uncontrolled />);
+
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.get(CHECKBOX_SELECTOR).eq(0).shadow().find(CONTAINER_SELECTOR).click();
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, true);
   });
 });

--- a/packages/react/src/component-tests/IcCheckbox/IcCheckboxTestData.tsx
+++ b/packages/react/src/component-tests/IcCheckbox/IcCheckboxTestData.tsx
@@ -1,5 +1,10 @@
-import React, { useState } from "react";
-import { IcCheckbox, IcCheckboxGroup, IcTextField } from "../../components";
+import React, { useState, useRef } from "react";
+import {
+  IcButton,
+  IcCheckbox,
+  IcCheckboxGroup,
+  IcTextField,
+} from "../../components";
 
 export const Checkbox = () => {
   return (
@@ -63,5 +68,51 @@ export const CheckboxForm = () => {
         </button>
       </form>
     </div>
+  );
+};
+
+export const Controlled = () => {
+  const [checked, setChecked] = useState(true);
+  const defaultButtonClickHandler = () => {
+    setChecked(false);
+  };
+  const differentButtonClickHandler = () => {
+    setChecked(true);
+  };
+  return (
+    <>
+      <IcCheckbox checked={checked} label="Label" value="valueName1" />
+      <IcButton
+        id="uncheck-btn"
+        variant="primary"
+        onClick={defaultButtonClickHandler}
+      >
+        Unchecked
+      </IcButton>
+      <IcButton
+        id="check-btn"
+        variant="primary"
+        onClick={differentButtonClickHandler}
+      >
+        Checked
+      </IcButton>
+    </>
+  );
+};
+
+export const Uncontrolled = () => {
+  const checkboxEl = useRef<any>(null);
+  const handleCheck = () => {
+    console.log(checkboxEl.current.checked);
+  };
+  return (
+    <>
+      <IcCheckbox
+        ref={checkboxEl}
+        label="Label"
+        value="valueName1"
+        onIcCheck={handleCheck}
+      />
+    </>
   );
 };

--- a/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
@@ -6,8 +6,15 @@ import {
   Radios,
   RadioOptionsEmptyInitial,
   RadioOptionsChanging,
+  Controlled,
+  Uncontrolled,
 } from "./IcRadioTestData";
-import { HAVE_PROP, HAVE_VALUE, HAVE_FOCUS } from "../utils/constants";
+import {
+  HAVE_PROP,
+  HAVE_VALUE,
+  HAVE_FOCUS,
+  HAVE_BEEN_CALLED_WITH,
+} from "../utils/constants";
 
 //const DEFAULT_TEST_THRESHOLD = 0.2;
 
@@ -86,5 +93,22 @@ describe("IcRadio", () => {
     cy.findShadowEl(RADIO_SELECTOR, INPUT).eq(1).should(HAVE_FOCUS);
     cy.get(RADIO_SELECTOR).first().should(HAVE_PROP, "selected", false);
     cy.get(RADIO_SELECTOR).last().should(HAVE_PROP, "selected", true);
+  });
+
+  it("should render as a controlled component", () => {
+    mount(<Controlled />);
+
+    cy.get("ic-button#unselect-btn").click();
+    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
+    cy.get("ic-button#select-btn").click();
+    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
+  });
+
+  it("should render as an uncontrolled component", () => {
+    mount(<Uncontrolled />);
+
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, true);
   });
 });

--- a/packages/react/src/component-tests/IcRadio/IcRadioTestData.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadioTestData.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import {
   IcRadioOption,
   IcRadioGroup,
@@ -83,5 +83,52 @@ export const RadioOptionsChanging = () => {
         <IcButton onClick={updateRadios}>Update</IcButton>
       </div>
     </IcSectionContainer>
+  );
+};
+
+export const Controlled = () => {
+  const [selected, setSelected] = useState(true);
+  const defaultButtonClickHandler = () => {
+    setSelected(false);
+  };
+  const differentButtonClickHandler = () => {
+    setSelected(true);
+  };
+  return (
+    <>
+      <IcRadioOption selected={selected} label="Label" value="valueName1" />
+      <IcButton
+        id="unselect-btn"
+        variant="primary"
+        onClick={defaultButtonClickHandler}
+      >
+        Unselected
+      </IcButton>
+      <IcButton
+        id="select-btn"
+        variant="primary"
+        onClick={differentButtonClickHandler}
+      >
+        Selected
+      </IcButton>
+    </>
+  );
+};
+
+export const Uncontrolled = () => {
+  const radioEl = useRef<any>(null);
+  const handleCheck = () => {
+    console.log(radioEl.current.selected);
+  };
+  return (
+    <IcRadioGroup label="This is a label" name="1">
+      <IcRadioOption
+        ref={radioEl}
+        value="valueName1"
+        label="Unselected / Default"
+        onIcSelectedChange={handleCheck}
+      />
+      <IcRadioOption value="valueName2" label="Selected / Default" selected />
+    </IcRadioGroup>
   );
 };

--- a/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
+++ b/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
@@ -1,0 +1,59 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import {
+  Controlled,
+  IC_INPUT_CONTAINER,
+  IC_MENU_LI,
+  Uncontrolled,
+} from "./IcSearchBarTestData";
+import {
+  BE_VISIBLE,
+  HAVE_BEEN_CALLED_WITH,
+  HAVE_LENGTH,
+} from "../utils/constants";
+
+const SEARCH_SELECTOR = "ic-search-bar";
+const TEXT_FIELD_SELECTOR = "ic-text-field";
+
+describe("IcSearchBar", () => {
+  it("renders as a controlled component", () => {
+    mount(<Controlled />);
+
+    cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
+      .shadow()
+      .find(IC_INPUT_CONTAINER)
+      .type("La");
+    cy.findShadowEl(SEARCH_SELECTOR, IC_MENU_LI)
+      .should(BE_VISIBLE)
+      .should(HAVE_LENGTH, "1");
+
+    cy.clickOnShadowEl(SEARCH_SELECTOR, "#clear-button");
+
+    cy.get("ic-button#update-opt").click();
+
+    cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
+      .shadow()
+      .find(IC_INPUT_CONTAINER)
+      .type("La");
+    cy.findShadowEl(SEARCH_SELECTOR, IC_MENU_LI)
+      .should(BE_VISIBLE)
+      .should(HAVE_LENGTH, "4");
+  });
+
+  it("renders as an uncontrolled component", () => {
+    mount(<Uncontrolled />);
+
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
+      .shadow()
+      .find(IC_INPUT_CONTAINER)
+      .type("La");
+    cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
+      .shadow()
+      .find(IC_INPUT_CONTAINER)
+      .type("{enter}");
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, "fla");
+  });
+});

--- a/packages/react/src/component-tests/IcSearchBar/IcSearchBarTestData.tsx
+++ b/packages/react/src/component-tests/IcSearchBar/IcSearchBarTestData.tsx
@@ -1,0 +1,69 @@
+import React, { useState, useRef } from "react";
+import { IcButton, IcSearchBar } from "../../components";
+
+export const IC_INPUT_CONTAINER = "ic-input-component-container";
+export const IC_MENU_LI = "ic-menu ul li";
+
+export const Controlled = () => {
+  const [options, setOptions] = useState([
+    { label: "Espresso", value: "Esp" },
+    { label: "Flat White", value: "Fla" },
+    { label: "Cappuccino", value: "Cap" },
+    { label: "Americano", value: "Ame" },
+    { label: "Mocha", value: "Moc" },
+  ]);
+  const handleChange = () => {
+    setOptions([
+      { label: "Cappuccino", value: "Cap" },
+      { label: "Latte", value: "Lat" },
+      { label: "Americano", value: "Ame" },
+      { label: "Filter", value: "Fil" },
+      { label: "Flat white", value: "Fla" },
+      { label: "Mocha", value: "Moc" },
+      { label: "Macchiato", value: "Mac" },
+      { label: "Café au lait", value: "Caf" },
+      { label: "Espresso", value: "Esp" },
+      { label: "Cortado", value: "Cor" },
+      { label: "Ristretto", value: "Ris" },
+      { label: "Latte macchiato", value: "Lam" },
+    ]);
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "row", gap: "8px" }}>
+      <IcSearchBar
+        placeholder="Controlled"
+        label="Controlled"
+        options={options}
+        hideLabel
+      />
+      <IcButton id="update-opt" onClick={() => handleChange()}>
+        Update options
+      </IcButton>
+    </div>
+  );
+};
+
+export const Uncontrolled = () => {
+  const searchEl = useRef<any>(null);
+  const handleChange = () => {
+    console.log(searchEl.current.value);
+  };
+  return (
+    <>
+      <IcSearchBar
+        ref={searchEl}
+        placeholder="Uncontrolled"
+        label="Uncontrolled"
+        options={[
+          { label: "Espresso", value: "esp" },
+          { label: "Double Espresso", value: "dbl" },
+          { label: "Flat White", value: "fla" },
+          { label: "Cappuccino", value: "cap" },
+          { label: "Americano", value: "ame" },
+          { label: "Mocha", value: "moc" },
+        ]}
+        onIcChange={handleChange}
+      />
+    </>
+  );
+};

--- a/packages/react/src/component-tests/IcSelect/IcSelect.cy.tsx
+++ b/packages/react/src/component-tests/IcSelect/IcSelect.cy.tsx
@@ -11,6 +11,7 @@ import {
   HAVE_ATTR,
   HAVE_BEEN_CALLED,
   HAVE_BEEN_CALLED_ONCE,
+  HAVE_BEEN_CALLED_WITH,
   HAVE_CLASS,
   HAVE_FOCUS,
   HAVE_LENGTH,
@@ -40,8 +41,10 @@ import {
   TYPE_ENTER,
 } from "./IcSelectConstants";
 import {
+  ControlledSelect,
   LoadingSelect,
   LoadingSelectNoTimeout,
+  UncontrolledSelect,
   coffeeCustomElements,
   coffeeDisabledOption,
   coffeeOptions,
@@ -1513,5 +1516,29 @@ describe("IcSelect", () => {
       testThreshold: DEFAULT_TEST_THRESHOLD + 0.045,
     });
     cy.checkA11yWithWait();
+  });
+
+  it("renders as an controlled component", () => {
+    mount(<ControlledSelect />);
+
+    cy.clickOnShadowEl("ic-select", IC_INPUT_CONTAINER);
+    cy.findShadowEl("ic-select", IC_MENU_LI)
+      .should(BE_VISIBLE)
+      .should(HAVE_LENGTH, "6");
+
+    cy.get("ic-button#update-opt").click();
+
+    cy.clickOnShadowEl("ic-select", IC_INPUT_CONTAINER);
+    cy.findShadowEl("ic-select", IC_MENU_LI)
+      .should(BE_VISIBLE)
+      .should(HAVE_LENGTH, "12");
+  });
+
+  it("renders as an uncontrolled component", () => {
+    mount(<UncontrolledSelect />);
+
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.findShadowEl("ic-select", IC_INPUT_CONTAINER).type(TYPE_DOWN_ARROW);
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, "espresso");
   });
 });

--- a/packages/react/src/component-tests/IcSelect/IcSelectSearchable.cy.tsx
+++ b/packages/react/src/component-tests/IcSelect/IcSelectSearchable.cy.tsx
@@ -8,6 +8,7 @@ import {
   CONTAIN_TEXT,
   HAVE_ATTR,
   HAVE_BEEN_CALLED,
+  HAVE_BEEN_CALLED_WITH,
   HAVE_LENGTH,
   HAVE_TEXT,
   HAVE_VALUE,
@@ -33,8 +34,10 @@ import {
   TYPE_ENTER,
 } from "./IcSelectConstants";
 import {
+  ControlledSearchableSelect,
   LoadingSelectSearchable,
   LoadingSelectSearchableNoTimeout,
+  UncontrolledSearchableSelect,
   coffeeCustomElements,
   coffeeDisabledOption,
   coffeeOptions,
@@ -935,5 +938,31 @@ describe("IcSelect searchable", () => {
       name: "searchable-recommended-open",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.003),
     });
+  });
+
+  it("renders as a controlled component", () => {
+    mount(<ControlledSearchableSelect />);
+
+    cy.clickOnShadowEl("ic-select", IC_INPUT_CONTAINER);
+    cy.findShadowEl("ic-select", IC_MENU_LI)
+      .should(BE_VISIBLE)
+      .should(HAVE_LENGTH, "6");
+
+    cy.get("ic-button#update-opt").click();
+
+    cy.clickOnShadowEl("ic-select", IC_INPUT_CONTAINER);
+    cy.findShadowEl("ic-select", IC_MENU_LI)
+      .should(BE_VISIBLE)
+      .should(HAVE_LENGTH, "12");
+  });
+
+  it("renders as an uncontrolled component", () => {
+    mount(<UncontrolledSearchableSelect />);
+
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.get("ic-select").shadow().find(IC_INPUT_CONTAINER).type("cap");
+    cy.findShadowEl("ic-select", IC_INPUT_CONTAINER).type(TYPE_DOWN_ARROW);
+    cy.findShadowEl("ic-select", IC_INPUT_CONTAINER).type(TYPE_ENTER);
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, "cappuccino");
   });
 });

--- a/packages/react/src/component-tests/IcSelect/IcSelectTestData.tsx
+++ b/packages/react/src/component-tests/IcSelect/IcSelectTestData.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState, useRef } from "react";
 import { IcButton, IcSelect } from "../../components";
 
 export const coffeeOptions = [
@@ -264,3 +264,75 @@ export const LoadingSelectSearchableNoTimeout = (): ReactElement => (
     />
   </>
 );
+
+export const ControlledSelect = () => {
+  const [options, setOptions] = useState(coffeeOptions);
+  const handleChange = () => {
+    setOptions(manyOptions);
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "row" }}>
+      <IcSelect placeholder="Controlled" label="Controlled" options={options} />
+      <IcButton id="update-opt" onClick={() => handleChange()}>
+        Update options
+      </IcButton>
+    </div>
+  );
+};
+
+export const ControlledSearchableSelect = () => {
+  const [options, setOptions] = useState(coffeeOptions);
+  const handleChange = () => {
+    setOptions(manyOptions);
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "row" }}>
+      <IcSelect
+        placeholder="Controlled"
+        label="Controlled"
+        options={options}
+        searchable
+      />
+      <IcButton id="update-opt" onClick={() => handleChange()}>
+        Update options
+      </IcButton>
+    </div>
+  );
+};
+
+export const UncontrolledSelect = () => {
+  const selectEl = useRef<any>(null);
+  const handleChange = () => {
+    console.log(selectEl.current.value);
+  };
+  return (
+    <>
+      <IcSelect
+        ref={selectEl}
+        placeholder="Uncontrolled"
+        label="Uncontrolled"
+        options={coffeeOptions}
+        onIcChange={handleChange}
+      />
+    </>
+  );
+};
+
+export const UncontrolledSearchableSelect = () => {
+  const selectEl = useRef<any>(null);
+  const handleChange = () => {
+    console.log(selectEl.current.value);
+  };
+  return (
+    <>
+      <IcSelect
+        ref={selectEl}
+        searchable
+        placeholder="Uncontrolled"
+        label="Uncontrolled"
+        options={coffeeOptions}
+        onIcChange={handleChange}
+      />
+    </>
+  );
+};

--- a/packages/react/src/component-tests/IcSwitch/IcSwitch.cy.tsx
+++ b/packages/react/src/component-tests/IcSwitch/IcSwitch.cy.tsx
@@ -1,0 +1,19 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { Controlled, Uncontrolled } from "./IcSwitchTestData";
+import { HAVE_BEEN_CALLED_WITH, HAVE_PROP } from "../utils/constants";
+
+describe("IcSwitch", () => {
+  it("renders as a controlled component", () => {
+    mount(<Controlled />);
+
+    cy.get("ic-button#uncheck-btn").click();
+    cy.get("ic-switch").eq(0).should(HAVE_PROP, "checked", false);
+    cy.get("ic-button#check-btn").click();
+    cy.get("ic-switch").eq(0).should(HAVE_PROP, "checked", true);
+  });
+
+  //No test for uncontrolled as it always returns false
+});

--- a/packages/react/src/component-tests/IcSwitch/IcSwitchTestData.tsx
+++ b/packages/react/src/component-tests/IcSwitch/IcSwitchTestData.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useRef } from "react";
+import { IcButton, IcSwitch } from "../../components";
+
+export const Controlled = () => {
+  const [checked, setChecked] = useState(true);
+  const defaultButtonClickHandler = () => {
+    setChecked(false);
+  };
+  const differentButtonClickHandler = () => {
+    setChecked(true);
+  };
+  return (
+    <>
+      <IcSwitch checked={checked} label="Label" />
+      <br />
+      <br />
+      <IcButton
+        id="uncheck-btn"
+        variant="primary"
+        onClick={defaultButtonClickHandler}
+      >
+        Unchecked
+      </IcButton>
+      <IcButton
+        id="check-btn"
+        variant="primary"
+        onClick={differentButtonClickHandler}
+      >
+        Checked
+      </IcButton>
+    </>
+  );
+};
+
+export const Uncontrolled = () => {
+  const switchEl = useRef<any>(null);
+  const handleChange = () => {
+    console.log(switchEl.current.checked);
+  };
+  return <IcSwitch ref={switchEl} label="Test" onIcChange={handleChange} />;
+};

--- a/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
@@ -1,0 +1,30 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { Controlled, Uncontrolled } from "./IcTextFieldTestData";
+import { HAVE_BEEN_CALLED_WITH, HAVE_PROP } from "../utils/constants";
+
+const TEXT_FIELD_SELECTOR = "ic-text-field";
+
+describe("IcTextField", () => {
+  it("renders as a controlled component", () => {
+    mount(<Controlled />);
+
+    cy.get(TEXT_FIELD_SELECTOR).eq(0).should(HAVE_PROP, "value", "");
+    cy.findShadowEl(TEXT_FIELD_SELECTOR, "ic-input-component-container").type(
+      "Test"
+    );
+    cy.get(TEXT_FIELD_SELECTOR).eq(0).should(HAVE_PROP, "value", "Test");
+  });
+
+  it("renders as an uncontrolled component", () => {
+    mount(<Uncontrolled />);
+
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.findShadowEl(TEXT_FIELD_SELECTOR, "ic-input-component-container").type(
+      "Test"
+    );
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, "Test");
+  });
+});

--- a/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
@@ -1,0 +1,33 @@
+import React, { useRef, useState } from "react";
+import { IcTextField } from "../../components";
+
+export const Controlled = () => {
+  const [value, setValue] = useState("");
+  const handleChange = (event: any) => {
+    console.log(event.detail.value);
+    setValue(event.detail.value);
+  };
+  return (
+    <IcTextField
+      placeholder="Controlled"
+      label="Controlled"
+      value={value}
+      onIcChange={handleChange}
+    />
+  );
+};
+
+export const Uncontrolled = () => {
+  const textFieldEl = useRef<any>(null);
+  const handleChange = () => {
+    console.log(textFieldEl.current.value);
+  };
+  return (
+    <IcTextField
+      ref={textFieldEl}
+      placeholder="Uncontrolled"
+      label="Uncontrolled"
+      onIcChange={handleChange}
+    />
+  );
+};

--- a/packages/react/src/stories/ic-checkbox.stories.mdx
+++ b/packages/react/src/stories/ic-checkbox.stories.mdx
@@ -5,11 +5,16 @@ import {
   ArgsTable,
   Description,
 } from "@storybook/addon-docs";
-import { IcCheckboxGroup, IcCheckbox, IcTextField } from "../components";
+import {
+  IcCheckboxGroup,
+  IcCheckbox,
+  IcTextField,
+  IcButton,
+} from "../components";
 import checkboxReadme from "../../../web-components/src/components/ic-checkbox/readme.md";
 import checkboxGroupReadme from "../../../web-components/src/components/ic-checkbox-group/readme.md";
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 <Meta title="Checkbox" component={IcCheckboxGroup} />
 
@@ -340,5 +345,59 @@ export const TextField = () => {
 <Canvas>
   <Story name="TextField value change">
     <TextField />
+  </Story>
+</Canvas>
+
+### Controlled
+
+export const Controlled = () => {
+  const [checked, setChecked] = useState(true);
+  const defaultButtonClickHandler = () => {
+    setChecked(false);
+  };
+  const differentButtonClickHandler = () => {
+    setChecked(true);
+  };
+  return (
+    <>
+      <IcCheckbox checked={checked} label="Label" value="valueName1" />
+      <IcButton variant="primary" onClick={defaultButtonClickHandler}>
+        Unchecked
+      </IcButton>
+      <IcButton variant="primary" onClick={differentButtonClickHandler}>
+        Checked
+      </IcButton>
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Controlled">
+    <Controlled />
+  </Story>
+</Canvas>
+
+### Uncontrolled
+
+export const Uncontrolled = () => {
+  const checkboxEl = useRef();
+  const handleCheck = () => {
+    console.log(checkboxEl.current.checked);
+  };
+  return (
+    <>
+      <IcCheckbox
+        ref={checkboxEl}
+        label="Label"
+        value="valueName1"
+        onIcCheck={handleCheck}
+      />
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <Uncontrolled />
   </Story>
 </Canvas>

--- a/packages/react/src/stories/ic-radio-group.stories.mdx
+++ b/packages/react/src/stories/ic-radio-group.stories.mdx
@@ -13,7 +13,7 @@ import {
 } from "../components";
 import radioOptionReadme from "../../../web-components/src/components/ic-radio-option/readme.md";
 import radioGroupReadme from "../../../web-components/src/components/ic-radio-group/readme.md";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 <Meta title="Radio button" component={IcRadioGroup} />
 
@@ -341,5 +341,60 @@ return (
 <Canvas>
   <Story name="Updating options">
     <RadioOptionsUpdate />
+  </Story>
+</Canvas>
+
+### Controlled
+
+export const Controlled = () => {
+  const [selected, setSelected] = useState(true);
+  const defaultButtonClickHandler = () => {
+    setSelected(false);
+  };
+  const differentButtonClickHandler = () => {
+    setSelected(true);
+  };
+  return (
+    <>
+      <IcRadioOption selected={selected} label="Label" value="valueName1" />
+      <IcButton variant="primary" onClick={defaultButtonClickHandler}>
+        Unselected
+      </IcButton>
+      <IcButton variant="primary" onClick={differentButtonClickHandler}>
+        Selected
+      </IcButton>
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Controlled">
+    <Controlled />
+  </Story>
+</Canvas>
+
+### Uncontrolled
+
+export const Uncontrolled = () => {
+  const radioEl = useRef();
+  const handleCheck = () => {
+    console.log(radioEl.current.selected);
+  };
+  return (
+    <IcRadioGroup label="This is a label" name="1">
+      <IcRadioOption
+        ref={radioEl}
+        value="valueName1"
+        label="Unselected / Default"
+        onIcSelectedChange={handleCheck}
+      />
+      <IcRadioOption value="valueName2" label="Selected / Default" selected />
+    </IcRadioGroup>
+  );
+};
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <Uncontrolled />
   </Story>
 </Canvas>

--- a/packages/react/src/stories/ic-search-bar.stories.mdx
+++ b/packages/react/src/stories/ic-search-bar.stories.mdx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Meta,
   Story,
@@ -254,5 +254,70 @@ export const ExternalFiltering = () => {
         { label: "Mocha", value: "mocha" },
       ]}
     />
+  </Story>
+</Canvas>
+
+### Controlled
+
+export const ControlledExample = () => {
+  const [value, setValue] = useState("cap");
+  const handleChange = (event) => {
+    console.log(event.detail.value);
+    setValue(event.detail.value);
+  };
+  return (
+    <IcSearchBar
+      placeholder="Controlled"
+      label="Controlled"
+      options={[
+        { label: "Espresso", value: "esp" },
+        { label: "Double Espresso", value: "dbl" },
+        { label: "Flat White", value: "fla" },
+        { label: "Cappuccino", value: "cap" },
+        { label: "Americano", value: "ame" },
+        { label: "Mocha", value: "moc" },
+      ]}
+      value={value}
+      onIcChange={handleChange}
+    />
+  );
+};
+
+<Canvas>
+  <Story name="Controlled">
+    <ControlledExample />
+  </Story>
+</Canvas>
+
+### Uncontrolled
+
+export const Uncontrolled = () => {
+  const searchEl = useRef();
+  const handleChange = () => {
+    console.log(searchEl.current.value);
+  };
+  return (
+    <>
+      <IcSearchBar
+        ref={searchEl}
+        placeholder="Uncontrolled"
+        label="Uncontrolled"
+        options={[
+          { label: "Espresso", value: "esp" },
+          { label: "Double Espresso", value: "dbl" },
+          { label: "Flat White", value: "fla" },
+          { label: "Cappuccino", value: "cap" },
+          { label: "Americano", value: "ame" },
+          { label: "Mocha", value: "moc" },
+        ]}
+        onIcChange={handleChange}
+      />
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <Uncontrolled />
   </Story>
 </Canvas>

--- a/packages/react/src/stories/ic-select_(searchable).stories.mdx
+++ b/packages/react/src/stories/ic-select_(searchable).stories.mdx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Meta, Story, Canvas, Description } from "@storybook/addon-docs";
 
 import { IcSelect, IcButton, IcTypography } from "../components";
@@ -607,6 +607,59 @@ export const ExternalFiltering = () => {
         />
       );
     }}
+  </Story>
+</Canvas>
+
+### Controlled
+
+export const ControlledExample = () => {
+  const [value, setValue] = useState("Cap");
+  const handleChange = (event) => {
+    console.log(event.detail.value);
+    setValue(event.detail.value);
+  };
+  return (
+    <IcSelect
+      searchable
+      placeholder="Controlled"
+      label="Controlled"
+      options={options}
+      value={value}
+      onIcChange={handleChange}
+    />
+  );
+};
+
+<Canvas>
+  <Story name="Controlled">
+    <ControlledExample />
+  </Story>
+</Canvas>
+
+### Uncontrolled
+
+export const Uncontrolled = () => {
+  const selectEl = useRef();
+  const handleChange = () => {
+    console.log(selectEl.current.value);
+  };
+  return (
+    <>
+      <IcSelect
+        ref={selectEl}
+        searchable
+        placeholder="Uncontrolled"
+        label="Uncontrolled"
+        options={options}
+        onIcChange={handleChange}
+      />
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <Uncontrolled />
   </Story>
 </Canvas>
 

--- a/packages/react/src/stories/ic-select_(single).stories.mdx
+++ b/packages/react/src/stories/ic-select_(single).stories.mdx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Meta, Story, Canvas, Description } from "@storybook/addon-docs";
 
 import { IcSelect } from "../components";
@@ -551,6 +551,57 @@ export const LoadingWithError = () => {
         />
       );
     }}
+  </Story>
+</Canvas>
+
+### Controlled
+
+export const ControlledExample = () => {
+  const [value, setValue] = useState("Cap");
+  const handleChange = (event) => {
+    console.log(event.detail.value);
+    setValue(event.detail.value);
+  };
+  return (
+    <IcSelect
+      placeholder="Controlled"
+      label="Controlled"
+      options={options}
+      value={value}
+      onIcChange={handleChange}
+    />
+  );
+};
+
+<Canvas>
+  <Story name="Controlled">
+    <ControlledExample />
+  </Story>
+</Canvas>
+
+### Uncontrolled
+
+export const Uncontrolled = () => {
+  const selectEl = useRef();
+  const handleChange = () => {
+    console.log(selectEl.current.value);
+  };
+  return (
+    <>
+      <IcSelect
+        ref={selectEl}
+        placeholder="Uncontrolled"
+        label="Uncontrolled"
+        options={options}
+        onIcChange={handleChange}
+      />
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <Uncontrolled />
   </Story>
 </Canvas>
 

--- a/packages/react/src/stories/ic-switch.stories.mdx
+++ b/packages/react/src/stories/ic-switch.stories.mdx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import {
   Meta,
   Story,

--- a/packages/react/src/stories/ic-text-field.stories.mdx
+++ b/packages/react/src/stories/ic-text-field.stories.mdx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import {
   Meta,
   Story,
@@ -425,6 +425,29 @@ export const ControlledExample = () => {
 <Canvas>
   <Story name="Controlled">
     <ControlledExample />
+  </Story>
+</Canvas>
+
+### Uncontrolled
+
+export const Uncontrolled = () => {
+  const textFieldEl = useRef();
+  const handleChange = () => {
+    console.log(textFieldEl.current.value);
+  };
+  return (
+    <IcTextField
+      ref={textFieldEl}
+      placeholder="Uncontrolled"
+      label="Uncontrolled"
+      onIcChange={handleChange}
+    />
+  );
+};
+
+<Canvas>
+  <Story name="Uncontrolled">
+    <Uncontrolled />
   </Story>
 </Canvas>
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add storybook examples and cypress tests for controlled/uncontrolled comps using useState and useRef

## Related issue
#1118 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.