### PR TITLE
test(react): add a11y test to disabled chips

### DIFF
--- a/packages/react/src/component-tests/IcChip/IcChip.cy.tsx
+++ b/packages/react/src/component-tests/IcChip/IcChip.cy.tsx
@@ -8,6 +8,7 @@ import { SlottedSVG } from "../../";
 import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
 import { SwitchColour } from "./IcChipTestData";
 import { HAVE_PROP } from "../utils/constants";
+import { CYPRESS_AXE_OPTIONS } from "../../../cypress/utils/a11y";
 
 const DEFAULT_TEST_THRESHOLD = 0.03;
 
@@ -121,6 +122,15 @@ describe("IcChip visual and a11y testing", () => {
       </div>
     );
 
+    // Disabled elements do not to pass contrast checks according to WCAG guidance
+    const customCypressRules = {
+      rules: {
+        ...CYPRESS_AXE_OPTIONS.rules,
+        "color-contrast": { enabled: false },
+      },
+    };
+
+    cy.checkA11yWithWait(undefined, undefined, customCypressRules);
     cy.compareSnapshot({
       name: "disabled",
       testThreshold: DEFAULT_TEST_THRESHOLD,


### PR DESCRIPTION
## Summary of the changes
[Disabled interface items are not required to meet constrast values](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum#:~:text=User%20Interface%20Components%20that%20are%20not%20available%20for%20user%20interaction%20(e.g.%2C%20a%20disabled%20control%20in%20HTML)%20are%20not%20required%20to%20meet%20contrast%20requirements.) so we can disable that rule in the cypress accessibility check for disabled chips. 

#1505 


- [x] Relevant unit tests and visual regression tests added. 
- [x] A11y unit test added and yields no issues.
