### PR TITLE
1970 additional component playgrounds

### DIFF
--- a/packages/react/src/stories/ic-popover-menu.stories.mdx
+++ b/packages/react/src/stories/ic-popover-menu.stories.mdx
@@ -183,3 +183,78 @@ import menuGroupReadme from "../../../web-components/src/components/ic-menu-grou
     }}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  open: true,
+  groupLabel: "View",
+  description: "",
+  disabled: false,
+  href: "/",
+  keyboardShortcut: "Cmd + C",
+  label: "Copy code",
+  variant: "default",
+  iconSlot: true,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      variant: {
+        options: [
+          "default", "toggle", "destructive"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      iconSlot: {
+        mapping: {
+          true: "icon",
+          false: "",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <div>
+          <IcPopoverMenu ariaLabel="popover" open={args.open}>
+            <IcMenuGroup label={args.groupLabel}>
+              <IcMenuItem
+                description={args.description}
+                disabled={args.disabled}
+                href={args.href}
+                keyboardShortcut={args.keyboardShortcut}
+                label={args.label}
+                variant={args.variant}
+              >
+                <svg
+                  slot={args.iconSlot}
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="24px"
+                  viewBox="0 0 24 24"
+                  width="24px"
+                >
+                  <path d="M0 0h24v24H0V0z" fill="none" />
+                  <path
+                    d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                  />
+                </svg>
+              </IcMenuItem>
+              <IcMenuItem label="Zoom out" keyboardShortcut="Cmd-" />
+            </IcMenuGroup>
+            <IcMenuItem label="Actions" submenuTriggerFor="abc" />
+          </IcPopoverMenu>
+          <IcPopoverMenu submenuId="abc">
+            <IcMenuItem label="Edit" />
+            <IcMenuItem label="Find" />
+            <IcMenuItem label="Delete" variant="destructive" />
+          </IcPopoverMenu>
+        </div>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-radio-group.stories.mdx
+++ b/packages/react/src/stories/ic-radio-group.stories.mdx
@@ -422,3 +422,111 @@ export const RadioOptionsAdditional = () => {
     <RadioOptionsAdditional />
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  disabled: false,
+  helperText: "Some helper text",
+  hideLabel: false,
+  label: "This is a label",
+  name: "1",
+  orientation: "vertical",
+  required: false,
+  size: "default",
+  validationStatus: "",
+  validationText: "",
+  additionalFieldDisplay: "static",
+  radioDisabled: false,
+  dynamicText: "This selection requires additional answers",
+  radioLabel: "Radio 1",
+  radioName: "radio1",
+  value: "valueName1",
+  selected: false,
+  additionalFieldSlot: true
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      orientation: {
+        options: [
+          "vertical", "horizontal"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      size: {
+        options: [
+          "default", "small"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      validationStatus: {
+        options: [
+          "error", "warning", "success", ""
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      additionalFieldDisplay: {
+        options: [
+          "static", "dynamic"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      additionalFieldSlot: {
+        mapping: {
+          true: "additional-field",
+          false: "",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      (
+        <IcRadioGroup
+          label={args.label}
+          name={args.name}
+          orientation={args.orientation}
+          required={args.required}
+          size={args.size}
+          validationStatus={args.validationStatus}
+          validationText={args.validationText}
+          helperText={args.helperText}
+          disabled={args.disabled}
+          hideLabel={args.hideLabel}
+        >
+          <IcRadioOption
+            additionalFieldDisplay={args.additionalFieldDisplay}
+            value={args.value}
+            label={args.radioLabel}
+            name={args.radioName}
+            selected={args.selected}
+            disabled={args.radioDisabled}
+            dynamicText={args.dynamicText}
+          >
+            <IcTextField
+              slot={args.additionalFieldSlot}
+              placeholder="Placeholder"
+              label="What's your favourite type of coffee?"
+            />
+          </IcRadioOption>
+          <IcRadioOption
+            value="valueName2"
+            label="Radio 2"
+          />
+        </IcRadioGroup>
+      )
+    }
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-status-tag.stories.mdx
+++ b/packages/react/src/stories/ic-status-tag.stories.mdx
@@ -75,3 +75,57 @@ import readme from "../../../web-components/src/components/ic-status-tag/readme.
     <IcStatusTag label="Neutral" appearance="outlined" />
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  announced: false,
+  label: "Status tag label",
+  size: "default",
+  status: "neutral",
+  variant: "filled",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      size: {
+        options: [
+          "default", "small"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      status: {
+        options: [
+          "neutral", "success", "warning", "danger"
+        ],
+        control: {
+          type: "select",
+        },
+      },
+      variant: {
+        options: [
+          "filled", "outlined"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcStatusTag
+        label={args.label}
+        size={args.size}
+        status={args.status}
+        variant={args.variant}
+        announced={args.announced}
+      ></IcStatusTag>
+    )}
+  </Story>
+</Canvas>

--- a/packages/react/src/stories/ic-tabs.stories.mdx
+++ b/packages/react/src/stories/ic-tabs.stories.mdx
@@ -12,6 +12,7 @@ import {
   IcTab,
   IcTabContext,
   IcButton,
+  IcBadge
 } from "../components";
 import readme from "../../../web-components/src/components/ic-tab-context/readme.md";
 import TabContextReadme from "../../../web-components/src/components/ic-tab-context/readme.md";
@@ -294,5 +295,85 @@ export const ControlledTabsExample = () => {
       <IcTabPanel>Tab Eight</IcTabPanel>
       <IcTabPanel>Tab Nine</IcTabPanel>
     </IcTabContext>
+  </Story>
+</Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  activationType: "automatic",
+  appearance: "dark",
+  disabled: false,
+  inline: false,
+  groupLabel: "Example tab group",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      activationType: {
+        options: [
+          "automatic", "manual"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      appearance: {
+        options: [
+          "dark", "light"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <div style={{ backgroundColor: args.appearance == "light" ? "black" : ""}}>
+        <IcTabContext
+          activationType={args.activationType}
+          appearance={args.appearance}
+        >
+          <IcTabGroup
+            label={args.groupLabel}
+            inline={args.inline}
+          >
+            <IcTab disabled={args.disabled}>
+              One
+            </IcTab>
+            <IcTab>
+              Two
+              <IcBadge
+                textLabel="1"
+                slot="badge"
+                position="inline"
+                accessibleLabel="1 notification found"
+              />
+            </IcTab>
+            <IcTab>
+              Three
+              <svg
+                slot="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 0 24 24"
+                width="24px"
+                fill="#000000"
+              >
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+              </svg>
+            </IcTab>
+          </IcTabGroup>
+          <IcTabPanel>Tab One</IcTabPanel>
+          <IcTabPanel>Tab Two</IcTabPanel>
+          <IcTabPanel>Tab Three</IcTabPanel>
+        </IcTabContext>
+      </div>
+    )}
   </Story>
 </Canvas>

--- a/packages/react/src/stories/ic-toggle-button-group.stories.mdx
+++ b/packages/react/src/stories/ic-toggle-button-group.stories.mdx
@@ -334,3 +334,162 @@ import { SlottedSVG } from "../react-component-lib/slottedSVG";
     </>
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  accessibleLabel: "",
+  appearance: "default",
+  disabled: false,
+  fullWidth: false,
+  iconPlacement: "left",
+  loading: false,
+  selectMethod: "manual",
+  selectType: "single",
+  size: "default",
+  variant: "default",
+  toggleAccessibleLabel: "",
+  toggleAppearance: "default",
+  toggleDisabled: false,
+  toggleFullWidth: false,
+  toggleIconPlacement: "left",
+  label: "Toggle",
+  toggleLoading: false,
+  toggleSize: "default",
+  toggleChecked: false,
+  toggleVariant: "default",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      appearance: {
+        options: [
+          "default", "dark", "light"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      iconPlacement: {
+        options: [
+          "left", "right", "top"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      selectMethod: {
+        options: [
+          "manual", "auto"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      selectType: {
+        options: [
+          "single", "multi"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      size: {
+        options: [
+          "default", "small", "large"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      variant: {
+        options: [
+          "default", "icon"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      toggleAppearance: {
+        options: [
+          "default", "dark", "light"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      toggleIconPlacement: {
+        options: [
+          "left", "right", "top"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      toggleSize: {
+        options: [
+          "default", "small", "large"
+        ],
+        control: {
+          type: "radio",
+        },
+      },
+      toggleVariant: {
+        options: [
+          "default", "icon"
+        ],
+        control: {
+          type: "inline-radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) => (
+      <IcToggleButtonGroup
+        accessibleLabel={args.accessibleLabel}
+        appearance={args.appearance}
+        disabled={args.disabled}
+        fullWidth={args.fullWidth}
+        iconPlacement={args.iconPlacement}
+        loading={args.loading}
+        selectMethod={args.selectMethod}
+        selectType={args.selectType}
+        size={args.size}
+        variant={args.variant}
+      >
+        <IcToggleButton
+          accessibleLabel={args.toggleAccessibleLabel}
+          appearance={args.toggleAppearance}
+          disabled={args.toggleDisabled}
+          fullWidth={args.toggleFullWidth}
+          iconPlacement={args.toggleIconPlacement}
+          loading={args.toggleLoading}
+          size={args.toggleSize}
+          toggleChecked={args.toggleChecked}
+          variant={args.toggleVariant}
+          label={args.label}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            fill="#000000"
+            slot="icon"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path
+              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+            />
+          </svg>
+        </IcToggleButton>
+        <IcToggleButton label="Second toggle" />
+        <IcToggleButton label="Third toggle" />
+      </IcToggleButtonGroup>
+    )}
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
@@ -450,3 +450,82 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
     }
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  open: true,
+  groupLabel: "View",
+  description: "",
+  disabled: false,
+  href: "/",
+  keyboardShortcut: "Cmd + C",
+  label: "Copy code",
+  variant: "default",
+  iconSlot: true,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      variant: {
+        options: ["default", "toggle", "destructive"],
+        control: {
+          type: "radio",
+        },
+      },
+      iconSlot: {
+        mapping: {
+          true: "icon",
+          false: "",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<div>
+        <ic-popover-menu aria-label="popover" open=${args.open}>
+          <ic-menu-group label=${args.groupLabel}>
+            <ic-menu-item
+              description=${args.description}
+              disabled=${args.disabled}
+              href=${args.href}
+              keyboard-shortcut=${args.keyboardShortcut}
+              label=${args.label}
+              variant=${args.variant}
+            >
+              <svg
+                slot=${args.iconSlot}
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 0 24 24"
+                width="24px"
+              >
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </ic-menu-item>
+            <ic-menu-item
+              label="Zoom out"
+              keyboard-shortcut="Cmd-"
+            ></ic-menu-item>
+          </ic-menu-group>
+          <ic-menu-item
+            label="Actions"
+            submenu-trigger-for="abc"
+          ></ic-menu-item>
+        </ic-popover-menu>
+        <ic-popover-menu submenu-id="abc">
+          <ic-menu-item label="Edit"></ic-menu-item>
+          <ic-menu-item label="Find"></ic-menu-item>
+          <ic-menu-item label="Delete" variant="destructive"></ic-menu-item>
+        </ic-popover-menu>
+      </div>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.mdx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.mdx
@@ -357,3 +357,100 @@ import readme from "./readme.md";
     }
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  disabled: false,
+  helperText: "Some helper text",
+  hideLabel: false,
+  label: "This is a label",
+  name: "1",
+  orientation: "vertical",
+  required: false,
+  size: "default",
+  validationStatus: "",
+  validationText: "",
+  additionalFieldDisplay: "static",
+  radioDisabled: false,
+  dynamicText: "This selection requires additional answers",
+  radioLabel: "Radio 1",
+  radioName: "radio1",
+  value: "valueName1",
+  selected: false,
+  additionalFieldSlot: true,
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      orientation: {
+        options: ["vertical", "horizontal"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      size: {
+        options: ["default", "small"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      validationStatus: {
+        options: ["error", "warning", "success", ""],
+        control: {
+          type: "radio",
+        },
+      },
+      additionalFieldDisplay: {
+        options: ["static", "dynamic"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      additionalFieldSlot: {
+        mapping: {
+          true: "additional-field",
+          false: "",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`
+        <ic-radio-group
+          label=${args.label}
+          name=${args.name}
+          orientation=${args.orientation}
+          required=${args.required}
+          size=${args.size}
+          validation-status=${args.validationStatus}
+          validation-text=${args.validationText}
+          helper-text=${args.helperText}
+          disabled=${args.disabled}
+          hide-label=${args.hideLabel}
+        >
+          <ic-radio-option
+            additional-field-display=${args.additionalFieldDisplay}
+            value=${args.value}
+            label=${args.radioLabel}
+            name=${args.radioName}
+            selected=${args.selected}
+            disabled=${args.radioDisabled}
+            dynamic-text=${args.dynamicText}
+          >
+            <ic-text-field
+              slot=${args.additionalFieldSlot}
+              placeholder="Placeholder"
+              label="What's your favourite type of coffee?"
+            ></ic-text-field>
+          </ic-radio-option>
+          <ic-radio-option value="valueName2" label="Radio 2"></ic-radio-option>
+        </ic-radio-group>
+      `
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
@@ -173,7 +173,7 @@ export class RadioOption {
   componentDidRender(): void {
     if (this.additionalFieldDisplay === "static") {
       const textfield = this.el.querySelector(TEXT_FIELD_SELECTOR);
-      if (!this.selected) {
+      if (!this.selected || this.disabled) {
         textfield?.setAttribute("disabled", "");
       } else {
         textfield?.removeAttribute("disabled");

--- a/packages/web-components/src/components/ic-status-tag/ic-status-tag.stories.mdx
+++ b/packages/web-components/src/components/ic-status-tag/ic-status-tag.stories.mdx
@@ -117,3 +117,51 @@ import readme from "./readme.md";
     `}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  announced: false,
+  label: "Status tag label",
+  size: "default",
+  status: "neutral",
+  variant: "filled",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      size: {
+        options: ["default", "small"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      status: {
+        options: ["neutral", "success", "warning", "danger"],
+        control: {
+          type: "select",
+        },
+      },
+      variant: {
+        options: ["filled", "outlined"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-status-tag
+        label=${args.label}
+        size=${args.size}
+        status=${args.status}
+        variant=${args.variant}
+        announced=${args.announced}
+      ></ic-status-tag>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
@@ -47,6 +47,14 @@ export class TabContext {
    * The appearance of the tab context, e.g dark, or light.
    */
   @Prop() appearance?: IcThemeForegroundNoDefault = "dark";
+  @Watch("appearance")
+  watchAppearanceHandler(): void {
+    this.tabs.forEach((tab, index) => {
+      tab.appearance = this.appearance;
+      this.tabPanels[index].appearance = this.appearance;
+    });
+    this.tabGroup.appearance = this.appearance;
+  }
 
   /**
    * The unique context needed if using multiple tabs inside one another i.e. rendering another set of tabs inside a tab panel.

--- a/packages/web-components/src/components/ic-tab-context/ic-tabs.stories.mdx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tabs.stories.mdx
@@ -335,3 +335,77 @@ import TabPanelReadme from "../ic-tab-panel/readme.md";
     </div>`}
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  activationType: "automatic",
+  appearance: "dark",
+  disabled: false,
+  inline: false,
+  groupLabel: "Example tab group",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      activationType: {
+        options: ["automatic", "manual"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      appearance: {
+        options: ["dark", "light"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<div
+        style="background-color: ${args.appearance == "light" ? "black" : ""};"
+      >
+        <ic-tab-context
+          activation-type=${args.activationType}
+          appearance=${args.appearance}
+        >
+          <ic-tab-group label=${args.groupLabel} inline=${args.inline}>
+            <ic-tab disabled=${args.disabled}> One </ic-tab>
+            <ic-tab>
+              Two
+              <ic-badge
+                text-label="1"
+                slot="badge"
+                position="inline"
+                accessible-label="1 notification found"
+              >
+              </ic-badge>
+            </ic-tab>
+            <ic-tab>
+              Three
+              <svg
+                slot="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                height="24px"
+                viewBox="0 0 24 24"
+                width="24px"
+                fill="#000000"
+              >
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+              </svg>
+            </ic-tab>
+          </ic-tab-group>
+          <ic-tab-panel>Tab One</ic-tab-panel>
+          <ic-tab-panel>Tab Two</ic-tab-panel>
+          <ic-tab-panel>Tab Three</ic-tab-panel>
+        </ic-tab-context>
+      </div>`
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.stories.mdx
+++ b/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.stories.mdx
@@ -421,3 +421,142 @@ import readme from "./readme.md";
     }
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  accessibleLabel: "",
+  appearance: "default",
+  disabled: false,
+  fullWidth: false,
+  iconPlacement: "left",
+  loading: false,
+  selectMethod: "manual",
+  selectType: "single",
+  size: "default",
+  variant: "default",
+  toggleAccessibleLabel: "",
+  toggleAppearance: "default",
+  toggleDisabled: false,
+  toggleFullWidth: false,
+  toggleIconPlacement: "left",
+  label: "Toggle",
+  toggleLoading: false,
+  toggleSize: "default",
+  toggleChecked: false,
+  toggleVariant: "default",
+};
+
+<Canvas>
+  <Story
+    args={defaultArgs}
+    parameters={{ loki: { skip: true } }}
+    argTypes={{
+      appearance: {
+        options: ["default", "dark", "light"],
+        control: {
+          type: "radio",
+        },
+      },
+      iconPlacement: {
+        options: ["left", "right", "top"],
+        control: {
+          type: "radio",
+        },
+      },
+      selectMethod: {
+        options: ["manual", "auto"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      selectType: {
+        options: ["single", "multi"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      size: {
+        options: ["default", "small", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      variant: {
+        options: ["default", "icon"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+      toggleAppearance: {
+        options: ["default", "dark", "light"],
+        control: {
+          type: "radio",
+        },
+      },
+      toggleIconPlacement: {
+        options: ["left", "right", "top"],
+        control: {
+          type: "radio",
+        },
+      },
+      toggleSize: {
+        options: ["default", "small", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      toggleVariant: {
+        options: ["default", "icon"],
+        control: {
+          type: "inline-radio",
+        },
+      },
+    }}
+    name="Playground"
+  >
+    {(args) =>
+      html`<ic-toggle-button-group
+        accessible-label=${args.accessibleLabel}
+        appearance=${args.appearance}
+        disabled=${args.disabled}
+        full-width=${args.fullWidth}
+        icon-placement=${args.iconPlacement}
+        loading=${args.loading}
+        select-method=${args.selectMethod}
+        select-type=${args.selectType}
+        size=${args.size}
+        variant=${args.variant}
+      >
+        <ic-toggle-button
+          accessible-label=${args.toggleAccessibleLabel}
+          appearance=${args.toggleAppearance}
+          disabled=${args.toggleDisabled}
+          full-width=${args.toggleFullWidth}
+          icon-placement=${args.toggleIconPlacement}
+          loading=${args.toggleLoading}
+          size=${args.toggleSize}
+          toggle-checked=${args.toggleChecked}
+          variant=${args.toggleVariant}
+          label=${args.label}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 0 24 24"
+            width="24px"
+            fill="#000000"
+            slot="icon"
+          >
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path
+              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+            />
+          </svg>
+        </ic-toggle-button>
+        <ic-toggle-button label="Second toggle"></ic-toggle-button>
+        <ic-toggle-button label="Third toggle"></ic-toggle-button>
+      </ic-toggle-button-group>`
+    }
+  </Story>
+</Canvas>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add playground stories for popover menu, radio, status tag, tab, and toggle button. 

Add watch to tab context appearance prop so that it passes down the correct value to tab/tab group/tab panel when appearance is toggled.

Tickets created for missing/incorrect functionality - #2017, #2018, #2022 

## Related issue
Part of #1970 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.