### PR TITLE
Feature/1354 prefix events with ic

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -13949,7 +13949,7 @@
       "methods": [],
       "events": [
         {
-          "event": "sideNavExpanded",
+          "event": "icSideNavExpanded",
           "detail": "IcExpandedDetail",
           "bubbles": true,
           "complexType": {
@@ -18312,7 +18312,7 @@
       "methods": [],
       "events": [
         {
-          "event": "topNavResized",
+          "event": "icTopNavResized",
           "detail": "{ size: number; }",
           "bubbles": true,
           "complexType": {

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-06-24T09:26:04",
+  "timestamp": "2024-07-02T13:02:20",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.10.0",
@@ -10840,7 +10840,7 @@
     },
     {
       "filePath": "src/components/ic-radio-option/ic-radio-option.tsx",
-      "encapsulation": "shadow",
+      "encapsulation": "none",
       "tag": "ic-radio-option",
       "readme": "# ic-radio-option\n\n\n",
       "docs": "",

--- a/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
@@ -55,11 +55,11 @@ describe("IcRadio", () => {
     cy.get(RADIO_SELECTOR).eq(2).should(HAVE_PROP, "selected", false);
     cy.get(RADIO_SELECTOR).last().should(HAVE_PROP, "selected", false);
 
-    cy.findShadowEl(RADIO_SELECTOR, INPUT).first().should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).first().should(HAVE_FOCUS);
 
     cy.realPress("ArrowDown");
 
-    cy.findShadowEl(RADIO_SELECTOR, INPUT).eq(1).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(1).should(HAVE_FOCUS);
     cy.get(RADIO_SELECTOR).first().should(HAVE_PROP, "selected", false);
     cy.get(RADIO_SELECTOR).eq(1).should(HAVE_PROP, "selected", true);
   });
@@ -76,7 +76,7 @@ describe("IcRadio", () => {
     cy.findShadowEl(IC_BUTTON, BUTTON).focus();
     cy.realPress(["Shift", "Tab"]);
 
-    cy.findShadowEl(RADIO_SELECTOR, INPUT).first().should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).first().should(HAVE_FOCUS);
 
     cy.get(RADIO_SELECTOR)
       .first()
@@ -90,7 +90,7 @@ describe("IcRadio", () => {
 
     cy.realPress("ArrowDown");
 
-    cy.findShadowEl(RADIO_SELECTOR, INPUT).eq(1).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(1).should(HAVE_FOCUS);
     cy.get(RADIO_SELECTOR).first().should(HAVE_PROP, "selected", false);
     cy.get(RADIO_SELECTOR).last().should(HAVE_PROP, "selected", true);
   });
@@ -108,7 +108,7 @@ describe("IcRadio", () => {
     mount(<Uncontrolled />);
 
     cy.spy(window.console, "log").as("spyWinConsoleLog");
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, true);
   });
 });

--- a/packages/react/src/stories/ic-side-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-side-navigation.stories.mdx
@@ -567,7 +567,7 @@ export const Controlled = () => {
       appTitle="ACME"
       version="v0.0.0"
       status="BETA"
-      onSideNavExpanded={(event) => console.log(event.detail.sideNavExpanded)}
+      onIcSideNavExpanded={(event) => console.log(event.detail.sideNavExpanded)}
     >
       <svg
         slot="app-icon"

--- a/packages/react/src/stories/ic-top-navigation.stories.mdx
+++ b/packages/react/src/stories/ic-top-navigation.stories.mdx
@@ -344,7 +344,7 @@ export const Controlled = () => {
   <Story name="Top nav resized event" parameters={{ layout: "fullscreen" }}>
     <IcTopNavigation
       appTitle="ApplicationName"
-      onTopNavResized={() => console.log(event.detail.size)}
+      onIcTopNavResized={() => console.log(event.detail.size)}
     >
       <svg
         slot="app-icon"

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -3037,7 +3037,7 @@ declare global {
         new (): HTMLIcSelectElement;
     };
     interface HTMLIcSideNavigationElementEventMap {
-        "sideNavExpanded": IcExpandedDetail;
+        "icSideNavExpanded": IcExpandedDetail;
     }
     interface HTMLIcSideNavigationElement extends Components.IcSideNavigation, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIcSideNavigationElementEventMap>(type: K, listener: (this: HTMLIcSideNavigationElement, ev: IcSideNavigationCustomEvent<HTMLIcSideNavigationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -3266,7 +3266,7 @@ declare global {
     interface HTMLIcTopNavigationElementEventMap {
         "icNavigationMenuClosed": void;
         "icNavigationMenuOpened": void;
-        "topNavResized": { size: number };
+        "icTopNavResized": { size: number };
     }
     interface HTMLIcTopNavigationElement extends Components.IcTopNavigation, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIcTopNavigationElementEventMap>(type: K, listener: (this: HTMLIcTopNavigationElement, ev: IcTopNavigationCustomEvent<HTMLIcTopNavigationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5193,7 +5193,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the side navigation is collapsed and expanded.
          */
-        "onSideNavExpanded"?: (event: IcSideNavigationCustomEvent<IcExpandedDetail>) => void;
+        "onIcSideNavExpanded"?: (event: IcSideNavigationCustomEvent<IcExpandedDetail>) => void;
         /**
           * The short title of the app to be displayed at small screen sizes in place of the app title.
          */
@@ -5772,7 +5772,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the top navigation is resized.
          */
-        "onTopNavResized"?: (event: IcTopNavigationCustomEvent<{ size: number }>) => void;
+        "onIcTopNavResized"?: (event: IcTopNavigationCustomEvent<{ size: number }>) => void;
         /**
           * The short title of the app to be displayed at small screen sizes in place of the app title.
          */

--- a/packages/web-components/src/components/ic-badge/ic-badge.css
+++ b/packages/web-components/src/components/ic-badge/ic-badge.css
@@ -30,7 +30,7 @@
 }
 
 :host(.warning) {
-  background-color: var(--ic-status-warning-mid);
+  background-color: var(--ic-status-warning);
 }
 
 :host(.error) {

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -61,12 +61,12 @@ export class NavigationGroup {
   disconnectedCallback(): void {
     if (this.navigationType === "side") {
       this.parentEl.removeEventListener(
-        "sideNavExpanded",
+        "icSideNavExpanded",
         this.sideNavExpandHandler
       );
     } else if (this.navigationType === "top") {
       this.parentEl.removeEventListener(
-        "topNavResized",
+        "icTopNavResized",
         this.topNavResizedHandler
       );
     }
@@ -80,12 +80,12 @@ export class NavigationGroup {
 
     if (this.navigationType === "side") {
       this.parentEl.addEventListener(
-        "sideNavExpanded",
+        "icSideNavExpanded",
         this.sideNavExpandHandler
       );
     } else if (this.navigationType === "top") {
       this.parentEl.addEventListener(
-        "topNavResized",
+        "icTopNavResized",
         this.topNavResizedHandler
       );
       if (

--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.tsx
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.tsx
@@ -122,12 +122,12 @@ export class NavigationItem {
   disconnectedCallback(): void {
     if (this.navigationType === "side") {
       this.parentEl.removeEventListener(
-        "sideNavExpanded",
+        "icSideNavExpanded",
         this.sideNavExpandHandler
       );
     } else if (this.navigationType === "top") {
       this.parentEl.removeEventListener(
-        "topNavResized",
+        "icTopNavResized",
         this.topNavResizedHandler
       );
     }
@@ -141,12 +141,12 @@ export class NavigationItem {
 
     if (this.navigationType === "side") {
       this.parentEl.addEventListener(
-        "sideNavExpanded",
+        "icSideNavExpanded",
         this.sideNavExpandHandler
       );
     } else if (this.navigationType === "top") {
       this.parentEl.addEventListener(
-        "topNavResized",
+        "icTopNavResized",
         this.topNavResizedHandler
       );
       if (this.el.parentElement.tagName === "IC-NAVIGATION-GROUP")

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -15,7 +15,6 @@ import {
   slotHasContent,
   onComponentRequiredPropUndefined,
   removeDisabledFalse,
-  renderHiddenInput,
   checkResizeObserver,
 } from "../../utils/helpers";
 import {
@@ -285,47 +284,52 @@ export class RadioGroup {
   };
 
   render() {
-    renderHiddenInput(
-      true,
-      this.el,
-      this.name,
-      this.checkedValue,
-      this.disabled
-    );
+    const {
+      currentOrientation,
+      disabled,
+      handleKeyDown,
+      helperText,
+      hideLabel,
+      label,
+      required,
+      size,
+      validationStatus,
+      validationText,
+    } = this;
 
     return (
       <Host
-        onKeyDown={this.handleKeyDown}
-        class={{ small: this.small || this.size === "small" }}
+        onKeyDown={handleKeyDown}
+        class={{ small: this.small || size === "small" }}
       >
         <div
           role="radiogroup"
-          aria-label={`${this.label}${this.required ? ", required" : ""}`}
+          aria-label={`${label}${required ? ", required" : ""}`}
         >
-          {!this.hideLabel && (
+          {!hideLabel && (
             <ic-input-label
-              class={{ [`${this.validationStatus}`]: true }}
-              label={this.label}
-              helperText={this.helperText}
-              required={this.required}
-              disabled={this.disabled}
+              class={{ [`${validationStatus}`]: true }}
+              label={label}
+              helperText={helperText}
+              required={required}
+              disabled={disabled}
             ></ic-input-label>
           )}
           <div
             class={{
               "radio-buttons-container": true,
-              horizontal: this.currentOrientation === "horizontal",
+              horizontal: currentOrientation === "horizontal",
             }}
             ref={(el) => (this.radioContainer = el)}
           >
             <slot></slot>
           </div>
         </div>
-        {hasValidationStatus(this.validationStatus, this.disabled) && (
+        {hasValidationStatus(validationStatus, disabled) && (
           <ic-input-validation
             ariaLiveMode="polite"
-            status={this.validationStatus}
-            message={this.validationText}
+            status={validationStatus}
+            message={validationText}
           ></ic-input-validation>
         )}
       </Host>

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -12,7 +12,7 @@ import {
 } from "@stencil/core";
 import {
   hasValidationStatus,
-  isSlotUsed,
+  slotHasContent,
   onComponentRequiredPropUndefined,
   removeDisabledFalse,
   renderHiddenInput,
@@ -277,8 +277,8 @@ export class RadioGroup {
       this.radioOptions !== undefined &&
       (this.radioOptions.length > 2 ||
         (this.radioOptions.length === 2 &&
-          (isSlotUsed(this.radioOptions[0], "additional-field") ||
-            isSlotUsed(this.radioOptions[1], "additional-field"))))
+          (slotHasContent(this.radioOptions[0], "additional-field") ||
+            slotHasContent(this.radioOptions[1], "additional-field"))))
     ) {
       this.currentOrientation = "vertical";
     }

--- a/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
@@ -22,7 +22,6 @@ exports[`ic-radio-group should render as helper text: renders-with-helpertext 1`
       </ic-typography>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
 `;
 
@@ -48,7 +47,6 @@ exports[`ic-radio-group should render as required: renders-required 1`] = `
       </ic-typography>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
 `;
 
@@ -76,7 +74,6 @@ exports[`ic-radio-group should render radio option disabled: renders-disabled 1`
       </ic-typography>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
 `;
 
@@ -126,7 +123,6 @@ exports[`ic-radio-group should render with dynamic additional field: renders-wit
       </div>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
 `;
 
@@ -152,7 +148,6 @@ exports[`ic-radio-group should render with selected option: renders-with-selecte
       </ic-typography>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
 `;
 
@@ -196,7 +191,6 @@ exports[`ic-radio-group should render with selected static additional field: ren
       </div>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
 `;
 
@@ -240,7 +234,6 @@ exports[`ic-radio-group should render with unselected static additional field: r
       </div>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
 `;
 
@@ -267,7 +260,6 @@ exports[`ic-radio-group should render with validation status: renders-with-valid
       </ic-typography>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
 `;
 
@@ -293,7 +285,6 @@ exports[`ic-radio-group should render: renders 1`] = `
       </ic-typography>
     </div>
   </ic-radio-option>
-  <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
 `;
 

--- a/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
@@ -11,17 +11,16 @@ exports[`ic-radio-group should render as helper text: renders-with-helpertext 1`
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input id="ic-radio-option-test-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test-test label"></label>
-        </ic-typography>
+    <!---->
+    <div class="container">
+      <div>
+        <input id="ic-radio-option-test-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-    </mock:shadow-root>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test-test label"></label>
+      </ic-typography>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
@@ -38,17 +37,16 @@ exports[`ic-radio-group should render as required: renders-required 1`] = `
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input id="ic-radio-option-test-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test-test label"></label>
-        </ic-typography>
+    <!---->
+    <div class="container">
+      <div>
+        <input id="ic-radio-option-test-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-    </mock:shadow-root>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test-test label"></label>
+      </ic-typography>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
@@ -65,19 +63,18 @@ exports[`ic-radio-group should render radio option disabled: renders-disabled 1`
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" class="disabled" disabled="" group-label="test group" label="test label" value="test">
-    <mock:shadow-root>
-      <div class="container disabled">
-        <div>
-          <input disabled="" id="ic-radio-option-test label-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test label-test label">
-            test label
-          </label>
-        </ic-typography>
+    <!---->
+    <div class="container disabled">
+      <div>
+        <input disabled="" id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-    </mock:shadow-root>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test label-test label">
+          test label
+        </label>
+      </ic-typography>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
@@ -94,42 +91,40 @@ exports[`ic-radio-group should render with dynamic additional field: renders-wit
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="dynamic" group-label="test group" label="test label" selected="" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input checked="" id="ic-radio-option-test label-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test label-test label">
-            test label
-          </label>
+    <!---->
+    <div class="container">
+      <div>
+        <input checked="" id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
+      </div>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test label-test label">
+          test label
+        </label>
+      </ic-typography>
+    </div>
+    <div class="dynamic-container">
+      <div class="branch-corner"></div>
+      <div>
+        <ic-typography variant="caption">
+          <p class="dynamic-text">
+            This selection requires additional answers
+          </p>
         </ic-typography>
-      </div>
-      <div class="dynamic-container">
-        <div class="branch-corner"></div>
         <div>
-          <ic-typography variant="caption">
-            <p class="dynamic-text">
-              This selection requires additional answers
-            </p>
-          </ic-typography>
-          <div>
-            <slot name="additional-field"></slot>
-          </div>
+          <ic-text-field label="Test label" placeholder="Placeholder" slot="additional-field" value="">
+            <mock:shadow-root>
+              <ic-input-container>
+                <ic-input-label for="ic-text-field-input-2" helpertext="" label="Test label"></ic-input-label>
+                <ic-input-component-container size="default" validationstatus="">
+                  <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-2" inputmode="text" name="ic-text-field-input-2" placeholder="Placeholder" type="text" value="">
+                </ic-input-component-container>
+              </ic-input-container>
+            </mock:shadow-root>
+          </ic-text-field>
         </div>
       </div>
-    </mock:shadow-root>
-    <ic-text-field label="Test label" placeholder="Placeholder" slot="additional-field" value="">
-      <mock:shadow-root>
-        <ic-input-container>
-          <ic-input-label for="ic-text-field-input-2" helpertext="" label="Test label"></ic-input-label>
-          <ic-input-component-container size="default" validationstatus="">
-            <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-2" inputmode="text" name="ic-text-field-input-2" placeholder="Placeholder" type="text" value="">
-          </ic-input-component-container>
-        </ic-input-container>
-      </mock:shadow-root>
-    </ic-text-field>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
@@ -146,17 +141,16 @@ exports[`ic-radio-group should render with selected option: renders-with-selecte
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" selected="" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input checked="" id="ic-radio-option-test-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test-test label"></label>
-        </ic-typography>
+    <!---->
+    <div class="container">
+      <div>
+        <input checked="" id="ic-radio-option-test-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-    </mock:shadow-root>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test-test label"></label>
+      </ic-typography>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
@@ -173,36 +167,34 @@ exports[`ic-radio-group should render with selected static additional field: ren
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" group-label="test group" label="test label" selected="" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input checked="" id="ic-radio-option-test label-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test label-test label">
-            test label
-          </label>
-        </ic-typography>
+    <!---->
+    <div class="container">
+      <div>
+        <input checked="" id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-      <div class="dynamic-container">
-        <div>
-          <div class="additional-field-wrapper">
-            <slot name="additional-field"></slot>
-          </div>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test label-test label">
+          test label
+        </label>
+      </ic-typography>
+    </div>
+    <div class="dynamic-container">
+      <div>
+        <div class="additional-field-wrapper">
+          <ic-text-field label="Test label" placeholder="Placeholder" slot="additional-field" value="">
+            <mock:shadow-root>
+              <ic-input-container>
+                <ic-input-label for="ic-text-field-input-1" helpertext="" label="Test label"></ic-input-label>
+                <ic-input-component-container size="default" validationstatus="">
+                  <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-1" inputmode="text" name="ic-text-field-input-1" placeholder="Placeholder" type="text" value="">
+                </ic-input-component-container>
+              </ic-input-container>
+            </mock:shadow-root>
+          </ic-text-field>
         </div>
       </div>
-    </mock:shadow-root>
-    <ic-text-field label="Test label" placeholder="Placeholder" slot="additional-field" value="">
-      <mock:shadow-root>
-        <ic-input-container>
-          <ic-input-label for="ic-text-field-input-1" helpertext="" label="Test label"></ic-input-label>
-          <ic-input-component-container size="default" validationstatus="">
-            <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-1" inputmode="text" name="ic-text-field-input-1" placeholder="Placeholder" type="text" value="">
-          </ic-input-component-container>
-        </ic-input-container>
-      </mock:shadow-root>
-    </ic-text-field>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
@@ -219,36 +211,34 @@ exports[`ic-radio-group should render with unselected static additional field: r
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" class="disabled" disabled="" group-label="test group" label="test label" value="test">
-    <mock:shadow-root>
-      <div class="container disabled">
-        <div>
-          <input disabled="" id="ic-radio-option-test label-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test label-test label">
-            test label
-          </label>
-        </ic-typography>
+    <!---->
+    <div class="container disabled">
+      <div>
+        <input disabled="" id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-      <div class="dynamic-container">
-        <div>
-          <div class="additional-field-wrapper">
-            <slot name="additional-field"></slot>
-          </div>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test label-test label">
+          test label
+        </label>
+      </ic-typography>
+    </div>
+    <div class="dynamic-container">
+      <div>
+        <div class="additional-field-wrapper">
+          <ic-text-field disabled="" label="Test label" placeholder="Placeholder" slot="additional-field" value="">
+            <mock:shadow-root>
+              <ic-input-container disabled="">
+                <ic-input-label disabled="" for="ic-text-field-input-0" helpertext="" label="Test label"></ic-input-label>
+                <ic-input-component-container disabled="" size="default" validationstatus="">
+                  <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-text-field-input-0" inputmode="text" name="ic-text-field-input-0" placeholder="" type="text" value="">
+                </ic-input-component-container>
+              </ic-input-container>
+            </mock:shadow-root>
+          </ic-text-field>
         </div>
       </div>
-    </mock:shadow-root>
-    <ic-text-field disabled="" label="Test label" placeholder="Placeholder" slot="additional-field" value="">
-      <mock:shadow-root>
-        <ic-input-container disabled="">
-          <ic-input-label disabled="" for="ic-text-field-input-0" helpertext="" label="Test label"></ic-input-label>
-          <ic-input-component-container disabled="" size="default" validationstatus="">
-            <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-text-field-input-0" inputmode="text" name="ic-text-field-input-0" placeholder="" type="text" value="">
-          </ic-input-component-container>
-        </ic-input-container>
-      </mock:shadow-root>
-    </ic-text-field>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
@@ -266,17 +256,16 @@ exports[`ic-radio-group should render with validation status: renders-with-valid
     <ic-input-validation arialivemode="polite" message="error" status="error"></ic-input-validation>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" selected="" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input checked="" id="ic-radio-option-test-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test-test label"></label>
-        </ic-typography>
+    <!---->
+    <div class="container">
+      <div>
+        <input checked="" id="ic-radio-option-test-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-    </mock:shadow-root>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test-test label"></label>
+      </ic-typography>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="test">
 </ic-radio-group>
@@ -293,17 +282,16 @@ exports[`ic-radio-group should render: renders 1`] = `
     </div>
   </mock:shadow-root>
   <ic-radio-option additional-field-display="static" value="test">
-    <mock:shadow-root>
-      <div class="container">
-        <div>
-          <input id="ic-radio-option-test-test label" name="test" role="radio" tabindex="0" type="radio" value="test">
-          <span class="checkmark"></span>
-        </div>
-        <ic-typography class="radio-label" variant="body">
-          <label htmlfor="ic-radio-option-test-test label"></label>
-        </ic-typography>
+    <!---->
+    <div class="container">
+      <div>
+        <input id="ic-radio-option-test-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
       </div>
-    </mock:shadow-root>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test-test label"></label>
+      </ic-typography>
+    </div>
   </ic-radio-option>
   <input class="ic-input" name="test" type="hidden" value="">
 </ic-radio-group>
@@ -311,18 +299,17 @@ exports[`ic-radio-group should render: renders 1`] = `
 
 exports[`ic-radio-group should test radio option as submit on form 1`] = `
 <ic-radio-option additional-field-display="static" form="new-form" id="ic-radio-option" label="IC Radio Test" selected="" value="test-value">
-  <mock:shadow-root>
-    <div class="container">
-      <div>
-        <input checked="" form="new-form" id="ic-radio-option-IC Radio Test-undefined" role="radio" tabindex="0" type="radio" value="test-value">
-        <span class="checkmark"></span>
-      </div>
-      <ic-typography class="radio-label" variant="body">
-        <label htmlfor="ic-radio-option-IC Radio Test-undefined">
-          IC Radio Test
-        </label>
-      </ic-typography>
+  <!---->
+  <div class="container">
+    <div>
+      <input checked="" form="new-form" id="ic-radio-option-IC Radio Test-undefined" tabindex="0" type="radio" value="test-value">
+      <span class="checkmark"></span>
     </div>
-  </mock:shadow-root>
+    <ic-typography class="radio-label" variant="body">
+      <label htmlfor="ic-radio-option-IC Radio Test-undefined">
+        IC Radio Test
+      </label>
+    </ic-typography>
+  </div>
 </ic-radio-option>
 `;

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.e2e.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.e2e.ts
@@ -15,10 +15,10 @@ describe("ic-radio-group component", () => {
     await page.waitForChanges();
 
     const radioButton1 = await page.find("ic-radio-option[value='test1']");
-    const input1 = radioButton1.shadowRoot.querySelector("input");
+    const input1 = await radioButton1.find("input");
 
     const radioButton2 = await page.find("ic-radio-option[value='test2']");
-    const input2 = radioButton2.shadowRoot.querySelector("input");
+    const input2 = await radioButton2.find("input");
 
     expect(input1.tabIndex).toBe(0);
     expect(input2.tabIndex).toBe(-1);
@@ -50,7 +50,7 @@ describe("ic-radio-group component", () => {
     expect(await radioButton.getProperty("selected")).toBe(true);
 
     radioButton = await page.find("ic-radio-option[value='test2']");
-    const input = radioButton.shadowRoot.querySelector("input");
+    const input = await radioButton.find("input");
     expect(input.tabIndex).toBe(0);
   });
   it("should enable textfield when associated option is selected when static", async () => {
@@ -90,9 +90,9 @@ describe("ic-radio-group component", () => {
     const radioButton = await page.find("ic-radio-option[value='test2']");
 
     let additionalFieldDisplay = await page.evaluate(() => {
-      const additionalField = document
-        .querySelector("ic-radio-option[value='test2']")
-        .shadowRoot.querySelector(".dynamic-container");
+      const additionalField = document.querySelector(
+        "ic-radio-option[value='test2'] .dynamic-container"
+      );
 
       return window.getComputedStyle(additionalField).display;
     });
@@ -102,9 +102,9 @@ describe("ic-radio-group component", () => {
     await page.waitForChanges();
 
     additionalFieldDisplay = await page.evaluate(() => {
-      const additionalField = document
-        .querySelector("ic-radio-option[value='test2']")
-        .shadowRoot.querySelector(".dynamic-container");
+      const additionalField = document.querySelector(
+        "ic-radio-option[value='test2'] .dynamic-container"
+      );
 
       return window.getComputedStyle(additionalField).display;
     });
@@ -171,7 +171,7 @@ describe("ic-radio-group component", () => {
     await page.waitForChanges();
 
     expect(await radioButton.getProperty("selected")).toBe(true);
-    const input = radioButton.shadowRoot.querySelector("input");
+    const input = await radioButton.find("input");
     expect(input.tabIndex).toBe(0);
   });
   it("should select next radio option down when arrow down is used", async () => {
@@ -191,7 +191,7 @@ describe("ic-radio-group component", () => {
     await radioButton1.press("ArrowDown");
     await page.waitForChanges();
 
-    const input = radioButton2.shadowRoot.querySelector("input");
+    const input = await radioButton2.find("input");
     expect(input.tabIndex).toBe(0);
   });
   it("should select next radio option down when arrow right is used", async () => {
@@ -211,7 +211,7 @@ describe("ic-radio-group component", () => {
     await radioButton1.press("ArrowRight");
     await page.waitForChanges();
 
-    const input = radioButton2.shadowRoot.querySelector("input");
+    const input = await radioButton2.find("input");
     expect(input.tabIndex).toBe(0);
   });
   it("should select next radio option down when arrow up is used", async () => {
@@ -232,7 +232,7 @@ describe("ic-radio-group component", () => {
     await radioButton2.press("ArrowUp");
     await page.waitForChanges();
 
-    const input = radioButton1.shadowRoot.querySelector("input");
+    const input = await radioButton1.find("input");
     expect(input.tabIndex).toBe(0);
   });
   it("should select next radio option down when arrow left is used", async () => {
@@ -253,7 +253,7 @@ describe("ic-radio-group component", () => {
     await radioButton2.press("ArrowLeft");
     await page.waitForChanges();
 
-    const input = radioButton1.shadowRoot.querySelector("input");
+    const input = await radioButton1.find("input");
     expect(input.tabIndex).toBe(0);
   });
   it("shold works in a form", async () => {
@@ -306,8 +306,8 @@ describe("ic-radio-group component", () => {
     await page.waitForChanges();
 
     const value = await (
-      await page.find('input[name="test"]')
-    ).getProperty("value");
+      await page.findAll('input[name="test"]')
+    )[1].getProperty("value");
 
     expect(value).toBe("test2");
   });
@@ -340,8 +340,8 @@ describe("ic-radio-group component", () => {
     await page.waitForChanges();
 
     let value = await (
-      await page.find('input[name="test"]')
-    ).getProperty("value");
+      await page.findAll('input[name="test"]')
+    )[1].getProperty("value");
 
     expect(value).toBe("test");
 
@@ -352,7 +352,9 @@ describe("ic-radio-group component", () => {
 
     await page.waitForChanges();
 
-    value = await (await page.find('input[name="test"]')).getProperty("value");
+    value = await (
+      await page.findAll('input[name="test"]')
+    )[1].getProperty("value");
 
     expect(value).toBe("test2");
   });
@@ -376,8 +378,8 @@ describe("ic-radio-group component", () => {
     await page.waitForChanges();
 
     const value = await (
-      await page.find('input[name="test"]')
-    ).getProperty("value");
+      await page.findAll('input[name="test"]')
+    )[1].getProperty("value");
 
     expect(value).toBe("testValue1");
   });

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
@@ -197,9 +197,7 @@ describe("ic-radio-group", () => {
     });
 
     const div =
-      page.rootInstance.radioOptions[1].shadowRoot.querySelector(
-        ".dynamic-container"
-      );
+      page.rootInstance.radioOptions[1].querySelector(".dynamic-container");
     div.click();
     await page.waitForChanges();
 

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
@@ -1,18 +1,18 @@
 @import "../../global/normalize.css";
 
-:host {
+ic-radio-option {
   display: flex;
   flex-direction: column;
   width: fit-content;
 }
 
-:host([additional-field-display="static"]) ::slotted(ic-text-field) {
+.additional-field-wrapper ic-text-field {
   margin-top: calc(var(--ic-space-sm) / 2);
   margin-left: var(--ic-space-xl);
 }
 
 /* The label turns grey when disabled  */
-:host(.disabled) {
+.disabled {
   color: var(--ic-architectural-200);
 }
 
@@ -182,7 +182,7 @@
 }
 
 @media (max-width: 576px) {
-  ::slotted(ic-text-field) {
+  ic-text-field {
     --input-width: 100%;
   }
 }

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
@@ -19,6 +19,7 @@ import {
   removeDisabledFalse,
   isPropDefined,
   isSlotUsed,
+  slotHasContent,
 } from "../../utils/helpers";
 
 const ADDITIONAL_FIELD = "additional-field";
@@ -30,9 +31,6 @@ const TEXT_FIELD_SELECTOR = "ic-text-field";
 @Component({
   tag: "ic-radio-option",
   styleUrl: "ic-radio-option.css",
-  shadow: {
-    delegatesFocus: true,
-  },
 })
 export class RadioOption {
   private defaultRadioValue: string = "";
@@ -160,7 +158,7 @@ export class RadioOption {
   }
 
   componentWillRender(): void {
-    const hasSlot = isSlotUsed(this.el, ADDITIONAL_FIELD);
+    const hasSlot = slotHasContent(this.el, ADDITIONAL_FIELD);
     if (hasSlot && !this.hasAdditionalField) {
       this.hasAdditionalField = true;
       const textField = this.el.querySelector(TEXT_FIELD_SELECTOR);
@@ -269,10 +267,9 @@ export class RadioOption {
 
     return (
       <Host onClick={handleClick} class={{ disabled }}>
-        <div class={{ ["container"]: true, disabled }}>
+        <div class={{ container: true, disabled }}>
           <div>
             <input
-              role="radio"
               tabindex={selected ? "0" : "-1"}
               type="radio"
               name={name}

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.stories.mdx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.stories.mdx
@@ -2251,7 +2251,7 @@ import readme from "./readme.md";
   >
     {html`<script>
         var sideNav = document.querySelector("ic-side-navigation");
-        sideNav.addEventListener("sideNavExpanded", function (event) {
+        sideNav.addEventListener("icSideNavExpanded", function (event) {
           console.log(event.detail.sideNavExpanded);
         });
       </script>

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -126,7 +126,7 @@ export class SideNavigation {
   /**
    * Emitted when the side navigation is collapsed and expanded.
    */
-  @Event() sideNavExpanded: EventEmitter<IcExpandedDetail>;
+  @Event() icSideNavExpanded: EventEmitter<IcExpandedDetail>;
 
   componentWillLoad(): void {
     this.setMenuExpanded(this.expanded);
@@ -176,7 +176,7 @@ export class SideNavigation {
     sideNavExpanded: boolean;
     sideNavMobile?: boolean;
   }): void => {
-    this.sideNavExpanded.emit({
+    this.icSideNavExpanded.emit({
       sideNavExpanded: objDetails.sideNavExpanded,
       sideNavMobile: objDetails.sideNavMobile,
     });

--- a/packages/web-components/src/components/ic-side-navigation/readme.md
+++ b/packages/web-components/src/components/ic-side-navigation/readme.md
@@ -23,9 +23,9 @@
 
 ## Events
 
-| Event             | Description                                                 | Type                            |
-| ----------------- | ----------------------------------------------------------- | ------------------------------- |
-| `sideNavExpanded` | Emitted when the side navigation is collapsed and expanded. | `CustomEvent<IcExpandedDetail>` |
+| Event               | Description                                                 | Type                            |
+| ------------------- | ----------------------------------------------------------- | ------------------------------- |
+| `icSideNavExpanded` | Emitted when the side navigation is collapsed and expanded. | `CustomEvent<IcExpandedDetail>` |
 
 
 ## Slots

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.mdx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.mdx
@@ -923,7 +923,7 @@ import NavigationGroup from "../ic-navigation-group/readme.md";
     {(args) =>
       html`<script>
           var topNav = document.querySelector("ic-top-navigation");
-          topNav.addEventListener("topNavResized", function (event) {
+          topNav.addEventListener("icTopNavResized", function (event) {
             console.log(event.detail.size);
           });
         </script>

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -131,7 +131,7 @@ export class TopNavigation {
   /**
    * Emitted when the top navigation is resized.
    */
-  @Event() topNavResized: EventEmitter<{ size: number }>;
+  @Event() icTopNavResized: EventEmitter<{ size: number }>;
 
   disconnectedCallback(): void {
     this.resizeObserver?.disconnect();
@@ -254,7 +254,7 @@ export class TopNavigation {
           this.toggleSearchBar();
         }
       }
-      this.topNavResized.emit({
+      this.icTopNavResized.emit({
         size: currSize,
       });
       if (this.searchBar && document.activeElement === this.searchBar) {

--- a/packages/web-components/src/components/ic-top-navigation/readme.md
+++ b/packages/web-components/src/components/ic-top-navigation/readme.md
@@ -21,9 +21,9 @@
 
 ## Events
 
-| Event           | Description                                 | Type                             |
-| --------------- | ------------------------------------------- | -------------------------------- |
-| `topNavResized` | Emitted when the top navigation is resized. | `CustomEvent<{ size: number; }>` |
+| Event             | Description                                 | Type                             |
+| ----------------- | ------------------------------------------- | -------------------------------- |
+| `icTopNavResized` | Emitted when the top navigation is resized. | `CustomEvent<{ size: number; }>` |
 
 
 ## Slots

--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -202,15 +202,6 @@
   --ic-status-unknown: var(--ic-architectural-500);
   --ic-status-unknown-dark: var(--ic-architectural-800);
 
-  /* deprecated status */
-  --ic-status-warning-mid: var(--ic-status-warning);
-  --ic-status-warning-mid-hover: var(--ic-status-warning-hover);
-  --ic-status-warning-mid-pressed: var(--ic-status-warning-pressed);
-  --ic-status-success-background: var(--ic-status-success-light);
-  --ic-status-warning-background: var(--ic-status-warning-light);
-  --ic-status-error-background: var(--ic-status-error-light);
-  --ic-status-info-background: var(--ic-status-info-light);
-
   /* architectural */
   --ic-architectural-20: #f9fafa;
   --ic-architectural-40: #f4f4f5;


### PR DESCRIPTION
## Summary of the changes
Update sideNavExpanded and topNavResized events to be prefixed with "ic".

## Related issue
#1354 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.