### PR TITLE
chore(web-components): removal of visual regression tests from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,6 @@
 
 bash "$(dirname "$0")/email-check.sh"
 
-npm run test-visual
-
 npm run test-cypress:headless
 
 pwd=$(pwd)


### PR DESCRIPTION
## Summary of the changes

Removal of visual regression tests from pre-commit hook, as they do not pass consistently between developers VMs. Thus people are not using the pre-commit hook.

## Related issue
Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.

#1756 