### PR TITLE
1970 text field playground

### DIFF
--- a/packages/react/src/stories/ic-text-field.stories.mdx
+++ b/packages/react/src/stories/ic-text-field.stories.mdx
@@ -482,3 +482,110 @@ export const Uncontrolled = () => {
     ></IcTextField>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  disabled: false,
+  fullWidth: false,
+  helperText: "",
+  hideLabel: false,
+  inputId: "ic-text-field-input-0",
+  inputmode: "text",
+  label: "Text Field",
+  maxCharacters: 0,
+  maxLength: 0,
+  minCharacters: 0,
+  name: "0",
+  placeholder: "",
+  readonly: false,
+  required: false,
+  resize: false,
+  rows: 1,
+  size: "default",
+  spellcheck: false,
+  type: "text",
+  validationInline: false,
+  validationStatus: "none",
+  validationText: "",
+  debounce: 0
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    argTypes={{
+      inputmode: {
+        options: ["none", "text", "tel", "url", "email", "numeric", "decimal", "search"],
+        control: { type: "select" }
+      },
+      size: {
+        options: ["default", "small"],
+        control: { type: "inline-radio" }
+      },
+      type: {
+        options: ["email", "password", "tel", "text", "url", "number", "search"],
+        control: { type: "select" }
+      },
+      validationStatus: {
+        options: ["warning", "error", "success", "none"],
+        mapping: {
+          "warning": "warning",
+          "error": "error",
+          "success": "success",
+          "none": ""
+        },
+        control: { type: "select" }
+      },
+      showIconSlot: {
+        control: { type: "boolean" }
+      }
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcTextField 
+        label={args.label}
+        disabled={args.disabled}
+        fullWidth={args.fullWidth}
+        helperText={args.helperText}
+        hideLabel={args.hideLabel}
+        inputId={args.inputId}
+        inputmode={args.inputmode}
+        max={args.max}
+        maxCharacters={args.maxCharacters}
+        maxLength={args.maxLength}
+        min={args.min}
+        minCharacters={args.minCharacters}
+        name={args.name}
+        placeholder={args.placeholder}
+        readonly={args.readonly}
+        required={args.required}
+        resize={args.resize}
+        rows={args.rows}
+        size={args.size}
+        spellcheck={args.spellcheck}
+        type={args.type}
+        validationInline={args.validationInline}
+        validationStatus={args.validationStatus}
+        validationText={args.validationText}
+        debounce={args.debounce}
+        onIcChange={(ev) => console.log(ev.detail.value)}
+      >
+        {args.showIconSlot && (
+          <SlottedSVG 
+            slot="icon"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            fill="#000000"
+          >
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z" />
+          </SlottedSVG>  
+        )}
+      </IcTextField>
+    )}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-input-component-container/test/basic/ic-input-component-container.spec.tsx
+++ b/packages/web-components/src/components/ic-input-component-container/test/basic/ic-input-component-container.spec.tsx
@@ -144,4 +144,22 @@ describe("ic-input-component-container", () => {
     </ic-input-component-container>
     `);
   });
+
+  it("should test rendering icon after initial render", async () => {
+    const page = await newSpecPage({
+      components: [InputComponentContainer],
+      html: `<ic-input-component-container>content</ic-input-component-container>`,
+    });
+
+    const icon = document.createElement("svg");
+    icon.setAttribute("slot", "left-icon");
+
+    page.rootInstance.hostMutationCallback([
+      {
+        type: "childList",
+        addedNodes: [icon],
+        removedNodes: [],
+      },
+    ]);
+  });
 });

--- a/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.input.spec.tsx
+++ b/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.input.spec.tsx
@@ -302,12 +302,17 @@ it("should test maxCharacters method", async () => {
 it("should test minCharacters method", async () => {
   const page = await newSpecPage({
     components: [TextField],
-    html: `<ic-text-field label="Test label" rows=1 min-characters=5></ic-text-field>`,
+    html: `<ic-text-field label="Test label" rows=1 min-characters=5 value="test"></ic-text-field>`,
   });
 
-  page.rootInstance.getMinCharactersUnattained("test");
+  const input = page.root.shadowRoot.querySelector("input");
+  input.blur();
   expect(page.rootInstance.minCharactersUnattained).toBe(true);
-  page.rootInstance.getMinCharactersUnattained("testing");
+
+  page.rootInstance.value = "testing";
+  await page.waitForChanges();
+
+  input.blur();
   expect(page.rootInstance.minCharactersUnattained).toBe(false);
 });
 

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -641,6 +641,15 @@ export const convertToRGBA = (color: IcColor): IcColorRGBA | null => {
     : null;
 };
 
-export const capitalize = (text: string): string => {
-  return text.charAt(0).toUpperCase() + text.slice(1);
+export const capitalize = (text: string): string =>
+  text.charAt(0).toUpperCase() + text.slice(1);
+
+export const checkSlotInChildMutations = (
+  addedNodes: NodeList,
+  removedNodes: NodeList,
+  slotName: string
+): boolean => {
+  const hasSlot = (nodeList: NodeList) =>
+    Array.from(nodeList).some((node) => (node as Element).slot === slotName);
+  return hasSlot(addedNodes) || hasSlot(removedNodes);
 };


### PR DESCRIPTION
## Summary of the changes
- Updated state when maxCharacters is set to zero after the validation has been shown, to allow users to enter text in this instance. Previously the text-field would not allow new characters due to the max being zero.
- Added child components to mutation observer for ic-text-field and ic-input-component-container, which will force an update if a slotted icon is added as a child, meaning that the icon can now be conditionally rendered

## Related issue
#1970 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.