### PR TITLE
1970 playground select, side nav and section container

### DIFF
--- a/packages/react/src/stories/ic-section-container.stories.mdx
+++ b/packages/react/src/stories/ic-section-container.stories.mdx
@@ -12,11 +12,16 @@ import readme from "../../../web-components/src/components/ic-section-container/
 
 <Description markdown={readme} />
 
-### Left aligned
+export const defaultArgs = {
+  aligned: null,
+  fullHeight: false
+}
+
+### Left Aligned
 
 <Canvas>
-  <Story name="Left aligned">
-    <IcSectionContainer>
+  <Story name="Left Aligned">
+    <IcSectionContainer style={{ border: "1px solid black" }}>
       <main>
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <button>Start</button>
@@ -31,7 +36,7 @@ import readme from "../../../web-components/src/components/ic-section-container/
 
 <Canvas>
   <Story name="Center alignment">
-    <IcSectionContainer aligned="center">
+    <IcSectionContainer aligned="center" style={{ border: "1px solid black" }}>
       <main>
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <button>Start</button>
@@ -46,7 +51,7 @@ import readme from "../../../web-components/src/components/ic-section-container/
 
 <Canvas>
   <Story name="Full-width alignment">
-    <IcSectionContainer aligned="full-width">
+    <IcSectionContainer aligned="full-width" style={{ border: "1px solid black" }}>
       <main>
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <button>Start</button>
@@ -61,7 +66,7 @@ import readme from "../../../web-components/src/components/ic-section-container/
 
 <Canvas>
   <Story name="Full-height">
-    <IcSectionContainer aligned="full-width" full-height>
+    <IcSectionContainer aligned="full-width" fullHeight="true" style={{ border: "1px solid black" }}>
       <main>
         <div style={{ display: "flex", justifyContent: "space-between" }}>
           <button>Start</button>
@@ -69,5 +74,31 @@ import readme from "../../../web-components/src/components/ic-section-container/
         </div>
       </main>
     </IcSectionContainer>
+  </Story>
+</Canvas>
+
+### Playground
+
+<Canvas>
+  <Story
+    name="Playground"
+    args={defaultArgs}
+    argTypes={{
+      aligned: {
+        options: [null, "left", "center", "full-width"],
+        control: { type: "inline-radio" },
+      },
+    }}
+  >
+    {(args) => (
+      <IcSectionContainer aligned={args.aligned} fullHeight={args.fullHeight} style={{ border: "1px solid black" }}>
+        <main>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <button>Start</button>
+            <button>End</button>
+          </div>
+        </main>
+      </IcSectionContainer>
+    )}
   </Story>
 </Canvas>

--- a/packages/react/src/stories/ic-select_(searchable).stories.mdx
+++ b/packages/react/src/stories/ic-select_(searchable).stories.mdx
@@ -19,7 +19,7 @@ export const defaultArgs = {
   placeholder: "Select an option",
   readonly: false,
   required: false,
-  small: false,
+  size: 'default',
   validationStatus: "",
   validationText: "",
   includeDescriptionsInSearch: false,
@@ -675,6 +675,10 @@ export const Uncontrolled = () => {
         options: ["anywhere", "start"],
         control: { type: "inline-radio" },
       },
+      size: {
+        options: ["default", "large", "small"],
+        control: { type: "inline-radio" },
+      },
       validationStatus: {
         defaultValue: "",
         options: ["none", "error", "success", "warning"],
@@ -699,7 +703,7 @@ export const Uncontrolled = () => {
         required={args.required}
         searchMatchPosition={args.searchMatchPosition}
         searchable
-        small={args.small}
+        size={args.size}
         validationStatus={args.validationStatus}
         validationText={args.validationText}
       />

--- a/packages/react/src/stories/ic-select_(single).stories.mdx
+++ b/packages/react/src/stories/ic-select_(single).stories.mdx
@@ -612,6 +612,10 @@ export const Uncontrolled = () => {
     name="Playground"
     args={defaultArgs}
     argTypes={{
+      size: {
+        options: ["default", "large", "small"],
+        control: { type: "inline-radio" },
+      },
       validationStatus: {
         defaultValue: "",
         options: ["none", "error", "success", "warning"],
@@ -633,7 +637,7 @@ export const Uncontrolled = () => {
         readonly={args.readonly}
         required={args.required}
         showClearButton={args.showClearButton}
-        small={args.small}
+        size={args.size}
         validationStatus={args.validationStatus}
         validationText={args.validationText}
       />

--- a/packages/react/src/stories/ic-side-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-side-navigation.stories.mdx
@@ -26,6 +26,17 @@ import { NavLink, MemoryRouter, Route, Routes } from "react-router-dom";
 
 <Description markdown={readme + NavigationItem + NavigationGroup} />
 
+export const defaultArgs = {
+  appTitle: "Test App Title",
+  version: "v1.0.0",
+  status: "BETA",
+  href: "https://www.google.com",
+  collapsedIconLabels: false,
+  navOneLabel: "Navigation One",
+  showSecondaryNav: true,
+  showNavigationGroup: true
+};
+
 ### Default
 
 <Canvas>
@@ -629,6 +640,105 @@ export const Controlled = () => {
     </IcSideNavigation>
   </Story>
 </Canvas>
+
+### Playground
+
+<Canvas>
+  <Story
+    name="Playground"
+    args={defaultArgs}
+  >
+    {(args) => (
+      <IcSideNavigation appTitle={args.appTitle} version={args.version} status={args.status} href={args.href} collapsedIconLabels={args.collapsedIconLabels}>
+      <svg
+        slot="app-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        fill="#000000"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+      </svg>
+      <IcNavigationItem slot="primary-navigation" href="/" label={args.navOneLabel}>
+        <IcBadge textLabel="1" slot="badge" variant="light" position="far" />
+        <svg
+          slot="icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+            fill="currentColor"
+          />
+        </svg>
+      </IcNavigationItem>
+      <IcNavigationItem
+        slot="primary-navigation"
+        href="/"
+        label="Item 2"
+        selected
+      >
+        <IcBadge slot="badge" variant="light" type="dot" position="far" />
+        <svg
+          slot="icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+            fill="currentColor"
+          />
+        </svg>
+      </IcNavigationItem>
+      {args.showNavigationGroup && <IcNavigationGroup
+        slot="primary-navigation"
+        label="Navigation Group"
+        expandable="true"
+      >
+        <IcNavigationItem href="/" label="Item 3">
+          <svg
+            slot="icon"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+              fill="currentColor"
+            />
+          </svg>
+        </IcNavigationItem>
+      </IcNavigationGroup>}
+      {args.showSecondaryNav && <IcNavigationItem slot="secondary-navigation" href="/" label="Settings">
+        <svg
+          slot="icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+            fill="currentColor"
+          />
+        </svg>
+      </IcNavigationItem>}
+    </IcSideNavigation>
+    )}
+  </Story>
+</Canvas>
+
 
 ### React Router
 

--- a/packages/web-components/src/components/ic-section-container/ic-section-container.tsx
+++ b/packages/web-components/src/components/ic-section-container/ic-section-container.tsx
@@ -22,7 +22,7 @@ export class SectionContainer {
     return (
       <Host
         class={{
-          ["aligned-left"]: aligned === "left",
+          ["aligned-left"]: aligned === "left" || aligned === null,
           ["aligned-center"]: aligned === "center",
           ["aligned-full-width"]: aligned === "full-width",
           ["no-vertical-padding"]: fullHeight,


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add Storybook playgrounds for Select, SideNav and Section Container
Small fix to Section Container for when you change 'aligned' prop to null after first render (as what happens in the storybook)

## Related issue
#1970 
