### PR TITLE
fix(web-components): removed p tag from select and menu options

### DIFF
--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -136,9 +136,7 @@ export class MenuItem {
       this.triggerPopoverMenuInstance.emit();
     } else if (this.variant === "toggle") {
       e.preventDefault();
-      this.toggleChecked
-        ? (this.toggleChecked = false)
-        : (this.toggleChecked = true);
+      this.toggleChecked = !this.toggleChecked;
     }
     this.handleMenuItemClick.emit({
       label: this.label,
@@ -214,11 +212,7 @@ export class MenuItem {
           role={this.variant === "toggle" ? "menuitemcheckbox" : "menuitem"}
           aria-disabled={`${this.disabled}`}
           aria-checked={
-            this.variant === "toggle" && this.toggleChecked === true
-              ? true
-              : this.variant === "toggle" && this.toggleChecked === false
-              ? false
-              : undefined
+            this.variant === "toggle" ? this.toggleChecked : undefined
           }
         >
           <ic-button

--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -861,7 +861,7 @@ export class Menu {
               ></div>
             )}
             <ic-typography variant="body" aria-hidden="true">
-              <p>{option[this.labelField]}</p>
+              {option[this.labelField]}
             </ic-typography>
           </div>
           {option.description && (

--- a/packages/web-components/src/components/ic-menu/test/basic/__snapshots__/ic-menu.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-menu/test/basic/__snapshots__/ic-menu.spec.tsx.snap
@@ -9,9 +9,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Espresso
-              </p>
+              Espresso
             </ic-typography>
           </div>
         </div>
@@ -23,9 +21,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Double Espresso
-              </p>
+              Double Espresso
             </ic-typography>
           </div>
         </div>
@@ -34,9 +30,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Flat White
-              </p>
+              Flat White
             </ic-typography>
           </div>
         </div>
@@ -45,9 +39,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Cappuccino
-              </p>
+              Cappuccino
             </ic-typography>
           </div>
           <ic-typography aria-hidden="true" class="option-description" id="menu-id-cappucino-description" variant="caption">
@@ -61,9 +53,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Americano
-              </p>
+              Americano
             </ic-typography>
           </div>
         </div>
@@ -72,9 +62,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Ameno
-              </p>
+              Ameno
             </ic-typography>
           </div>
         </div>
@@ -89,9 +77,7 @@ Object {
           <div class="option-text-container">
             <div class="option-label">
               <ic-typography aria-hidden="true" variant="body">
-                <p>
-                  green
-                </p>
+                green
               </ic-typography>
             </div>
           </div>
@@ -108,9 +94,7 @@ Object {
               </svg>
             </div>
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Aicano
-              </p>
+              Aicano
             </ic-typography>
           </div>
         </div>
@@ -119,9 +103,7 @@ Object {
         <div class="option-text-container">
           <div class="option-label">
             <ic-typography aria-hidden="true" variant="body">
-              <p>
-                Mocha
-              </p>
+              Mocha
             </ic-typography>
           </div>
           <div aria-hidden="true" class="option-element">

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
@@ -77,11 +77,9 @@ export class PopoverMenu {
       this.currentFocus = isPropDefined(this.submenuId) ? 1 : 0;
       // Needed so that anchorEl isn't always focused
       setTimeout(this.setButtonFocus, 50);
-    } else {
-      if (this.popperInstance) {
-        this.popperInstance.destroy();
-        this.popperInstance = null;
-      }
+    } else if (this.popperInstance) {
+      this.popperInstance.destroy();
+      this.popperInstance = null;
     }
   }
 
@@ -126,7 +124,12 @@ export class PopoverMenu {
   }
 
   @Listen("handleMenuItemClick")
-  handleMenuItemClick(ev: CustomEvent): void {
+  handleMenuItemClick(
+    ev: CustomEvent<{
+      label: string;
+      hasSubMenu: boolean;
+    }>
+  ): void {
     if (!ev.detail.hasSubMenu && ev.detail.label !== "Back") {
       this.closeMenu();
     }
@@ -166,13 +169,12 @@ export class PopoverMenu {
   handleKeyDown(ev: KeyboardEvent): void {
     switch (ev.key) {
       case "ArrowDown":
-        ev.preventDefault();
-        this.currentFocus = this.getNextItemToSelect(this.currentFocus, true);
-        this.setButtonFocus();
-        break;
       case "ArrowUp":
         ev.preventDefault();
-        this.currentFocus = this.getNextItemToSelect(this.currentFocus, false);
+        this.currentFocus = this.getNextItemToSelect(
+          this.currentFocus,
+          ev.key === "ArrowDown"
+        );
         this.setButtonFocus();
         break;
       case "Home":
@@ -224,7 +226,7 @@ export class PopoverMenu {
   // Checks that the popover menu has an anchor
   private findAnchorEl = (anchor: string): HTMLElement => {
     let anchorElement: HTMLElement = null;
-    if (anchor === null || anchor === undefined) {
+    if (!anchor) {
       this.submenuId === undefined &&
         console.error("No anchor specified for popover component");
     } else {
@@ -239,12 +241,12 @@ export class PopoverMenu {
   };
 
   private isNotPopoverMenuEl = (ev: Event) => {
-    const target = ev.target as HTMLElement;
+    const { id, tagName } = ev.target as HTMLElement;
     return (
-      target.id !== this.anchor &&
-      target.tagName !== "IC-MENU-ITEM" &&
-      target.tagName !== "IC-MENU-GROUP" &&
-      target.tagName !== "IC-POPOVER-MENU"
+      id !== this.anchor &&
+      tagName !== "IC-MENU-ITEM" &&
+      tagName !== "IC-MENU-GROUP" &&
+      tagName !== "IC-POPOVER-MENU"
     );
   };
 

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -1218,7 +1218,7 @@ export class Select {
                         this.getLabelFromValue(currValue) === undefined,
                     }}
                   >
-                    <p>{this.getLabelFromValue(currValue) || placeholder}</p>
+                    {this.getLabelFromValue(currValue) || placeholder}
                   </ic-typography>
                   <div class="select-input-end">
                     {currValue && showClearButton && (

--- a/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
@@ -84,9 +84,7 @@ exports[`ic-select searchable should render as required: required-searchable 1`]
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -110,9 +108,7 @@ exports[`ic-select should have correct validation status: with-validation-status
           <div class="select-container">
             <button aria-controls="ic-select-input-3-menu" aria-describedby="ic-select-input-3-validation-text" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-3-menu" class="select-input" id="ic-select-input-3">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <span aria-hidden="true" class="expand-icon">
@@ -129,9 +125,7 @@ exports[`ic-select should have correct validation status: with-validation-status
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -156,9 +150,7 @@ exports[`ic-select should not have a validation status if disabled: no-validatio
           <div class="select-container">
             <button aria-controls="ic-select-input-4-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-4-menu" class="select-input" disabled="" id="ic-select-input-4">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <span aria-hidden="true" class="expand-icon">
@@ -175,9 +167,7 @@ exports[`ic-select should not have a validation status if disabled: no-validatio
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -200,9 +190,7 @@ exports[`ic-select should not render a label when the 'hide-label' prop is suppl
           <div class="select-container">
             <button aria-controls="ic-select-input-0-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-0-menu" class="select-input" id="ic-select-input-0">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <span aria-hidden="true" class="expand-icon">
@@ -219,9 +207,7 @@ exports[`ic-select should not render a label when the 'hide-label' prop is suppl
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -245,9 +231,7 @@ exports[`ic-select should not render validation text if no validation status has
           <div class="select-container">
             <button aria-controls="ic-select-input-6-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-6-menu" class="select-input" id="ic-select-input-6">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <span aria-hidden="true" class="expand-icon">
@@ -264,9 +248,7 @@ exports[`ic-select should not render validation text if no validation status has
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -290,9 +272,7 @@ exports[`ic-select should render correct validation text: with-validation-text 1
           <div class="select-container">
             <button aria-controls="ic-select-input-5-menu" aria-describedby="ic-select-input-5-validation-text" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-5-menu" class="select-input" id="ic-select-input-5">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <span aria-hidden="true" class="expand-icon">
@@ -309,9 +289,7 @@ exports[`ic-select should render correct validation text: with-validation-text 1
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -344,9 +322,7 @@ exports[`ic-select should render readonly: readonly 1`] = `
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -370,9 +346,7 @@ exports[`ic-select should test select as submit on form 1`] = `
           <div class="select-container">
             <button aria-controls="ic-select-input-1-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-1-menu" class="select-input" id="ic-select-input-1">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <span aria-hidden="true" class="expand-icon expand-icon-filled">
@@ -389,9 +363,7 @@ exports[`ic-select should test select as submit on form 1`] = `
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    No results found
-                  </p>
+                  No results found
                 </ic-typography>
               </div>
             </div>
@@ -415,9 +387,7 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
           <div class="select-container">
             <button aria-controls="ic-select-input-7-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-7-menu" class="select-input" id="ic-select-input-7">
               <ic-typography class="placeholder value-text" variant="body">
-                <p>
-                  Select an option
-                </p>
+                Select an option
               </ic-typography>
               <div class="select-input-end">
                 <div class="divider"></div>
@@ -445,9 +415,7 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    Test label 1
-                  </p>
+                  Test label 1
                 </ic-typography>
               </div>
             </div>
@@ -456,9 +424,7 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    Test label 2
-                  </p>
+                  Test label 2
                 </ic-typography>
               </div>
             </div>
@@ -467,9 +433,7 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
-                  <p>
-                    Test label 3
-                  </p>
+                  Test label 3
                 </ic-typography>
               </div>
             </div>


### PR DESCRIPTION
## Summary of the changes
Removed p tag from typography in single select and menu options, to prevent text becoming misaligned when text spacing is increased

## Related issue
#1817 

## Checklist
### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.