### PR TITLE
ci(root): github workflow change

### DIFF
--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -266,8 +266,8 @@ jobs:
         with:
           message: |
             Cypress visual tests failed.
-            View the image diff here: https://github.com/mi6/ic-ui-kit/tree/gh-pages/branches/${{ steps.extract_branch.outputs.branch }}/cypress-image-diff-screenshots
-            View the html report here: https://github.com/mi6/ic-ui-kit/tree/gh-pages/branches/${{ steps.extract_branch.outputs.branch }}/cypress-image-diff-html-report
+            View the image diff here: https://github.com/mi6/ic-ui-kit/tree/gh-pages/branches/${{ steps.extract_branch.outputs.branch }}/cypress-image-diff-screenshots/diff
+            View the html report here: https://mi6.github.io/ic-ui-kit/branches/${{ steps.extract_branch.outputs.branch }}/cypress-image-diff-html-report/cypress-image-diff-html-report.html
           message-id: "image-diff"
 
   ic-ui-kit-deploy:


### PR DESCRIPTION
## Summary of the changes
changed the output of a failed cypress visual regression test in the CI to output the diff directory directly and the html format of the report

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->