### PR TITLE
1970 canary date component playgrounds

### DIFF
--- a/packages/canary-react/src/stories/ic-date-input.stories.mdx
+++ b/packages/canary-react/src/stories/ic-date-input.stories.mdx
@@ -6,9 +6,10 @@ import {
   Description,
 } from "@storybook/addon-docs";
 import { IcDateInput } from "../components";
-import { IcButton, IcTypography } from "@ukic/react";
+import { IcButton, IcTypography, IcLink } from "@ukic/react";
 import readme from "../../../canary-web-components/src/components/ic-date-input/readme.md";
 import { useState } from "react";
+import { useArgs } from '@storybook/client-api';
 
 <Meta title="React Components/Date Input" component={IcDateInput} />
 
@@ -605,5 +606,96 @@ The date input can be cleared by setting the the value attribute to one of the f
 <Canvas withSource='none'>
   <Story name="With clearing value" parameters={{ loki: { skip: true } }}>
     <ClearDateInput />
+  </Story>
+</Canvas>
+
+### Playground example
+
+Go to the <IcLink href="/?path=/story/react-components-date-input--playground-example">separate page for the playground example</IcLink> to view the prop controls.
+
+export const defaultArgs = {
+  dateFormat: "DD/MM/YYYY",
+  disabled: false,
+  disableDays: [],
+  disableDaysMessage: "This day is not available",
+  disableFuture: false,
+  disableFutureMessage: "This date is in the future",
+  disablePast: false,
+  disablePastMessage: "This date is in the past",
+  helperText: "Choose a date",
+  label: "When would you like to collect your coffee?",
+  max: "",
+  min: "",
+  required: false,
+  showClearButton: true,
+  size: "default",
+  validationStatus: "",
+  validationText: "",
+  value: "",
+};
+
+<Canvas withSource="none">
+  <Story
+    args={defaultArgs}
+    argTypes={{
+      dateFormat: {
+        options: ["DD/MM/YYYY", "MM/DD/YYYY", "YYYY/MM/DD"],
+        control: {
+          type: "radio",
+        },
+      },
+      validationStatus: {
+        options: ["", "error", "success", "warning"],
+        control: {
+          type: "radio",
+        },
+      },
+      size: {
+        options: ["small", "default", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+    }}
+    name="Playground example"
+  >
+    {(args) => {
+
+      const [{ value }, updateArgs] = useArgs();
+
+      const updateDate = (ev) => {
+        const date = ev.detail.value;
+        let formattedDate;
+        date === null ? formattedDate = "" : formattedDate = `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
+        updateArgs({ value: formattedDate});
+      };
+
+      return(
+       <IcDateInput
+          dateFormat={args.dateFormat}
+          disabled={args.disabled}
+          disableDays={args.disableDays}
+          disableDaysMessage={args.disableDaysMessage}
+          disableFuture={args.disableFuture}
+          disableFutureMessage={args.disableFutureMessage}
+          disablePast={args.disablePast}
+          disablePastMessage={args.disablePastMessage}
+          helperText={args.helperText}
+          label={args.label}
+          max={args.max}
+          min={args.min}
+          openAtDate={args.openAtDate}
+          required={args.required}
+          showDaysOutsideMonth={args.showDaysOutsideMonth}
+          showPickerClearButton={args.showPickerClearButton}
+          showPickerTodayButton={args.showPickerTodayButton}
+          size={args.size}
+          startOfWeek={args.startOfWeek}
+          validationStatus={args.validationStatus}
+          validationText={args.validationText}
+          value={value}
+          onIcChange={updateDate}
+      />
+    )}}
   </Story>
 </Canvas>

--- a/packages/canary-react/src/stories/ic-date-picker.stories.mdx
+++ b/packages/canary-react/src/stories/ic-date-picker.stories.mdx
@@ -6,7 +6,9 @@ import {
   Description,
 } from "@storybook/addon-docs";
 import { IcDatePicker } from "../components";
+import { IcLink } from "@ukic/react";
 import { useState } from "react";
+import { useArgs } from '@storybook/client-api';
 import readme from "../../../canary-web-components/src/components/ic-date-picker/readme.md";
 
 
@@ -507,3 +509,109 @@ const DatePickerWithIcChange = () => {
 
 export default DatePickerWithIcChange;
 ```
+
+### Playground example
+
+Go to the <IcLink href="/?path=/story/react-components-date-picker--playground-example">separate page for the playground example</IcLink> to view the prop controls.
+
+export const defaultArgs = {
+  dateFormat: "DD/MM/YYYY",
+  disabled: false,
+  disableDays: [],
+  disableDaysMessage: "This day is not available",
+  disableFuture: false,
+  disableFutureMessage: "This date is in the future",
+  disablePast: false,
+  disablePastMessage: "This date is in the past",
+  helperText: "Choose a date",
+  label: "When would you like to collect your coffee?",
+  max: "",
+  min: "",
+  openAtDate: "",
+  required: false,
+  showDaysOutsideMonth: true,
+  showPickerClearButton: true,
+  showPickerTodayButton: true,
+  size: "default",
+  startOfWeek: 1,
+  validationStatus: "",
+  validationText: "",
+  value: "",
+};
+
+<Canvas withSource="none">
+  <Story
+    args={defaultArgs}
+    argTypes={{
+      dateFormat: {
+        options: ["DD/MM/YYYY", "MM/DD/YYYY", "YYYY/MM/DD"],
+        control: {
+          type: "radio",
+        },
+      },
+      validationStatus: {
+        options: ["", "error", "success", "warning"],
+        control: {
+          type: "radio",
+        },
+      },
+      size: {
+        options: ["small", "default", "large"],
+        control: {
+          type: "radio",
+        },
+      },
+      startOfWeek: {
+        options: [0, 1, 2, 3, 4, 5, 6],
+        control: {
+          type: "select",
+        },
+      },
+      openAtDate: {
+        control: {
+          type: "text",
+        },
+      },
+    }}
+    name="Playground example"
+  >
+    {(args) => {
+      const [{ value }, updateArgs] = useArgs();
+
+      const updateDate = (ev) => {
+        const date = ev.detail.value;
+        let formattedDate;
+        date === null ? formattedDate = "" : formattedDate = `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
+        updateArgs({ value: formattedDate});
+      };
+
+      return(
+       <IcDatePicker
+          dateFormat={args.dateFormat}
+          disabled={args.disabled}
+          disableDays={args.disableDays}
+          disableDaysMessage={args.disableDaysMessage}
+          disableFuture={args.disableFuture}
+          disableFutureMessage={args.disableFutureMessage}
+          disablePast={args.disablePast}
+          disablePastMessage={args.disablePastMessage}
+          helperText={args.helperText}
+          label={args.label}
+          max={args.max}
+          min={args.min}
+          openAtDate={args.openAtDate}
+          required={args.required}
+          showDaysOutsideMonth={args.showDaysOutsideMonth}
+          showPickerClearButton={args.showPickerClearButton}
+          showPickerTodayButton={args.showPickerTodayButton}
+          size={args.size}
+          startOfWeek={args.startOfWeek}
+          validationStatus={args.validationStatus}
+          validationText={args.validationText}
+          value={value}
+          onIcChange={updateDate}
+       />
+    )}
+    }
+  </Story>
+</Canvas>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add playground stories for date input and date picker

Ticket already created for startOfWeek not updating - https://github.com/mi6/ic-ui-kit/issues/1877

## Related issue
Part of #1970

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.