### PR TITLE
ci(root): removes --legacy-peer-deps flag from actions

### DIFF
--- a/.github/workflows/deploy-storybook-only.yml
+++ b/.github/workflows/deploy-storybook-only.yml
@@ -63,8 +63,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build core components
         if: ${{ needs.check-updates.outputs.canary == 'false' }}

--- a/.github/workflows/ic-ui-kit-branches.yml
+++ b/.github/workflows/ic-ui-kit-branches.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build core components
         if: ${{ needs.check-updates.outputs.canary == 'false' }}
@@ -118,8 +118,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: E2E core tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -159,8 +159,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Core visual regression tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -205,8 +205,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Cache Cypress Binary
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
@@ -305,8 +305,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build core components
         if: ${{ needs.check-updates.outputs.canary == 'false' }}

--- a/.github/workflows/ic-ui-kit-develop.yml
+++ b/.github/workflows/ic-ui-kit-develop.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build core components
         if: ${{ needs.check-updates.outputs.canary == 'false' }}
@@ -93,8 +93,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: E2E core tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -122,8 +122,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Core visual regression tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -146,8 +146,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Core Cypress tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -180,8 +180,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build core components
         if: ${{ needs.check-updates.outputs.canary == 'false' }}

--- a/.github/workflows/ic-ui-kit-main.yml
+++ b/.github/workflows/ic-ui-kit-main.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build core components
         if: ${{ needs.check-updates.outputs.canary == 'false' }}
@@ -89,8 +89,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: E2E core tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -119,8 +119,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Core visual regression tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -143,8 +143,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Core Cypress tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}
@@ -179,8 +179,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build
         run: npm run build:all
@@ -210,8 +210,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Build components and web-components and react storybook
         run: |

--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Core Cypress tests
         if: ${{ needs.check-updates.outputs.core == 'true' }}

--- a/.github/workflows/update-cypress-visual-regression-tests.yml
+++ b/.github/workflows/update-cypress-visual-regression-tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-visual-regression-tests.yml
+++ b/.github/workflows/update-visual-regression-tests.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install dependencies
         run: |
           google-chrome --version
-          npm ci --legacy-peer-deps
-          npm run bootstrap -- -- --ci --legacy-peer-deps
+          npm ci
+          npm run bootstrap -- -- --ci
 
       - name: Update Visual Regression Test References
         run: |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Removes `--legacy-peer-deps` flag from ci actions as not required

## Related issue
#1759 



