### PR TITLE
fix(web-components): remove aria-hidden in see more/less buttons

### DIFF
--- a/packages/react/src/component-tests/IcTypography/IcTypography.cy.tsx
+++ b/packages/react/src/component-tests/IcTypography/IcTypography.cy.tsx
@@ -132,7 +132,7 @@ describe("IcTypography visual regression and a11y tests", () => {
 
     cy.checkHydrated(TYPOGRAPHY_SELECTOR);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "truncation",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.071),
@@ -145,7 +145,7 @@ describe("IcTypography visual regression and a11y tests", () => {
     cy.checkHydrated(TYPOGRAPHY_SELECTOR);
     cy.findShadowEl(TYPOGRAPHY_SELECTOR, ".trunc-btn").click();
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "truncation-expanded",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.164),

--- a/packages/web-components/src/components/ic-typography/ic-typography.tsx
+++ b/packages/web-components/src/components/ic-typography/ic-typography.tsx
@@ -203,7 +203,6 @@ export class Typography {
             onBlur={this.truncButtonBlur}
             onMouseDown={this.truncButtonFocusFromMouse}
             onClick={this.toggleExpanded}
-            aria-hidden="true"
           >
             {expanded ? "See less" : "See more"}
           </button>

--- a/packages/web-components/src/components/ic-typography/test/basic/__snapshots__/ic-typography.spec.ts.snap
+++ b/packages/web-components/src/components/ic-typography/test/basic/__snapshots__/ic-typography.spec.ts.snap
@@ -182,7 +182,7 @@ exports[`ic-typography component should render the typography with truncation 2`
     <div class="trunc-wrapper">
       <slot></slot>
     </div>
-    <button aria-hidden="true" class="trunc-btn">
+    <button class="trunc-btn">
       See more
     </button>
   </mock:shadow-root>


### PR DESCRIPTION
## Summary of the changes
Removes aria hidden attribute and enables skipped a11y tests in ic -typography.

## Related issue
Fixes #1854

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.