### PR TITLE
Cypress config retries

### DIFF
--- a/packages/canary-react/cypress.config.ts
+++ b/packages/canary-react/cypress.config.ts
@@ -8,5 +8,9 @@ export default defineConfig({
   component: {
     ...config.component,
     supportFile: "../react/cypress/support/index.ts",
-  }
+    retries: {
+       runMode: 3,
+       openMode: 0
+     },
+  },
 } as Cypress.ConfigOptions) 

--- a/packages/react/cypress.config.ts
+++ b/packages/react/cypress.config.ts
@@ -20,7 +20,10 @@ export const config: Cypress.ConfigOptions = {
       return config;
     },
     supportFile: "./cypress/support/index.ts",
-    retries: 3,
+    retries: {
+      runMode: 3,
+      openMode: 0
+    },
   },
 }
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
When running Cypress tests locally with `open` there will now be 0 retries, this will help save time when testing and increase accuracy of tests ensuring they pass first time. Tests on the CI remain at 3.

