### PR TITLE
1845 ic button accessibility error when setting title attribute on icon variant

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1844,7 +1844,7 @@ export namespace Components {
     }
     interface IcStatusTag {
         /**
-          * If `true`, role='status' is added to the component and it will act as an 'aria-live' region.
+          * If `true`, role='status' is added to the component and it will act as an 'aria-live' region. Screen readers will announce changes to the `label`, but not the initial value.
          */
         "announced"?: boolean;
         /**
@@ -5227,7 +5227,7 @@ declare namespace LocalJSX {
     }
     interface IcStatusTag {
         /**
-          * If `true`, role='status' is added to the component and it will act as an 'aria-live' region.
+          * If `true`, role='status' is added to the component and it will act as an 'aria-live' region. Screen readers will announce changes to the `label`, but not the initial value.
          */
         "announced"?: boolean;
         /**

--- a/packages/web-components/src/components/ic-button/ic-button.stories.mdx
+++ b/packages/web-components/src/components/ic-button/ic-button.stories.mdx
@@ -1059,6 +1059,36 @@ export const defaultArgs = {
             d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
           /></svg
       ></ic-button>
+      <ic-button variant="icon" size="small" title="refresh but as a title"
+        ><svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path
+            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+          /></svg
+      ></ic-button>
+      <ic-button
+        variant="icon"
+        size="small"
+        aria-label="refresh label"
+        title="title alongside a label"
+        ><svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path
+            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+          /></svg
+      ></ic-button>
       <ic-button variant="icon" aria-label="refresh"
         ><svg
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -57,7 +57,7 @@ export class Button {
   private hasTooltip: boolean = false;
   private id: string;
   private inheritedAttributes: { [k: string]: string } = {};
-  private describedByEl: HTMLElement = null;
+  private describedbyEl: HTMLElement = null;
   private describedById: string = null;
   private mutationObserver: MutationObserver = null;
   private hostMutationObserver: MutationObserver = null;
@@ -292,7 +292,7 @@ export class Button {
         );
         if (el) {
           this.describedByContent = el.innerText;
-          this.describedByEl = el;
+          this.describedbyEl = el;
         }
       }
     }
@@ -304,7 +304,7 @@ export class Button {
     if (typeof MutationObserver !== "undefined") {
       if (this.describedById) {
         this.mutationObserver = new MutationObserver(this.mutationCallback);
-        this.mutationObserver.observe(this.describedByEl, {
+        this.mutationObserver.observe(this.describedbyEl, {
           characterData: true,
           childList: true,
           subtree: true,
@@ -414,7 +414,7 @@ export class Button {
 
   // triggered when text content of sibling element in light DOM changes
   private mutationCallback = (): void => {
-    this.describedByContent = this.describedByEl.innerText;
+    this.describedByContent = this.describedbyEl.innerText;
   };
 
   // triggered when attributes of host element change
@@ -464,19 +464,19 @@ export class Button {
             hreflang: this.hreflang,
           };
 
-    let describedBy: string = null;
+    let describedby: string = null;
     let buttonId: string = null;
     if (this.hasTooltip) {
       buttonId =
         this.id !== null
           ? `ic-button-with-tooltip-${this.id}`
           : `ic-button-with-tooltip-${this.buttonIdNum}`;
-      describedBy =
+      describedby =
         this.variant === "icon" && !!ariaLabel
           ? null
           : `ic-tooltip-${buttonId}`;
     } else {
-      describedBy = this.describedById;
+      describedby = this.describedById;
     }
 
     const ButtonContent = () => {
@@ -491,7 +491,7 @@ export class Button {
           onFocus={this.onFocus}
           onBlur={this.onBlur}
           ref={(el) => (this.buttonEl = el)}
-          aria-describedby={describedBy}
+          aria-describedby={describedby}
           part="button"
         >
           {this.hasIconSlot() && !this.loading && (
@@ -578,11 +578,11 @@ export class Button {
       >
         {this.hasTooltip && (
           <ic-tooltip
-            id={describedBy}
+            id={describedby}
             label={title || ariaLabel}
             target={buttonId}
             placement={this.tooltipPlacement}
-            silent={this.variant === "icon" && (!!title || !!ariaLabel)}
+            silent={this.variant === "icon" && !!ariaLabel}
           >
             {this.hasRouterSlot() ? (
               <slot name="router-item"></slot>
@@ -599,7 +599,7 @@ export class Button {
             <ButtonContent />
           ))}
         {this.describedByContent && (
-          <span id={describedBy} class="ic-button-describedby">
+          <span id={describedby} class="ic-button-describedby">
             {this.describedByContent}
           </span>
         )}

--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -225,7 +225,7 @@ exports[`button component should render icon variant with a tooltip based on tit
   <mock:shadow-root>
     <ic-tooltip class="ic-tooltip" id="ic-tooltip-ic-button-with-tooltip-test-button" target="ic-button-with-tooltip-test-button">
       <mock:shadow-root>
-        <div aria-hidden="true" class="ic-tooltip-container" role="tooltip">
+        <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
           <ic-typography variant="caption">
             Tooltip text
           </ic-typography>
@@ -413,7 +413,7 @@ exports[`button component should update aria-label when attribute changed 2`] = 
 exports[`button component should update tooltip label when title attribute changed 1`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
       <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
         <slot></slot>
       </button>
@@ -426,7 +426,7 @@ exports[`button component should update tooltip label when title attribute chang
 exports[`button component should update tooltip label when title attribute changed 2`] = `
 <ic-button class="button-size-default button-variant-icon" exportparts="button" id="test-button" title="New tooltip text" variant="icon">
   <mock:shadow-root>
-    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="New tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
+    <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="New tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
       <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
         <slot></slot>
       </button>

--- a/packages/web-components/src/components/ic-status-tag/ic-status-tag.tsx
+++ b/packages/web-components/src/components/ic-status-tag/ic-status-tag.tsx
@@ -14,6 +14,7 @@ import { IcEmphasisType, IcSizesNoLarge } from "../../utils/types";
 export class StatusTag {
   /**
    * If `true`, role='status' is added to the component and it will act as an 'aria-live' region.
+   * Screen readers will announce changes to the `label`, but not the initial value.
    */
   @Prop() announced?: boolean = false;
 

--- a/packages/web-components/src/components/ic-status-tag/readme.md
+++ b/packages/web-components/src/components/ic-status-tag/readme.md
@@ -7,15 +7,15 @@
 
 ## Properties
 
-| Property             | Attribute    | Description                                                                                                                         | Type                                              | Default     |
-| -------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ----------- |
-| `announced`          | `announced`  | If `true`, role='status' is added to the component and it will act as an 'aria-live' region.                                        | `boolean`                                         | `false`     |
-| `appearance`         | `appearance` | <span style="color:red">**[DEPRECATED]**</span> This prop should not be used anymore. Use variant prop instead.<br/><br/>           | `"filled" \| "outlined"`                          | `undefined` |
-| `label` _(required)_ | `label`      | The content rendered within the status tag.                                                                                         | `string`                                          | `undefined` |
-| `size`               | `size`       | The size of the status tag component.                                                                                               | `"default" \| "small"`                            | `"default"` |
-| `small`              | `small`      | <span style="color:red">**[DEPRECATED]**</span> This prop should not be used anymore. Set prop `size` to "small" instead.<br/><br/> | `boolean`                                         | `false`     |
-| `status`             | `status`     | The colour of the status tag.                                                                                                       | `"danger" \| "neutral" \| "success" \| "warning"` | `"neutral"` |
-| `variant`            | `variant`    | The emphasis of the status tag.                                                                                                     | `"filled" \| "outlined"`                          | `"filled"`  |
+| Property             | Attribute    | Description                                                                                                                                                                  | Type                                              | Default     |
+| -------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ----------- |
+| `announced`          | `announced`  | If `true`, role='status' is added to the component and it will act as an 'aria-live' region. Screen readers will announce changes to the `label`, but not the initial value. | `boolean`                                         | `false`     |
+| `appearance`         | `appearance` | <span style="color:red">**[DEPRECATED]**</span> This prop should not be used anymore. Use variant prop instead.<br/><br/>                                                    | `"filled" \| "outlined"`                          | `undefined` |
+| `label` _(required)_ | `label`      | The content rendered within the status tag.                                                                                                                                  | `string`                                          | `undefined` |
+| `size`               | `size`       | The size of the status tag component.                                                                                                                                        | `"default" \| "small"`                            | `"default"` |
+| `small`              | `small`      | <span style="color:red">**[DEPRECATED]**</span> This prop should not be used anymore. Set prop `size` to "small" instead.<br/><br/>                                          | `boolean`                                         | `false`     |
+| `status`             | `status`     | The colour of the status tag.                                                                                                                                                | `"danger" \| "neutral" \| "success" \| "warning"` | `"neutral"` |
+| `variant`            | `variant`    | The emphasis of the status tag.                                                                                                                                              | `"filled" \| "outlined"`                          | `"filled"`  |
 
 
 ## Dependencies


### PR DESCRIPTION
## Summary of the changes
To test this:  go to the [Card with interaction Button story (develop)](https://mi6.github.io/ic-ui-kit/branches/develop/web-components/?path=/story/web-components-card--with-interaction-button) and use voiceover to read the icon button. 
That story on this branch will read the tooltip.

## Related issue
#1845