### PR TITLE
1970 more component playgrounds

### DIFF
--- a/packages/react/src/stories/ic-chip.stories.mdx
+++ b/packages/react/src/stories/ic-chip.stories.mdx
@@ -5,7 +5,7 @@ import {
   ArgsTable,
   Description,
 } from "@storybook/addon-docs";
-import { IcChip } from "../components";
+import { IcChip, IcBadge } from "../components";
 import chipReadme from "../../../web-components/src/components/ic-chip/readme.md";
 
 <Meta title="Chip" component={IcChip} />
@@ -429,5 +429,82 @@ import chipReadme from "../../../web-components/src/components/ic-chip/readme.md
         <path d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM10 3C11.66 3 13 4.34 13 6C13 7.66 11.66 9 10 9C8.34 9 7 7.66 7 6C7 4.34 8.34 3 10 3ZM10 17.2C7.5 17.2 5.29 15.92 4 13.98C4.03 11.99 8 10.9 10 10.9C11.99 10.9 15.97 11.99 16 13.98C14.71 15.92 12.5 17.2 10 17.2Z" />
       </svg>
     </IcChip>
+  </Story>
+</Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  customColor: null,
+  disabled: false,
+  dismissible: false,
+  label: "Default",
+  size: "default",
+  transparentBackground: true,
+  variant: "filled",
+  badgeSlot: "badge",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      customColor: {
+        control: { type: "text" },
+      },
+      size: {
+        options: ["small", "default", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      variant: {
+        options: [
+          "filled",
+          "outlined",
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      badgeSlot: {
+        options: [
+          "badge",
+          ""
+        ],
+        control: {
+          type: "select",
+        }
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcChip
+        label={args.label}
+        customColor={args.customColor}
+        dismissible={args.dismissible}
+        disabled={args.disabled}
+        size={args.size}
+        variant={args.variant}
+        transparentBackground={args.transparentBackground}
+      >
+        <svg
+          slot="icon"
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-label="account"
+        >
+          <path
+            d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM10 3C11.66 3 13 4.34 13 6C13 7.66 11.66 9 10 9C8.34 9 7 7.66 7 6C7 4.34 8.34 3 10 3ZM10 17.2C7.5 17.2 5.29 15.92 4 13.98C4.03 11.99 8 10.9 10 10.9C11.99 10.9 15.97 11.99 16 13.98C14.71 15.92 12.5 17.2 10 17.2Z"
+          />
+        </svg>
+        <IcBadge textLabel="1" slot={args.badgeSlot} variant="success" position="near" />
+      </IcChip>
+    )}
   </Story>
 </Canvas>

--- a/packages/react/src/stories/ic-classification-banner.stories.mdx
+++ b/packages/react/src/stories/ic-classification-banner.stories.mdx
@@ -88,3 +88,39 @@ import readme from "../../../web-components/src/components/ic-classification-ban
     />
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  additionalSelectors: "",
+  classification: "official",
+  country: "uk",
+  inline: true,
+  upTo: false,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      classification: {
+        options: ["default", "official", "secret", "official-sensitive", "top-secret"],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcClassificationBanner
+        classification={args.classification}
+        inline={args.inline}
+        up-to={args.upTo}
+        country={args.country}
+        additional-selectors={args.additionalSelectors}
+      ></IcClassificationBanner>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-data-entity.stories.mdx
+++ b/packages/react/src/stories/ic-data-entity.stories.mdx
@@ -476,3 +476,67 @@ import readme from "../../../web-components/src/components/ic-data-row/readme.md
     </IcButton>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  heading: "Details",
+  size: "default",
+  label: "Name",
+  rowSize: "default",
+  value: "Michael Johnson",
+  endCompSlot: "end-component",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      size: {
+        options: ["default", "small" ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      rowSize: {
+        options: ["default", "small" ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      endCompSlot: {
+        options: ["end-component", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcDataEntity heading={args.heading} size={args.size}>
+        <IcDataRow
+          label={args.label}
+          value={args.value}
+          size={args.rowSize}
+        >
+          <IcButton variant="icon" aria-label="Edit" slot={args.endCompSlot}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.127 22.562l-7.127 1.438 1.438-7.128 5.689 5.69zm1.414-1.414l11.228-11.225-5.69-5.692-11.227 11.227 5.689 5.69zm9.768-21.148l-2.816 2.817 5.691 5.691 2.816-2.819-5.691-5.689z"
+              />
+            </svg>
+          </IcButton>
+        </IcDataRow>
+        <IcDataRow label="Date of birth" value="16 October 1995" />
+        <IcDataRow label="Telephone" value="07449 7654873" />
+      </IcDataEntity>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-dialog.stories.mdx
+++ b/packages/react/src/stories/ic-dialog.stories.mdx
@@ -790,3 +790,59 @@ export const showAutoOpenCloseButtonDialog = () => {
     </IcDialog>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  buttons: true,
+  closeOnBackdropClick: true,
+  destructive: false,
+  dismissLabel: "Dismiss",
+  disableHeightConstraint: false,
+  disableWidthConstraint: false,
+  hideCloseButton: false,
+  heading: "This is a dialog",
+  label: "Dialog",
+  open: true,
+  size: "medium",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      size: {
+        options: ["small", "medium", "large"],
+        control: {
+          type: "radio",
+        },
+      }
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcDialog
+        heading={args.heading}
+        label={args.label}
+        size={args.size}
+        open={args.open}
+        closeOnBackdropClick={args.closeOnBackdropClick}
+        destructive={args.destructive}
+        dismissLabel={args.dismissLabel}
+        disableHeightConstraint={args.disableHeightConstraint}
+        disableWidthConstraint={args.disableWidthConstraint}
+        hideCloseButton={args.hideCloseButton}
+        buttons={args.buttons}
+        id="medium-dialog"
+      >
+        <IcTypography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua.
+        </IcTypography>
+      </IcDialog>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-empty-state.stories.mdx
+++ b/packages/react/src/stories/ic-empty-state.stories.mdx
@@ -325,3 +325,85 @@ Dripper caramelization java saucer grounds galão, mocha, and robusta kopi-luwak
     </div>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  aligned: "left",
+  body: "This is the body text for the empty state.",
+  bodyMaxLines: 3,
+  heading: "This is the heading",
+  imageSize: "default",
+  subheading: "This is the subheading",
+  imageSlot: "image",
+  actionsSlot: "actions",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      aligned: {
+        options: ["left", "center", "right"],
+        control: {
+          type: "radio",
+        },
+      },
+      imageSize: {
+        options: ["default", "small", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      imageSlot: {
+        options: ["image", ""],
+        control: {
+          type: "select",
+        },
+      },
+      actionsSlot: {
+        options: ["actions", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcEmptyState
+        heading={args.heading}
+        subheading={args.subheading}
+        body={args.body}
+        imageSize={args.imageSize}
+        bodyMaxLines={args.bodyMaxLines}
+        aligned={args.aligned}
+      >
+        <svg
+          slot={args.imageSlot}
+          height="326px"
+          width="326px"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 1600 900"
+        >
+          <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+          <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+          <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+          <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+          <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+          <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+          <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+          <polygon fill="#b80066" points="641 695 886 900 367 900" />
+          <polygon fill="#960052" points="587 900 641 695 886 900" />
+          <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+          <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+          <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+          <polygon fill="#880088" points="943 900 1210 900 971 687" />
+        </svg>
+        <IcButton slot={args.actionsSlot}>Action</IcButton>
+        <IcLink href="/" slot={args.actionsSlot}>Standalone link</IcLink>
+      </IcEmptyState>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-toast.stories.mdx
+++ b/packages/react/src/stories/ic-toast.stories.mdx
@@ -337,3 +337,89 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
     }}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  autoDismissTimeout: 5000,
+  dismissButtonAriaLabel: "dismiss",
+  dismissMode: "manual",
+  heading: "This is the heading",
+  message: "This is the message",
+  neutralIconAriaLabel: "",
+  variant: "neutral",
+  actionSlot: "action",
+  neutralIconSlot: "neutral-icon",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      dismissMode: {
+        options: ["manual", "automatic"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      variant: {
+        options: ["neutral", "info", "warning", "error", "success", ""],
+        control: {
+          type: "select",
+        },
+      },
+      actionSlot: {
+        options: ["action", ""],
+        control: {
+          type: "select",
+        },
+      },
+      neutralIconSlot: {
+        options: ["neutral-icon", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => {
+      function func() {
+        document.querySelector("ic-toast-region").openToast =
+          document.getElementById("toast1");
+      }
+      return (
+      <>
+      <button onClick={func}>Display toast</button>
+      <IcToastRegion>
+        <IcToast
+          id="toast1"
+          heading={args.heading}
+          message={args.message}
+          variant={args.variant}
+          dismissMode={args.dismissMode}
+          autoDismissTimeout={args.autoDismissTimeout}
+          neutralIconAriaLabel={args.neutralIconAriaLabel}
+          dismissButtonAriaLabel={args.dismissButtonAriaLabel}
+        >
+          <IcButton slot={args.actionSlot} appearance="light">Click me</IcButton>
+          <svg
+            slot={args.neutralIconSlot}
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8.79502 15.875L4.62502 11.705L3.20502 13.115L8.79502 18.705L20.795 6.70501L19.385 5.29501L8.79502 15.875Z"
+            />
+          </svg>
+        </IcToast>
+      </IcToastRegion>
+      </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-chip/ic-chip.stories.mdx
+++ b/packages/web-components/src/components/ic-chip/ic-chip.stories.mdx
@@ -611,3 +611,79 @@ import readme from "./readme.md";
     `}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  customColor: null,
+  disabled: false,
+  dismissible: false,
+  label: "Default",
+  size: "default",
+  transparentBackground: true,
+  variant: "filled",
+  badgeSlot: "badge",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      customColor: {
+        control: { type: "text" },
+      },
+      size: {
+        options: ["small", "default", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      variant: {
+        options: ["filled", "outlined"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      badgeSlot: {
+        options: ["badge", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-chip
+        label=${args.label}
+        custom-color=${args.customColor}
+        dismissible=${args.dismissible}
+        disabled=${args.disabled}
+        size=${args.size}
+        variant=${args.variant}
+        transparent-background=${args.transparentBackground}
+      >
+        <svg
+          slot="icon"
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-label="account"
+        >
+          <path
+            d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM10 3C11.66 3 13 4.34 13 6C13 7.66 11.66 9 10 9C8.34 9 7 7.66 7 6C7 4.34 8.34 3 10 3ZM10 17.2C7.5 17.2 5.29 15.92 4 13.98C4.03 11.99 8 10.9 10 10.9C11.99 10.9 15.97 11.99 16 13.98C14.71 15.92 12.5 17.2 10 17.2Z"
+          />
+        </svg>
+        <ic-badge
+          text-label="1"
+          slot=${args.badgeSlot}
+          variant="success"
+          position="near"
+        ></ic-badge>
+      </ic-chip>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-bannner.stories.mdx
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-bannner.stories.mdx
@@ -105,3 +105,45 @@ import readme from "./readme.md";
     />`}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  additionalSelectors: "",
+  classification: "official",
+  country: "uk",
+  inline: true,
+  upTo: false,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      classification: {
+        options: [
+          "default",
+          "official",
+          "secret",
+          "official-sensitive",
+          "top-secret",
+        ],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-classification-banner
+        classification=${args.classification}
+        inline=${args.inline}
+        up-to=${args.upTo}
+        country=${args.country}
+        additional-selectors=${args.additionalSelectors}
+      ></ic-classification-banner>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-data-entity/ic-data-entity.stories.mdx
+++ b/packages/web-components/src/components/ic-data-entity/ic-data-entity.stories.mdx
@@ -447,3 +447,70 @@ import Typography from "../ic-typography/readme.md";
       </ic-button>`}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  heading: "Details",
+  size: "default",
+  label: "Name",
+  rowSize: "default",
+  value: "Michael Johnson",
+  endCompSlot: "end-component",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      size: {
+        options: ["default", "small"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      rowSize: {
+        options: ["default", "small"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      endCompSlot: {
+        options: ["end-component", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-data-entity heading=${args.heading} size=${args.size}>
+        <ic-data-row
+          label=${args.label}
+          value=${args.value}
+          size=${args.rowSize}
+        >
+          <ic-button variant="icon" aria-label="Edit" slot=${args.endCompSlot}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.127 22.562l-7.127 1.438 1.438-7.128 5.689 5.69zm1.414-1.414l11.228-11.225-5.69-5.692-11.227 11.227 5.689 5.69zm9.768-21.148l-2.816 2.817 5.691 5.691 2.816-2.819-5.691-5.689z"
+              />
+            </svg>
+          </ic-button>
+        </ic-data-row>
+        <ic-data-row
+          label="Date of birth"
+          value="16 October 1995"
+        ></ic-data-row>
+        <ic-data-row label="Telephone" value="07449 7654873"></ic-data-row>
+      </ic-data-entity>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.stories.mdx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.stories.mdx
@@ -1284,3 +1284,59 @@ import readme from "./readme.md";
     `}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  buttons: true,
+  closeOnBackdropClick: true,
+  destructive: false,
+  dismissLabel: "Dismiss",
+  disableHeightConstraint: false,
+  disableWidthConstraint: false,
+  hideCloseButton: false,
+  heading: "This is a dialog",
+  label: "Dialog",
+  open: true,
+  size: "medium",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      size: {
+        options: ["small", "medium", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-dialog
+        heading=${args.heading}
+        label=${args.label}
+        size=${args.size}
+        open=${args.open}
+        close-on-backdrop-click=${args.closeOnBackdropClick}
+        destructive=${args.destructive}
+        dismiss-label=${args.dismissLabel}
+        disable-height-constraint=${args.disableHeightConstraint}
+        disable-width-constraint=${args.disableWidthConstraint}
+        hide-close-button=${args.hideCloseButton}
+        buttons=${args.buttons}
+        id="medium-dialog"
+      >
+        <ic-typography>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua.
+        </ic-typography>
+      </ic-dialog>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-empty-state/ic-empty-state.stories.mdx
+++ b/packages/web-components/src/components/ic-empty-state/ic-empty-state.stories.mdx
@@ -344,3 +344,84 @@ Dripper caramelization java saucer grounds galão, mocha, and robusta kopi-luwak
     </div>`}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  aligned: "left",
+  body: "This is the body text for the empty state.",
+  bodyMaxLines: 3,
+  heading: "This is the heading",
+  imageSize: "default",
+  subheading: "This is the subheading",
+  imageSlot: "image",
+  actionsSlot: "actions",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      aligned: {
+        options: ["left", "center", "right"],
+        control: {
+          type: "radio",
+        },
+      },
+      imageSize: {
+        options: ["default", "small", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      imageSlot: {
+        options: ["image", ""],
+        control: {
+          type: "select",
+        },
+      },
+      actionsSlot: {
+        options: ["actions", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-empty-state
+        heading=${args.heading}
+        subheading=${args.subheading}
+        body=${args.body}
+        image-size=${args.imageSize}
+        body-max-lines=${args.bodyMaxLines}
+        aligned=${args.aligned}
+    >
+      <svg
+        slot=${args.imageSlot}
+        height:326px;width:326px;"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 1600 900"
+      >
+        <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+        <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+        <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+        <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+        <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+        <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+        <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+        <polygon fill="#b80066" points="641 695 886 900 367 900" />
+        <polygon fill="#960052" points="587 900 641 695 886 900" />
+        <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+        <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+        <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+        <polygon fill="#880088" points="943 900 1210 900 971 687" />
+      </svg>
+      <ic-button slot=${args.actionsSlot}>Action</ic-button>
+      <ic-link href="/" slot=${args.actionsSlot}>Standalone link</ic-link>
+    </ic-empty-state>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-toast/ic-toast.stories.mdx
+++ b/packages/web-components/src/components/ic-toast/ic-toast.stories.mdx
@@ -341,3 +341,90 @@ import readme from "./readme.md";
       </ic-toast-region>`}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  autoDismissTimeout: 5000,
+  dismissButtonAriaLabel: "dismiss",
+  dismissMode: "manual",
+  heading: "This is the heading",
+  message: "This is the message",
+  neutralIconAriaLabel: "",
+  variant: "neutral",
+  actionSlot: "action",
+  neutralIconSlot: "neutral-icon",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      dismissMode: {
+        options: ["manual", "automatic"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      variant: {
+        options: ["neutral", "info", "warning", "error", "success", ""],
+        control: {
+          type: "select",
+        },
+      },
+      actionSlot: {
+        options: ["action", ""],
+        control: {
+          type: "select",
+        },
+      },
+      neutralIconSlot: {
+        options: ["neutral-icon", ""],
+        control: {
+          type: "select",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<button onclick="func()">Display toast</button>
+        <script>
+          var toastRegion = document.querySelector("ic-toast-region");
+          function func() {
+            var x = document.getElementById("toast1");
+            toastRegion.openToast = x;
+          }
+        </script>
+        <ic-toast-region>
+          <ic-toast
+            id="toast1"
+            heading=${args.heading}
+            message=${args.message}
+            variant=${args.variant}
+            dismiss-mode=${args.dismissMode}
+            auto-dismiss-timeout=${args.autoDismissTimeout}
+            neutral-icon-aria-label=${args.neutralIconAriaLabel}
+            dismiss-button-aria-label=${args.dismissButtonAriaLabel}
+          >
+            <ic-button slot=${args.actionSlot} appearance="light"
+              >Click me</ic-button
+            >
+            <svg
+              slot=${args.neutralIconSlot}
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8.79502 15.875L4.62502 11.705L3.20502 13.115L8.79502 18.705L20.795 6.70501L19.385 5.29501L8.79502 15.875Z"
+              />
+            </svg>
+          </ic-toast>
+        </ic-toast-region>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-toast/ic-toast.tsx
+++ b/packages/web-components/src/components/ic-toast/ic-toast.tsx
@@ -9,6 +9,7 @@ import {
   Method,
   Prop,
   State,
+  Watch,
 } from "@stencil/core";
 import closeIcon from "../../assets/close-icon.svg";
 import { VARIANT_ICONS } from "../../utils/constants";
@@ -65,6 +66,10 @@ export class Toast {
    * How the toast will be dismissed. If manual will display a dismiss button.
    */
   @Prop({ mutable: true }) dismissMode?: IcActivationTypes = "manual";
+  @Watch("dismissMode")
+  dismissModeChangeHandler(newValue: IcActivationTypes): void {
+    this.isManual = newValue === "manual";
+  }
 
   /**
    * The title to display at the start of the toast. (NOTE: Should be no more than `70` characters)


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add playground stories for chip, classification banner, data entity, dialog, empty state and toast.
Update dismissMode on toast so that it can change between manual and automatic

## Related issue
Part of #1970 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.