### PR TITLE
Breadcrumb fixes as part of Component Review

### DIFF
--- a/packages/react/src/stories/ic-breadcrumb-group.stories.mdx
+++ b/packages/react/src/stories/ic-breadcrumb-group.stories.mdx
@@ -371,7 +371,7 @@ export const Breadcrumbs = () => {
     ]}
   >
     <div>
-      <IcBreadcrumbGroup />
+      <Breadcrumbs />
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/daily-tippers" element={<DailyTippers />} />

--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
@@ -210,6 +210,8 @@ export class BreadcrumbGroup {
       this.removeVisuallyHiddenClass(breadcrumb);
     });
     this.expandedBreadcrumbs = true;
+    // Set focus to first unhidden breadcrumb
+    this.collapsedBreadcrumbs[0].setFocus();
   };
 
   private transitionendHandler = (event: TransitionEvent) => {


### PR DESCRIPTION
## Summary of the changes
- Fix React Router storybook for breadcrumbs, so it actually displays breadcrumbs
- When breadcrumbs are Collapsed, and the '...' button is clicked to expand them, focus is moved to the first expanded breadcrumb (previously focus was lost, particularly noticeable when using a screenreader)

## Related issue
#1817 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.