### PR TITLE
fix(web-components): add max-content to ic-tooltip to make size match child element

### DIFF
--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.css
@@ -4,6 +4,11 @@
  * @prop --ic-z-index-tooltip: z-index of tooltip
  */
 
+:host(.ic-tooltip) {
+  width: max-content;
+  height: max-content;
+}
+
 :host(.ic-tooltip) .ic-tooltip-container {
   background-color: var(--ic-architectural-800);
   color: #ffff;


### PR DESCRIPTION
## Summary of the changes
Set width and height on ic-tooltip to `max-content` so that it always matches the size of the child element.

You can see this working if you go to the [StackBlitz](https://stackblitz.com/edit/3uyj9c?file=src%2Fapp.tsx) provided on the ticket; go to the `<ic-tooltip>` element in the DevTools and add `width: max-content` in the styles.

## Related issue
#1815 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 