### PR TITLE
fix(canary-react): fixes test threshold issue

### DIFF
--- a/packages/canary-react/src/component-tests/IcDatePicker/IcDatePicker.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDatePicker/IcDatePicker.cy.tsx
@@ -1053,7 +1053,7 @@ describe("IcDatePickers", () => {
 
     cy.compareSnapshot({
       name: "escape-pressed-in-input",
-      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.002),
     });
   });
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Increases threshold for failing datepicker test

## Related issue
N/A

