### PR TITLE
1970 badge, breadcrumb and card playgrounds

### DIFF
--- a/packages/react/src/stories/ic-badge.stories.mdx
+++ b/packages/react/src/stories/ic-badge.stories.mdx
@@ -835,3 +835,88 @@ export const showHideBadge = () => {
     </div>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  accessibleLabel: "notification",
+  customColor: null,
+  maxNumber: 1000,
+  position: "far",
+  size: "default",
+  textLabel: "1",
+  type: "text",
+  variant: "neutral",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    argTypes={{
+      customColor: {
+        control: { type: "text" },
+      },
+      position: {
+        options: ["far", "near", "inline"],
+        control: {
+          type: "radio",
+        },
+      },
+      size: {
+          options: ["small", "default", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      type: {
+          options: ["text", "dot", "icon"],
+        control: {
+          type: "radio",
+        },
+      },
+      variant: {
+          options: [
+            "neutral",
+            "success",
+            "warning",
+            "error",
+            "info",
+            "light",
+            "custom",
+          ],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcButton variant="secondary">
+        <IcBadge 
+          accessibleLabel={args.accessibleLabel}
+          customColor={args.customColor}
+          maxNumber={args.maxNumber}
+          position={args.position}
+          size={args.size}
+          textLabel={args.textLabel}
+          type={args.type}
+          variant={args.variant}
+        >
+          <svg
+            slot="badge-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            aria-label="retry"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+          </svg>
+        </IcBadge>
+        Default
+      </IcButton>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-breadcrumb-group.stories.mdx
+++ b/packages/react/src/stories/ic-breadcrumb-group.stories.mdx
@@ -400,3 +400,74 @@ export const Breadcrumbs = () => {
     </div>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  appearance: "default",
+  backBreadcrumbOnly: false,
+  collapsed: false,
+  current: false,
+  href: "/",
+  pageTitle: "Home",
+  iconSlot: true,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    argTypes={{
+      appearance: {
+        options: ["default", "dark", "light"],
+        control: {
+          type: "radio",
+        },
+      },
+      iconSlot: {
+        mapping: {
+          true: "icon",
+          false: "",
+        }
+      }
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <div style={{backgroundColor: args.appearance == "light" ? "black" : null, width: "fit-content"}}>
+        <IcBreadcrumbGroup
+          appearance={args.appearance}
+          backBreadcrumbOnly={args.backBreadcrumbOnly}
+          collapsed={args.collapsed}
+        >
+          <IcBreadcrumb
+            current={args.current}
+            pageTitle={args.pageTitle}
+            href={args.href}
+          >
+            <svg
+              slot={args.iconSlot}
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </IcBreadcrumb>
+          <IcBreadcrumb
+            pageTitle="Breadcrumb 2"
+            href="/breadcrumb-2"
+          />
+          <IcBreadcrumb
+            pageTitle="Breadcrumb 3"
+            href="/breadcrumb-3"
+          />
+        </IcBreadcrumbGroup>
+      </div>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-card.stories.mdx
+++ b/packages/react/src/stories/ic-card.stories.mdx
@@ -758,3 +758,181 @@ import { NavLink, MemoryRouter, Switch, Route, Routes } from "react-router-dom";
     </a>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  clickable: false,
+  disabled: false,
+  expandable: false,
+  fullWidth: false,
+  heading: "Heading",
+  href: "/",
+  message: "Message",
+  subheading: "Subheading",
+  iconSlot: true,
+  badgeSlot: true,
+  imageTopSlot: true,
+  imageMidSlot: true,
+  interactionButtonSlot: true,
+  interactionControlsSlot: true,
+  adornmentSlot: true,
+  expandedContentSlot: true
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    argTypes={{
+      iconSlot: {
+        mapping: {
+          true: "icon",
+          false: ""
+        }
+      },
+      badgeSlot: {
+        mapping: {
+          true: "badge",
+          false: ""
+        }
+      },
+      imageTopSlot: {
+        mapping: {
+          true: "image-top",
+          false: ""
+        }
+      },
+      imageMidSlot: {
+        mapping: {
+          true: "image-mid",
+          false: ""
+        }
+      },
+      interactionButtonSlot: {
+        mapping: {
+          true: "interaction-button",
+          false: ""
+        }
+      },
+      interactionControlsSlot: {
+        mapping: {
+          true: "interaction-controls",
+          false: ""
+        }
+      },
+      adornmentSlot: {
+        mapping: {
+          true: "adornment",
+          false: ""
+        }
+      },
+      expandedContentSlot: {
+        mapping: {
+          true: "expanded-content",
+          false: ""
+        }
+      }
+    }}
+    name="Playground"
+  >
+    {(args) => (
+    <IcCard 
+      clickable={args.clickable}
+      disabled={args.disabled}
+      expandable={args.expandable}
+      fullWidth={args.fullWidth}
+      heading={args.heading}
+      href={args.href}
+      message={args.message}
+      subheading={args.subheading}
+    >
+      <svg
+        slot={args.iconSlot}
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        fill="#000000"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path
+          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+        />
+      </svg>
+      <IcBadge textLabel="1" slot={args.badgeSlot} />
+      <IcButton
+        variant="icon"
+        title="More information"
+        slot={args.interactionButtonSlot}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          className="bi bi-three-dots-vertical"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+          />
+        </svg>
+      </IcButton>
+      <IcStatusTag
+        slot={args.adornmentSlot}
+        label="Neutral"
+        size="small"
+      />
+      <svg
+        slot={args.imageTopSlot}
+        style={{height: "200px", width:"326px"}}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 1600 900"
+      >
+        <rect fill="#edb99d" width="1600" height="1600" y="-350" />
+        <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+        <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+        <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+        <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+        <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+        <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+        <polygon fill="#b80066" points="641 695 886 900 367 900" />
+        <polygon fill="#960052" points="587 900 641 695 886 900" />
+        <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+        <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+        <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+        <polygon fill="#880088" points="943 900 1210 900 971 687" />
+      </svg>
+      <svg
+        slot={args.imageMidSlot}
+        style={{height: "200px", width:"326px"}}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 1600 900"
+      >
+        <rect fill="#FFC0CB" width="1600" height="1600" y="-350" />
+        <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+        <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+        <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+        <polygon fill="#ff3300" points="337 900 398 662 816 900" />
+        <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+        <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+        <polygon fill="#b80066" points="641 695 886 900 367 900" />
+        <polygon fill="#960052" points="587 900 641 695 886 900" />
+        <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+        <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+        <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+        <polygon fill="#880088" points="943 900 1210 900 971 687" />
+      </svg>
+      <IcButton slot={args.interactionControlsSlot} variant="primary">
+        Learn more
+      </IcButton>
+      <IcButton slot={args.interactionControlsSlot} variant="secondary">
+        Hide
+      </IcButton>
+      <IcTypography slot={args.expandedContentSlot} variant="body">
+        This is an example of a new card component with text included.
+      </IcTypography>
+    </IcCard>
+    )}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-badge/ic-badge.stories.mdx
+++ b/packages/web-components/src/components/ic-badge/ic-badge.stories.mdx
@@ -1004,3 +1004,92 @@ import readme from "./readme.md";
     </div> `}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  accessibleLabel: "notification",
+  customColor: null,
+  maxNumber: 1000,
+  position: "far",
+  size: "default",
+  textLabel: "1",
+  type: "text",
+  variant: "neutral",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      customColor: {
+        control: { type: "text" },
+      },
+      position: {
+        options: ["far", "near", "inline"],
+        control: {
+          type: "radio",
+        },
+      },
+      size: {
+        options: ["small", "default", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      type: {
+        options: ["text", "dot", "icon"],
+        control: {
+          type: "radio",
+        },
+      },
+      variant: {
+        options: [
+          "neutral",
+          "success",
+          "warning",
+          "error",
+          "info",
+          "light",
+          "custom",
+        ],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-button variant="secondary">
+        <ic-badge
+          slot="badge"
+          accessible-label=${args.accessibleLabel}
+          custom-color=${args.customColor}
+          max-number=${args.maxNumber}
+          position=${args.position}
+          size=${args.size}
+          text-label=${args.textLabel}
+          type=${args.type}
+          variant=${args.variant}
+        >
+          <svg
+            slot="badge-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            aria-label="retry"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path
+              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+            />
+          </svg>
+        </ic-badge>
+        Default
+      </ic-button>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.stories.mdx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.stories.mdx
@@ -453,3 +453,79 @@ import BreadcrumbReadme from "../ic-breadcrumb/readme.md";
     `}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  appearance: "default",
+  backBreadcrumbOnly: false,
+  collapsed: false,
+  current: false,
+  href: "/",
+  pageTitle: "Home",
+  iconSlot: true,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      appearance: {
+        options: ["default", "dark", "light"],
+        control: {
+          type: "radio",
+        },
+      },
+      iconSlot: {
+        mapping: {
+          true: "icon",
+          false: "",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<div
+        style="background-color: ${args.appearance == "light"
+          ? "black"
+          : null}; width: fit-content;"
+      >
+        <ic-breadcrumb-group
+          appearance=${args.appearance}
+          back-breadcrumb-only=${args.backBreadcrumbOnly}
+          collapsed=${args.collapsed}
+        >
+          <ic-breadcrumb
+            current=${args.current}
+            page-title=${args.pageTitle}
+            href=${args.href}
+          >
+            <svg
+              slot=${args.iconSlot}
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 6.19L17 10.69V18.5H15V12.5H9V18.5H7V10.69L12 6.19ZM12 3.5L2 12.5H5V20.5H11V14.5H13V20.5H19V12.5H22L12 3.5Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </ic-breadcrumb>
+          <ic-breadcrumb
+            page-title="Breadcrumb 2"
+            href="/breadcrumb-2"
+          ></ic-breadcrumb>
+          <ic-breadcrumb
+            page-title="Breadcrumb 3"
+            href="/breadcrumb-3"
+          ></ic-breadcrumb>
+        </ic-breadcrumb-group>
+      </div>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Element, Prop, State } from "@stencil/core";
+import { Component, Host, h, Element, Prop, State, Watch } from "@stencil/core";
 import {
   checkResizeObserver,
   DEVICE_SIZES,
@@ -33,11 +33,20 @@ export class BreadcrumbGroup {
    * The appearance of the breadcrumb group.
    */
   @Prop() appearance: IcThemeForeground = "default";
+  @Watch("appearance")
+  watchAppearanceHandler(): void {
+    this.setAppearance();
+  }
 
   /**
    * If `true`, display only a single breadcrumb for the parent page with a back icon.
    */
   @Prop() backBreadcrumbOnly: boolean = false;
+  @Watch("backBreadcrumbOnly")
+  watchBackBreadcrumbHandler(): void {
+    this.setBackBreadcrumb();
+  }
+
   /**
    * If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.
    */
@@ -48,11 +57,7 @@ export class BreadcrumbGroup {
       this.el.querySelectorAll(this.IC_BREADCRUMB)
     );
 
-    if (this.appearance !== "default") {
-      allBreadcrumbs.forEach((breadcrumb) => {
-        breadcrumb.setAttribute("appearance", this.appearance);
-      });
-    }
+    this.setAppearance();
 
     if (this.backBreadcrumbOnly) {
       this.setBackBreadcrumb();
@@ -86,6 +91,16 @@ export class BreadcrumbGroup {
         this.clickHandler
       );
   }
+
+  private setAppearance = () => {
+    const allBreadcrumbs = Array.from(
+      this.el.querySelectorAll(this.IC_BREADCRUMB)
+    );
+
+    allBreadcrumbs.forEach((breadcrumb) => {
+      breadcrumb.setAttribute("appearance", this.appearance);
+    });
+  };
 
   private setBackBreadcrumb = () => {
     if (this.backBreadcrumbOnly) {

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`ic-breadcrumb-group should handle the hidden collapsed breadcrumbs: sho
       </ol>
     </nav>
   </mock:shadow-root>
-  <ic-breadcrumb href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
+  <ic-breadcrumb appearance="default" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -21,7 +21,7 @@ exports[`ic-breadcrumb-group should handle the hidden collapsed breadcrumbs: sho
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb class="visuallyhidden" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
+  <ic-breadcrumb appearance="default" class="visuallyhidden" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -33,7 +33,7 @@ exports[`ic-breadcrumb-group should handle the hidden collapsed breadcrumbs: sho
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb aria-current="page" current="true" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+  <ic-breadcrumb appearance="default" aria-current="page" current="true" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -57,7 +57,7 @@ exports[`ic-breadcrumb-group should render collapse on already small devices: sh
       </ol>
     </nav>
   </mock:shadow-root>
-  <ic-breadcrumb aria-current="page" current="true" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
+  <ic-breadcrumb appearance="default" aria-current="page" current="true" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -69,7 +69,7 @@ exports[`ic-breadcrumb-group should render collapse on already small devices: sh
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
+  <ic-breadcrumb appearance="default" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -81,7 +81,7 @@ exports[`ic-breadcrumb-group should render collapse on already small devices: sh
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+  <ic-breadcrumb appearance="default" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -93,7 +93,7 @@ exports[`ic-breadcrumb-group should render collapse on already small devices: sh
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb class="back show" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem" show-back-icon="true">
+  <ic-breadcrumb appearance="default" class="back show" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem" show-back-icon="true">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -179,7 +179,7 @@ exports[`ic-breadcrumb-group should render with collapse button: should render w
       </ol>
     </nav>
   </mock:shadow-root>
-  <ic-breadcrumb href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
+  <ic-breadcrumb appearance="default" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -210,7 +210,7 @@ exports[`ic-breadcrumb-group should render with collapse button: should render w
       ...
     </button>
   </ic-breadcrumb>
-  <ic-breadcrumb class="hide" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
+  <ic-breadcrumb appearance="default" class="hide" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -222,7 +222,7 @@ exports[`ic-breadcrumb-group should render with collapse button: should render w
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb aria-current="page" current="true" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+  <ic-breadcrumb appearance="default" aria-current="page" current="true" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -246,7 +246,7 @@ exports[`ic-breadcrumb-group should render with ic-breadcrumb: should render wit
       </ol>
     </nav>
   </mock:shadow-root>
-  <ic-breadcrumb role="listitem">
+  <ic-breadcrumb appearance="default" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -280,7 +280,7 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
       </ol>
     </nav>
   </mock:shadow-root>
-  <ic-breadcrumb aria-current="page" current="true" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
+  <ic-breadcrumb appearance="default" aria-current="page" current="true" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -311,7 +311,7 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
       ...
     </button>
   </ic-breadcrumb>
-  <ic-breadcrumb class="hide" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
+  <ic-breadcrumb appearance="default" class="hide" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -323,7 +323,7 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb class="hide" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+  <ic-breadcrumb appearance="default" class="hide" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -335,7 +335,7 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb class="show" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem" show-back-icon="true">
+  <ic-breadcrumb appearance="default" class="show" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem" show-back-icon="true">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">

--- a/packages/web-components/src/components/ic-card/ic-card.stories.mdx
+++ b/packages/web-components/src/components/ic-card/ic-card.stories.mdx
@@ -836,3 +836,183 @@ import Button from "../ic-button/readme.md";
     ></a>`}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  clickable: false,
+  disabled: false,
+  expandable: false,
+  fullWidth: false,
+  heading: "Heading",
+  href: "/",
+  message: "Message",
+  subheading: "Subheading",
+  iconSlot: true,
+  badgeSlot: true,
+  imageTopSlot: true,
+  imageMidSlot: true,
+  interactionButtonSlot: true,
+  interactionControlsSlot: true,
+  adornmentSlot: true,
+  expandedContentSlot: true,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      iconSlot: {
+        mapping: {
+          true: "icon",
+          false: "",
+        },
+      },
+      badgeSlot: {
+        mapping: {
+          true: "badge",
+          false: "",
+        },
+      },
+      imageTopSlot: {
+        mapping: {
+          true: "image-top",
+          false: "",
+        },
+      },
+      imageMidSlot: {
+        mapping: {
+          true: "image-mid",
+          false: "",
+        },
+      },
+      interactionButtonSlot: {
+        mapping: {
+          true: "interaction-button",
+          false: "",
+        },
+      },
+      interactionControlsSlot: {
+        mapping: {
+          true: "interaction-controls",
+          false: "",
+        },
+      },
+      adornmentSlot: {
+        mapping: {
+          true: "adornment",
+          false: "",
+        },
+      },
+      expandedContentSlot: {
+        mapping: {
+          true: "expanded-content",
+          false: "",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-card
+        clickable=${args.clickable}
+        disabled=${args.disabled}
+        expandable=${args.expandable}
+        full-width=${args.fullWidth}
+        heading=${args.heading}
+        href=${args.href}
+        message=${args.message}
+        subheading=${args.subheading}
+      >
+        <svg
+          slot=${args.iconSlot}
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path
+            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+          />
+        </svg>
+        <ic-badge text-label="1" slot=${args.badgeSlot}></ic-badge>
+        <ic-button
+          variant="icon"
+          title="More information"
+          slot=${args.interactionButtonSlot}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-three-dots-vertical"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+            />
+          </svg>
+        </ic-button>
+        <ic-status-tag
+          slot=${args.adornmentSlot}
+          label="Neutral"
+          size="small"
+        ></ic-status-tag>
+        <svg
+          slot=${args.imageTopSlot}
+          style="height:200px;width:326px;"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 1600 900"
+        >
+          <rect fill="#edb99d" width="1600" height="1600" y="-350" />
+          <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+          <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+          <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+          <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+          <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+          <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+          <polygon fill="#b80066" points="641 695 886 900 367 900" />
+          <polygon fill="#960052" points="587 900 641 695 886 900" />
+          <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+          <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+          <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+          <polygon fill="#880088" points="943 900 1210 900 971 687" />
+        </svg>
+        <svg
+          slot=${args.imageMidSlot}
+          style="height:200px;width:326px;"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 1600 900"
+        >
+          <rect fill="#FFC0CB" width="1600" height="1600" y="-350" />
+          <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+          <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+          <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+          <polygon fill="#ff3300" points="337 900 398 662 816 900" />
+          <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+          <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+          <polygon fill="#b80066" points="641 695 886 900 367 900" />
+          <polygon fill="#960052" points="587 900 641 695 886 900" />
+          <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+          <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+          <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+          <polygon fill="#880088" points="943 900 1210 900 971 687" />
+        </svg>
+        <ic-button slot=${args.interactionControlsSlot} variant="primary"
+          >Learn more</ic-button
+        >
+        <ic-button slot=${args.interactionControlsSlot} variant="secondary"
+          >Hide</ic-button
+        >
+        <ic-typography slot=${args.expandedContentSlot} variant="body"
+          >This is an example of a new card component with text
+          included.</ic-typography
+        >
+      </ic-card>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
+++ b/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
@@ -318,7 +318,7 @@ exports[`ic-page-header component renders additional functionality should render
         </ol>
       </nav>
     </mock:shadow-root>
-    <ic-breadcrumb href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
+    <ic-breadcrumb appearance="default" href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
       <mock:shadow-root>
         <div class="breadcrumb">
           <span aria-hidden="true" class="chevron">
@@ -330,7 +330,7 @@ exports[`ic-page-header component renders additional functionality should render
         </div>
       </mock:shadow-root>
     </ic-breadcrumb>
-    <ic-breadcrumb aria-current="page" current="true" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
+    <ic-breadcrumb appearance="default" aria-current="page" current="true" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
       <mock:shadow-root>
         <div class="breadcrumb">
           <span aria-hidden="true" class="chevron">


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Storybook playgrounds for badge, breadcrumb and card. Fix for breadcrumbs so that appearance and backBreadcrumbOnly props can be changed after being set.

Ticket created for collapsed prop not working after being set on breadcrumbs - https://github.com/mi6/ic-ui-kit/issues/1998

## Related issue
Part of #1970 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.