### PR TITLE
Update toggle button icon placement to be overridden by group icon placement

### DIFF
--- a/packages/react/src/component-tests/IcToggleButtonGroup/IcToggleButtonGroupTestData.tsx
+++ b/packages/react/src/component-tests/IcToggleButtonGroup/IcToggleButtonGroupTestData.tsx
@@ -177,7 +177,7 @@ export const ToggleGroupIconRight = (): ReactElement => {
   return (
     <div style={{ margin: "1rem" }}>
       <IcToggleButtonGroup iconPlacement="right">
-        <IcToggleButton label="First toggle" iconPlacement="right">
+        <IcToggleButton label="First toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -190,7 +190,7 @@ export const ToggleGroupIconRight = (): ReactElement => {
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Second toggle" iconPlacement="right">
+        <IcToggleButton label="Second toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -203,7 +203,7 @@ export const ToggleGroupIconRight = (): ReactElement => {
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Third toggle" iconPlacement="right">
+        <IcToggleButton label="Third toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -225,7 +225,7 @@ export const ToggleGroupIconLeft = (): ReactElement => {
   return (
     <div style={{ margin: "1rem" }}>
       <IcToggleButtonGroup iconPlacement="left">
-        <IcToggleButton label="First toggle" iconPlacement="left">
+        <IcToggleButton label="First toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -238,7 +238,7 @@ export const ToggleGroupIconLeft = (): ReactElement => {
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Second toggle" iconPlacement="left">
+        <IcToggleButton label="Second toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -251,7 +251,7 @@ export const ToggleGroupIconLeft = (): ReactElement => {
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Third toggle" iconPlacement="left">
+        <IcToggleButton label="Third toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -272,7 +272,7 @@ export const ToggleGroupIconTop = (): ReactElement => {
   return (
     <div style={{ margin: "1rem" }}>
       <IcToggleButtonGroup iconPlacement="top">
-        <IcToggleButton label="First toggle" iconPlacement="top">
+        <IcToggleButton label="First toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -285,7 +285,7 @@ export const ToggleGroupIconTop = (): ReactElement => {
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Second toggle" iconPlacement="top">
+        <IcToggleButton label="Second toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -298,7 +298,7 @@ export const ToggleGroupIconTop = (): ReactElement => {
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Third toggle" iconPlacement="top">
+        <IcToggleButton label="Third toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/stories/ic-toggle-button-group.stories.mdx
+++ b/packages/react/src/stories/ic-toggle-button-group.stories.mdx
@@ -238,7 +238,7 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
         iconPlacement="right"
         accessibleLabel="Single and manual select toggle group"
       >
-        <IcToggleButton label="First toggle" iconPlacement="right">
+        <IcToggleButton label="First toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -251,7 +251,7 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Second toggle" iconPlacement="right">
+        <IcToggleButton label="Second toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -271,7 +271,7 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
         iconPlacement="left"
         accessibleLabel="Single and manual select toggle group"
       >
-        <IcToggleButton label="First toggle" iconPlacement="left">
+        <IcToggleButton label="First toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -284,7 +284,7 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Second toggle" iconPlacement="left">
+        <IcToggleButton label="Second toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -304,7 +304,7 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
         iconPlacement="top"
         accessibleLabel="Single and manual select toggle group"
       >
-        <IcToggleButton label="First toggle" iconPlacement="top">
+        <IcToggleButton label="First toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"
@@ -317,7 +317,7 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
           </SlottedSVG>
         </IcToggleButton>
-        <IcToggleButton label="Second toggle" iconPlacement="top">
+        <IcToggleButton label="Second toggle">
           <SlottedSVG
             slot="icon"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.stories.mdx
+++ b/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.stories.mdx
@@ -313,7 +313,7 @@ import readme from "./readme.md";
           icon-placement="right"
           accessible-label="Single and manual select toggle group"
         >
-          <ic-toggle-button label="Toggle" icon-placement="right">
+          <ic-toggle-button label="Toggle">
             <svg
               slot="icon"
               xmlns="http://www.w3.org/2000/svg"
@@ -328,7 +328,7 @@ import readme from "./readme.md";
               />
             </svg>
           </ic-toggle-button>
-          <ic-toggle-button label="Toggle" icon-placement="right">
+          <ic-toggle-button label="Toggle">
             <svg
               slot="icon"
               xmlns="http://www.w3.org/2000/svg"
@@ -350,7 +350,7 @@ import readme from "./readme.md";
           icon-placement="top"
           accessible-label="Single and manual select toggle group"
         >
-          <ic-toggle-button label="Toggle" icon-placement="top">
+          <ic-toggle-button label="Toggle">
             <svg
               slot="icon"
               xmlns="http://www.w3.org/2000/svg"
@@ -365,7 +365,7 @@ import readme from "./readme.md";
               />
             </svg>
           </ic-toggle-button>
-          <ic-toggle-button label="Toggle" icon-placement="top">
+          <ic-toggle-button label="Toggle">
             <svg
               slot="icon"
               xmlns="http://www.w3.org/2000/svg"
@@ -387,7 +387,7 @@ import readme from "./readme.md";
           icon-placement="left"
           accessible-label="Single and manual select toggle group"
         >
-          <ic-toggle-button label="Toggle" icon-placement="left">
+          <ic-toggle-button label="Toggle">
             <svg
               slot="icon"
               xmlns="http://www.w3.org/2000/svg"
@@ -402,7 +402,7 @@ import readme from "./readme.md";
               />
             </svg>
           </ic-toggle-button>
-          <ic-toggle-button label="Toggle" icon-placement="left">
+          <ic-toggle-button label="Toggle">
             <svg
               slot="icon"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/web-components/src/components/ic-toggle-button/ic-toggle-button.tsx
+++ b/packages/web-components/src/components/ic-toggle-button/ic-toggle-button.tsx
@@ -28,6 +28,8 @@ import { IcSizes, IcThemeForeground } from "../../utils/types";
   },
 })
 export class ToggleButton {
+  private iconPosition: "left" | "right" | "top";
+
   @Element() el: HTMLIcToggleButtonElement;
 
   /**
@@ -89,6 +91,11 @@ export class ToggleButton {
 
   componentWillLoad(): void {
     removeDisabledFalse(this.disabled, this.el);
+
+    const parentIconPlacement = (
+      this.el.parentElement as HTMLIcToggleButtonGroupElement
+    ).iconPlacement;
+    this.iconPosition = this.iconPlacement || parentIconPlacement;
   }
 
   componentDidLoad(): void {
@@ -158,7 +165,7 @@ export class ToggleButton {
             <slot
               name="icon"
               slot={`${
-                this.iconPlacement ? `${this.iconPlacement}-icon` : "icon"
+                this.iconPosition ? `${this.iconPosition}-icon` : "icon"
               }`}
             ></slot>
           )}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update toggle button icon placement to be overridden by group icon placement if its set

## Related issue
#1811 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.