### PR TITLE
fix(web-components): removed state update that triggers focusing of the menu after closing

### DIFF
--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -250,14 +250,9 @@ export class Menu {
   }
 
   componentDidUpdate(): void {
-    const inputValueInOptions: boolean = this.options.some(
+    const inputValueInOptions = this.options.some(
       (option) => option[this.valueField] === this.value
     );
-
-    const optionHighlightedIsSet =
-      this.optionHighlighted !== null &&
-      this.optionHighlighted !== undefined &&
-      this.optionHighlighted !== "";
 
     if (this.open && this.options.length !== 0) {
       if (
@@ -274,7 +269,7 @@ export class Menu {
       ) {
         this.menu.focus();
       } else if (
-        optionHighlightedIsSet &&
+        !!this.optionHighlighted &&
         !this.focusFromSearchKeypress &&
         !this.preventIncorrectTabOrder
       ) {
@@ -322,8 +317,6 @@ export class Menu {
    */
   @Method()
   async handleKeyboardOpen(event: KeyboardEvent): Promise<void> {
-    this.keyboardNav = false;
-
     if (this.activationType === "automatic") {
       this.autoSetInputValueKeyboardOpen(event);
     } else {
@@ -485,8 +478,6 @@ export class Menu {
   private manSetInputValueKeyboardOpen = (event: KeyboardEvent) => {
     const menuOptions = this.setMenuOptions();
 
-    this.keyboardNav = false;
-
     const highlightedOptionIndex = menuOptions.findIndex(
       (option) => option[this.valueField] === this.optionHighlighted
     );
@@ -554,6 +545,7 @@ export class Menu {
         });
         break;
       case " ":
+        this.keyboardNav = false;
         if (this.isSearchBar || this.isSearchableSelect) {
           break;
         } else {
@@ -564,6 +556,7 @@ export class Menu {
         break;
       case "Enter":
         event.preventDefault();
+        this.keyboardNav = false;
         if (isOpen) {
           if (highlightedOptionIndex >= 0) {
             if (menuOptions[highlightedOptionIndex] !== undefined) {
@@ -600,6 +593,7 @@ export class Menu {
         this.preventIncorrectTabOrder = true;
         break;
       default:
+        this.keyboardNav = false;
         this.focusOnSearchOrSelectInput(menuOptions, highlightedOptionIndex);
         break;
     }

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -618,7 +618,7 @@ export class SearchBar {
     }
   };
 
-  private handleMenuChange = (ev: CustomEvent) => {
+  private handleMenuChange = (ev: CustomEvent<IcMenuChangeEventDetail>) => {
     this.setMenuChange(ev.detail.open);
     if (!ev.detail.open) {
       this.handleMenuCloseFromMenuChange(true);


### PR DESCRIPTION
## Summary of the changes
Removed state update when escape is pressed on the menu, to prevent the menu from receiving focus after it has technically been closed.

## Related issue
#703 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.