### PR TITLE
fix(web-components): set heading levels on Hero component

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2024-07-12T08:47:25",
+  "timestamp": "2024-07-15T08:50:42",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.10.0",
@@ -10,7 +10,7 @@
       "filePath": "src/components/ic-accordion/ic-accordion.tsx",
       "encapsulation": "shadow",
       "tag": "ic-accordion",
-      "readme": "# ic-accordion\n\n\n",
+      "readme": "# ic-accordion\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -202,7 +202,7 @@
       "filePath": "src/components/ic-accordion-group/ic-accordion-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-accordion-group",
-      "readme": "# ic-accordion-title\n\n\n",
+      "readme": "# ic-accordion-title\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -395,7 +395,7 @@
           },
           "signature": "setFocus() => Promise<void>",
           "parameters": [],
-          "docs": "Sets the focus on first focusable element in the accordion group. If the \"See/Hide all\" button is present, it will be focused.\nOtherwise, the first accordion will be focused.",
+          "docs": "Sets the focus on first focusable element in the accordion group. If the \"See/Hide all\" button is present, it will be focused.\r\nOtherwise, the first accordion will be focused.",
           "docsTags": []
         }
       ],
@@ -441,7 +441,7 @@
       "filePath": "src/components/ic-alert/ic-alert.tsx",
       "encapsulation": "shadow",
       "tag": "ic-alert",
-      "readme": "# ic-alert\n\n\n",
+      "readme": "# ic-alert\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -697,7 +697,7 @@
       "filePath": "src/components/ic-back-to-top/ic-back-to-top.tsx",
       "encapsulation": "shadow",
       "tag": "ic-back-to-top",
-      "readme": "# ic-back-to-top\n\n\n",
+      "readme": "# ic-back-to-top\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -788,7 +788,7 @@
       "filePath": "src/components/ic-badge/ic-badge.tsx",
       "encapsulation": "shadow",
       "tag": "ic-badge",
-      "readme": "# ic-badge\n\n\n",
+      "readme": "# ic-badge\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -836,7 +836,7 @@
           "mutable": false,
           "attr": "custom-color",
           "reflectToAttr": false,
-          "docs": "The custom badge colour. This will only style the badge component if variant=\"custom\".\nCan be a hex value e.g. \"#ff0000\", RGB e.g. \"rgb(255, 0, 0)\", or RGBA e.g. \"rgba(255, 0, 0, 1)\".",
+          "docs": "The custom badge colour. This will only style the badge component if variant=\"custom\".\r\nCan be a hex value e.g. \"#ff0000\", RGB e.g. \"rgb(255, 0, 0)\", or RGBA e.g. \"rgba(255, 0, 0, 1)\".",
           "docsTags": [],
           "default": "null",
           "values": [
@@ -885,7 +885,7 @@
           "mutable": false,
           "attr": "max-number",
           "reflectToAttr": false,
-          "docs": "The maximum number shown on the badge appended with a +.\nThis will only be displayed if type=\"text\" and label is not empty.",
+          "docs": "The maximum number shown on the badge appended with a +.\r\nThis will only be displayed if type=\"text\" and label is not empty.",
           "docsTags": [],
           "values": [
             {
@@ -1164,7 +1164,7 @@
       "filePath": "src/components/ic-breadcrumb/ic-breadcrumb.tsx",
       "encapsulation": "shadow",
       "tag": "ic-breadcrumb",
-      "readme": "# ic-breadcrumb\n\n\n",
+      "readme": "# ic-breadcrumb\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -1292,7 +1292,7 @@
       "filePath": "src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-breadcrumb-group",
-      "readme": "# ic-breadcrumb-group\n\n\n",
+      "readme": "# ic-breadcrumb-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -1402,7 +1402,7 @@
       "filePath": "src/components/ic-button/ic-button.tsx",
       "encapsulation": "shadow",
       "tag": "ic-button",
-      "readme": "# ic-button\n",
+      "readme": "# ic-button\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -2414,7 +2414,7 @@
       "filePath": "src/components/ic-card/ic-card.tsx",
       "encapsulation": "shadow",
       "tag": "ic-card",
-      "readme": "# ic-card\n\n\n",
+      "readme": "# ic-card\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -2865,7 +2865,7 @@
       "filePath": "src/components/ic-checkbox/ic-checkbox.tsx",
       "encapsulation": "shadow",
       "tag": "ic-checkbox",
-      "readme": "# ic-checkbox\n\n\n",
+      "readme": "# ic-checkbox\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -3402,7 +3402,7 @@
       "filePath": "src/components/ic-checkbox-group/ic-checkbox-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-checkbox-group",
-      "readme": "# ic-checkbox-group\n\n\n",
+      "readme": "# ic-checkbox-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -3725,7 +3725,7 @@
       "filePath": "src/components/ic-chip/ic-chip.tsx",
       "encapsulation": "shadow",
       "tag": "ic-chip",
-      "readme": "# ic-chip\n\n\n",
+      "readme": "# ic-chip\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -4067,7 +4067,7 @@
       "filePath": "src/components/ic-classification-banner/ic-classification-banner.tsx",
       "encapsulation": "shadow",
       "tag": "ic-classification-banner",
-      "readme": "# ic-classification-banner\n\n\n",
+      "readme": "# ic-classification-banner\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -4232,7 +4232,7 @@
       "filePath": "src/components/ic-data-list/ic-data-list.tsx",
       "encapsulation": "shadow",
       "tag": "ic-data-list",
-      "readme": "# ic-data-list\n\n\n",
+      "readme": "# ic-data-list\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -4350,7 +4350,7 @@
       "filePath": "src/components/ic-data-row/ic-data-row.tsx",
       "encapsulation": "shadow",
       "tag": "ic-data-row",
-      "readme": "# ic-data-row\n\n\n",
+      "readme": "# ic-data-row\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -4505,7 +4505,7 @@
       "filePath": "src/components/ic-dialog/ic-dialog.tsx",
       "encapsulation": "shadow",
       "tag": "ic-dialog",
-      "readme": "# ic-dialog\n\n\n",
+      "readme": "# ic-dialog\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -4593,7 +4593,7 @@
           "reflectToAttr": false,
           "docs": "Sets the label and onclick functions for default buttons.",
           "docsTags": [],
-          "default": "[\n    {\n      label: \"Cancel\",\n      onclick: \"this.cancelDialog();\",\n    },\n    { label: \"Confirm\", onclick: \"this.confirmDialog();\" },\n  ]",
+          "default": "[\r\n    {\r\n      label: \"Cancel\",\r\n      onclick: \"this.cancelDialog();\",\r\n    },\r\n    { label: \"Confirm\", onclick: \"this.confirmDialog();\" },\r\n  ]",
           "values": [
             {
               "type": "{ label: string; onclick: string; }[]"
@@ -4679,7 +4679,7 @@
           "mutable": false,
           "attr": "disable-height-constraint",
           "reflectToAttr": false,
-          "docs": "If set to `true`, the content area max height and overflow properties are removed allowing the dialog to stretch below the fold.\nThis prop also prevents popover elements from being cut off within the content area.",
+          "docs": "If set to `true`, the content area max height and overflow properties are removed allowing the dialog to stretch below the fold.\r\nThis prop also prevents popover elements from being cut off within the content area.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -5127,7 +5127,7 @@
       "filePath": "src/components/ic-divider/ic-divider.tsx",
       "encapsulation": "scoped",
       "tag": "ic-divider",
-      "readme": "# ic-divider\n\n\n",
+      "readme": "# ic-divider\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -5159,7 +5159,7 @@
       "filePath": "src/components/ic-empty-state/ic-empty-state.tsx",
       "encapsulation": "shadow",
       "tag": "ic-empty-state",
-      "readme": "# ic-empty-state\n\n\n",
+      "readme": "# ic-empty-state\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -5385,7 +5385,7 @@
       "filePath": "src/components/ic-footer/ic-footer.tsx",
       "encapsulation": "shadow",
       "tag": "ic-footer",
-      "readme": "# ic-footer\n\n\n",
+      "readme": "# ic-footer\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -5622,7 +5622,7 @@
       "filePath": "src/components/ic-footer-link/ic-footer-link.tsx",
       "encapsulation": "shadow",
       "tag": "ic-footer-link",
-      "readme": "# ic-footer-link\n\n\n",
+      "readme": "# ic-footer-link\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -5823,7 +5823,7 @@
       "filePath": "src/components/ic-footer-link-group/ic-footer-link-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-footer-link-group",
-      "readme": "# ic-footer-link-group\n\n\n",
+      "readme": "# ic-footer-link-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -5885,7 +5885,7 @@
       "filePath": "src/components/ic-hero/ic-hero.tsx",
       "encapsulation": "shadow",
       "tag": "ic-hero",
-      "readme": "# ic-hero\n\n\n",
+      "readme": "# ic-hero\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -6031,7 +6031,7 @@
           "mutable": false,
           "attr": "heading",
           "reflectToAttr": false,
-          "docs": "The heading of the hero.",
+          "docs": "The heading of the hero. An <h2> level heading.",
           "docsTags": [],
           "values": [
             {
@@ -6052,7 +6052,7 @@
           "mutable": false,
           "attr": "secondary-heading",
           "reflectToAttr": false,
-          "docs": "The optional secondary heading, replaced by slotted right content.",
+          "docs": "The optional secondary heading, an <h3> level heading. Replaced by slotted right content.",
           "docsTags": [],
           "values": [
             {
@@ -6111,34 +6111,6 @@
             {
               "value": "small",
               "type": "string"
-            }
-          ],
-          "optional": true,
-          "required": false
-        },
-        {
-          "name": "small",
-          "type": "boolean",
-          "complexType": {
-            "original": "boolean",
-            "resolved": "boolean",
-            "references": {}
-          },
-          "mutable": false,
-          "attr": "small",
-          "reflectToAttr": false,
-          "docs": "",
-          "docsTags": [
-            {
-              "name": "deprecated",
-              "text": "This prop should not be used anymore. Set prop `size` to \"small\" instead."
-            }
-          ],
-          "default": "false",
-          "deprecation": "This prop should not be used anymore. Set prop `size` to \"small\" instead.",
-          "values": [
-            {
-              "type": "boolean"
             }
           ],
           "optional": true,
@@ -6218,7 +6190,7 @@
       "filePath": "src/components/ic-horizontal-scroll/ic-horizontal-scroll.tsx",
       "encapsulation": "shadow",
       "tag": "ic-horizontal-scroll",
-      "readme": "# ic-horizontal-scroll\n\n\n",
+      "readme": "# ic-horizontal-scroll\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -6304,7 +6276,7 @@
       "filePath": "src/components/ic-input-component-container/ic-input-component-container.tsx",
       "encapsulation": "none",
       "tag": "ic-input-component-container",
-      "readme": "# ic-input-container\n\n\n",
+      "readme": "# ic-input-container\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -6620,7 +6592,7 @@
       "filePath": "src/components/ic-input-container/ic-input-container.tsx",
       "encapsulation": "none",
       "tag": "ic-input-container",
-      "readme": "# ic-input-container\n\n\n",
+      "readme": "# ic-input-container\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -6694,7 +6666,7 @@
       "filePath": "src/components/ic-input-label/ic-input-label.tsx",
       "encapsulation": "none",
       "tag": "ic-input-label",
-      "readme": "# ic-input-label\n\n\n",
+      "readme": "# ic-input-label\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -6952,7 +6924,7 @@
       "filePath": "src/components/ic-input-validation/ic-input-validation.tsx",
       "encapsulation": "none",
       "tag": "ic-input-validation",
-      "readme": "# ic-input-validation\n\n\n",
+      "readme": "# ic-input-validation\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -7142,7 +7114,7 @@
       "filePath": "src/components/ic-link/ic-link.tsx",
       "encapsulation": "shadow",
       "tag": "ic-link",
-      "readme": "# ic-link\n\n\n",
+      "readme": "# ic-link\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -7440,7 +7412,7 @@
       "filePath": "src/components/ic-loading-indicator/ic-loading-indicator.tsx",
       "encapsulation": "shadow",
       "tag": "ic-loading-indicator",
-      "readme": "# ic-loading\n\n\n",
+      "readme": "# ic-loading\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -7533,7 +7505,7 @@
           "mutable": false,
           "attr": "label",
           "reflectToAttr": false,
-          "docs": "The label to be displayed beneath the loading indicator.\nDisplay a changing label by separating multiple messages with forward slashes.",
+          "docs": "The label to be displayed beneath the loading indicator.\r\nDisplay a changing label by separating multiple messages with forward slashes.",
           "docsTags": [],
           "values": [
             {
@@ -7576,7 +7548,7 @@
           "mutable": false,
           "attr": "max",
           "reflectToAttr": false,
-          "docs": "The maximum value that the progress value can take.\nUsed to calculate the proportional width of the progress bar.",
+          "docs": "The maximum value that the progress value can take.\r\nUsed to calculate the proportional width of the progress bar.",
           "docsTags": [],
           "default": "100",
           "values": [
@@ -7598,7 +7570,7 @@
           "mutable": false,
           "attr": "min",
           "reflectToAttr": false,
-          "docs": "The minimum value that the progress value can take.\nUsed to calculate the proportional width of the progress bar.",
+          "docs": "The minimum value that the progress value can take.\r\nUsed to calculate the proportional width of the progress bar.",
           "docsTags": [],
           "default": "0",
           "values": [
@@ -7620,7 +7592,7 @@
           "mutable": false,
           "attr": "progress",
           "reflectToAttr": false,
-          "docs": "The current amount of progress made.\nIf not provided, component acts as an indeterminate loading indicator.",
+          "docs": "The current amount of progress made.\r\nIf not provided, component acts as an indeterminate loading indicator.",
           "docsTags": [],
           "values": [
             {
@@ -7753,7 +7725,7 @@
       "filePath": "src/components/ic-menu/ic-menu.tsx",
       "encapsulation": "scoped",
       "tag": "ic-menu",
-      "readme": "# ic-menu\n\n\n",
+      "readme": "# ic-menu\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -8152,7 +8124,7 @@
               "docs": "The keyboard event which is available when handleKeyboardOpen is invoked."
             }
           ],
-          "docs": "Used alongside activationType\nIf menu is opened via keyboard navigation (i.e. Enter, ArrowUp or ArrowDown), emit optionSelect custom event.",
+          "docs": "Used alongside activationType\r\nIf menu is opened via keyboard navigation (i.e. Enter, ArrowUp or ArrowDown), emit optionSelect custom event.",
           "docsTags": [
             {
               "name": "param",
@@ -8209,7 +8181,7 @@
       "filePath": "src/components/ic-menu-group/ic-menu-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-menu-group",
-      "readme": "# ic-menu-group\n\n\n",
+      "readme": "# ic-menu-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -8256,7 +8228,7 @@
       "filePath": "src/components/ic-menu-item/ic-menu-item.tsx",
       "encapsulation": "shadow",
       "tag": "ic-menu-item",
-      "readme": "# ic-menu-item\n\n\n",
+      "readme": "# ic-menu-item\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -8600,7 +8572,7 @@
       "filePath": "src/components/ic-navigation-button/ic-navigation-button.tsx",
       "encapsulation": "shadow",
       "tag": "ic-navigation-button",
-      "readme": "# ic-navigation-button\n\n\n",
+      "readme": "# ic-navigation-button\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -8884,7 +8856,7 @@
       "filePath": "src/components/ic-navigation-group/ic-navigation-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-navigation-group",
-      "readme": "# ic-navigation-group\n\n\n",
+      "readme": "# ic-navigation-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -8999,7 +8971,7 @@
       "filePath": "src/components/ic-navigation-item/ic-navigation-item.tsx",
       "encapsulation": "shadow",
       "tag": "ic-navigation-item",
-      "readme": "# ic-navigation-item\n\n\n",
+      "readme": "# ic-navigation-item\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -9304,7 +9276,7 @@
       "filePath": "src/components/ic-navigation-menu/ic-navigation-menu.tsx",
       "encapsulation": "shadow",
       "tag": "ic-navigation-menu",
-      "readme": "# ic-navigation-menu\n\n\n",
+      "readme": "# ic-navigation-menu\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -9427,7 +9399,7 @@
       "filePath": "src/components/ic-page-header/ic-page-header.tsx",
       "encapsulation": "shadow",
       "tag": "ic-page-header",
-      "readme": "# ic-page-header\n\n\n",
+      "readme": "# ic-page-header\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -9770,7 +9742,7 @@
       "filePath": "src/components/ic-pagination/ic-pagination.tsx",
       "encapsulation": "shadow",
       "tag": "ic-pagination",
-      "readme": "# ic-pagination\n\n\n",
+      "readme": "# ic-pagination\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -10145,7 +10117,7 @@
       "filePath": "src/components/ic-pagination-item/ic-pagination-item.tsx",
       "encapsulation": "shadow",
       "tag": "ic-pagination-item",
-      "readme": "# ic-pagination-item\n\n\n",
+      "readme": "# ic-pagination-item\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -10336,7 +10308,7 @@
       "filePath": "src/components/ic-popover-menu/ic-popover-menu.tsx",
       "encapsulation": "shadow",
       "tag": "ic-popover-menu",
-      "readme": "# ic-popover-menu\n\nThis is a wrapper component to be placed around one or more ic-menu-item components.\n",
+      "readme": "# ic-popover-menu\r\n\r\nThis is a wrapper component to be placed around one or more ic-menu-item components.\r\n\r",
       "docs": "This is a wrapper component to be placed around one or more ic-menu-item components.",
       "docsTags": [],
       "usage": {},
@@ -10495,7 +10467,7 @@
       "filePath": "src/components/ic-radio-group/ic-radio-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-radio-group",
-      "readme": "# ic-radio-group\n\n\n",
+      "readme": "# ic-radio-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -10846,7 +10818,7 @@
       "filePath": "src/components/ic-radio-option/ic-radio-option.tsx",
       "encapsulation": "none",
       "tag": "ic-radio-option",
-      "readme": "# ic-radio-option\n\n\n",
+      "readme": "# ic-radio-option\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -11281,7 +11253,7 @@
       "filePath": "src/components/ic-search-bar/ic-search-bar.tsx",
       "encapsulation": "shadow",
       "tag": "ic-search-bar",
-      "readme": "# ic-search-bar\n\n\n",
+      "readme": "# ic-search-bar\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -11319,7 +11291,7 @@
           "mutable": false,
           "attr": "autocapitalize",
           "reflectToAttr": false,
-          "docs": "The automatic capitalisation of the text value as it is entered/edited by the user.\nAvailable options: \"off\", \"none\", \"on\", \"sentences\", \"words\", \"characters\".",
+          "docs": "The automatic capitalisation of the text value as it is entered/edited by the user.\r\nAvailable options: \"off\", \"none\", \"on\", \"sentences\", \"words\", \"characters\".",
           "docsTags": [],
           "default": "\"off\"",
           "values": [
@@ -11681,7 +11653,7 @@
           "mutable": false,
           "attr": "disable-auto-filtering",
           "reflectToAttr": false,
-          "docs": "Specify whether to disable the built in filtering. For example, if options will already be filtered from external source.\nIf `true`, all options provided will be displayed.",
+          "docs": "Specify whether to disable the built in filtering. For example, if options will already be filtered from external source.\r\nIf `true`, all options provided will be displayed.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -11769,7 +11741,7 @@
           "mutable": false,
           "attr": "full-width",
           "reflectToAttr": false,
-          "docs": "Specify whether the search bar fills the full width of the container.\nIf `true`, this overrides the --input-width CSS variable.",
+          "docs": "Specify whether the search bar fills the full width of the container.\r\nIf `true`, this overrides the --input-width CSS variable.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -12543,7 +12515,7 @@
       "filePath": "src/components/ic-section-container/ic-section-container.tsx",
       "encapsulation": "shadow",
       "tag": "ic-section-container",
-      "readme": "# ic-section-container\n\n\n",
+      "readme": "# ic-section-container\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -12644,7 +12616,7 @@
       "filePath": "src/components/ic-select/ic-select.tsx",
       "encapsulation": "shadow",
       "tag": "ic-select",
-      "readme": "# ic-select\n\n\n",
+      "readme": "# ic-select\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -12802,7 +12774,7 @@
           "mutable": false,
           "attr": "formaction",
           "reflectToAttr": false,
-          "docs": "The URL that processes the information submitted by the select. It overrides the action attribute of the select's form owner. Does nothing if there is no form owner.\nThis prop should only be used with searchable select and will only be applied if searchable is true.",
+          "docs": "The URL that processes the information submitted by the select. It overrides the action attribute of the select's form owner. Does nothing if there is no form owner.\r\nThis prop should only be used with searchable select and will only be applied if searchable is true.",
           "docsTags": [],
           "values": [
             {
@@ -12886,7 +12858,7 @@
           "mutable": false,
           "attr": "formtarget",
           "reflectToAttr": false,
-          "docs": "The place to display the response from submitting the form. It overrides the target attribute of the select's form owner.\nThis prop should only be used with searchable select and will only be applied if searchable is true.",
+          "docs": "The place to display the response from submitting the form. It overrides the target attribute of the select's form owner.\r\nThis prop should only be used with searchable select and will only be applied if searchable is true.",
           "docsTags": [],
           "values": [
             {
@@ -13629,7 +13601,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an option is highlighted within the menu.\nHighlighting a menu item will also trigger an `icChange/onIcChange` due to the value being updated.",
+          "docs": "Emitted when an option is highlighted within the menu.\r\nHighlighting a menu item will also trigger an `icChange/onIcChange` due to the value being updated.",
           "docsTags": []
         },
         {
@@ -13720,7 +13692,7 @@
       "filePath": "src/components/ic-side-navigation/ic-side-navigation.tsx",
       "encapsulation": "shadow",
       "tag": "ic-side-navigation",
-      "readme": "# ic-side-navigation\n\n\n",
+      "readme": "# ic-side-navigation\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -14045,8 +14017,8 @@
       "filePath": "src/components/ic-skeleton/ic-skeleton.tsx",
       "encapsulation": "shadow",
       "tag": "ic-skeleton",
-      "readme": "# ic-skeleton\n\nWhen using the skeleton component, an aria-live level should be applied to the parent element of the skeleton and the element that it is\nrepresenting so that any changes, such as the real element replacing the skeleton placeholder, are announced to assistive technology like screen readers. The recommendation is to use aria-live=\"polite\" over aria-live=\"recommended\" unless changes are critically important. \n",
-      "docs": "When using the skeleton component, an aria-live level should be applied to the parent element of the skeleton and the element that it is\nrepresenting so that any changes, such as the real element replacing the skeleton placeholder, are announced to assistive technology like screen readers. The recommendation is to use aria-live=\"polite\" over aria-live=\"recommended\" unless changes are critically important.",
+      "readme": "# ic-skeleton\r\n\r\nWhen using the skeleton component, an aria-live level should be applied to the parent element of the skeleton and the element that it is\r\nrepresenting so that any changes, such as the real element replacing the skeleton placeholder, are announced to assistive technology like screen readers. The recommendation is to use aria-live=\"polite\" over aria-live=\"recommended\" unless changes are critically important. \r\n\r",
+      "docs": "When using the skeleton component, an aria-live level should be applied to the parent element of the skeleton and the element that it is\r\nrepresenting so that any changes, such as the real element replacing the skeleton placeholder, are announced to assistive technology like screen readers. The recommendation is to use aria-live=\"polite\" over aria-live=\"recommended\" unless changes are critically important.",
       "docsTags": [],
       "usage": {},
       "props": [
@@ -14157,7 +14129,7 @@
       "filePath": "src/components/ic-status-tag/ic-status-tag.tsx",
       "encapsulation": "shadow",
       "tag": "ic-status-tag",
-      "readme": "# ic-status-tag\n\n\n",
+      "readme": "# ic-status-tag\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -14173,7 +14145,7 @@
           "mutable": false,
           "attr": "announced",
           "reflectToAttr": false,
-          "docs": "If `true`, role='status' is added to the component and it will act as an 'aria-live' region.\nScreen readers will announce changes to the `label`, but not the initial value.",
+          "docs": "If `true`, role='status' is added to the component and it will act as an 'aria-live' region.\r\nScreen readers will announce changes to the `label`, but not the initial value.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -14403,7 +14375,7 @@
       "filePath": "src/components/ic-step/ic-step.tsx",
       "encapsulation": "shadow",
       "tag": "ic-step",
-      "readme": "# ic-step\n\n\n",
+      "readme": "# ic-step\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -14549,7 +14521,7 @@
       "filePath": "src/components/ic-stepper/ic-stepper.tsx",
       "encapsulation": "shadow",
       "tag": "ic-stepper",
-      "readme": "# ic-stepper\n\nThis is a wrapper component to be placed around one or more ic-step components\n",
+      "readme": "# ic-stepper\r\n\r\nThis is a wrapper component to be placed around one or more ic-step components\r\n\r",
       "docs": "This is a wrapper component to be placed around one or more ic-step components",
       "docsTags": [],
       "usage": {},
@@ -14706,7 +14678,7 @@
       "filePath": "src/components/ic-switch/ic-switch.tsx",
       "encapsulation": "shadow",
       "tag": "ic-switch",
-      "readme": "# ic-switch\n\n\n",
+      "readme": "# ic-switch\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -15055,7 +15027,7 @@
       "filePath": "src/components/ic-tab/ic-tab.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tab",
-      "readme": "# ic-tab\n\n\n",
+      "readme": "# ic-tab\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -15144,7 +15116,7 @@
       "filePath": "src/components/ic-tab-context/ic-tab-context.tsx",
       "encapsulation": "none",
       "tag": "ic-tab-context",
-      "readme": "# ic-tab-context\n\n\n",
+      "readme": "# ic-tab-context\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -15341,7 +15313,7 @@
       "filePath": "src/components/ic-tab-group/ic-tab-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tab-group",
-      "readme": "# ic-tab-group\n\n\n",
+      "readme": "# ic-tab-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -15361,11 +15333,11 @@
           "docsTags": [
             {
               "name": "deprecated",
-              "text": "This is no longer required.\nThe context id is passed down from `ic-tab-context`"
+              "text": "This is no longer required.\r\nThe context id is passed down from `ic-tab-context`"
             }
           ],
           "default": "\"default\"",
-          "deprecation": "This is no longer required.\nThe context id is passed down from `ic-tab-context`",
+          "deprecation": "This is no longer required.\r\nThe context id is passed down from `ic-tab-context`",
           "values": [
             {
               "type": "string"
@@ -15451,7 +15423,7 @@
       "filePath": "src/components/ic-tab-panel/ic-tab-panel.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tab-panel",
-      "readme": "# ic-tab-panel\n\n\n",
+      "readme": "# ic-tab-panel\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -15499,7 +15471,7 @@
       "filePath": "src/components/ic-text-field/ic-text-field.tsx",
       "encapsulation": "shadow",
       "tag": "ic-text-field",
-      "readme": "# ic-textfield\n\n\n",
+      "readme": "# ic-textfield\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -15542,7 +15514,7 @@
           "mutable": false,
           "attr": "autocapitalize",
           "reflectToAttr": false,
-          "docs": "The automatic capitalisation of the text value as it is entered/edited by the user.\nAvailable options: \"off\", \"none\", \"on\", \"sentences\", \"words\", \"characters\".",
+          "docs": "The automatic capitalisation of the text value as it is entered/edited by the user.\r\nAvailable options: \"off\", \"none\", \"on\", \"sentences\", \"words\", \"characters\".",
           "docsTags": [],
           "default": "\"off\"",
           "values": [
@@ -15882,7 +15854,7 @@
           "mutable": false,
           "attr": "full-width",
           "reflectToAttr": false,
-          "docs": "Specify whether the text field fills the full width of the container.\nIf `true`, this overrides the --input-width CSS variable.",
+          "docs": "Specify whether the text field fills the full width of the container.\r\nIf `true`, this overrides the --input-width CSS variable.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -15976,7 +15948,7 @@
           "mutable": false,
           "attr": "inputmode",
           "reflectToAttr": false,
-          "docs": "A hint to the browser for which keyboard to display.\nPossible values: `\"none\"`, `\"text\"`, `\"tel\"`, `\"url\"`,\n`\"email\"`, `\"numeric\"`, `\"decimal\"`, and `\"search\"`.",
+          "docs": "A hint to the browser for which keyboard to display.\r\nPossible values: `\"none\"`, `\"text\"`, `\"tel\"`, `\"url\"`,\r\n`\"email\"`, `\"numeric\"`, `\"decimal\"`, and `\"search\"`.",
           "docsTags": [],
           "default": "\"text\"",
           "values": [
@@ -16707,7 +16679,7 @@
       "filePath": "src/components/ic-theme/ic-theme.tsx",
       "encapsulation": "shadow",
       "tag": "ic-theme",
-      "readme": "# ic-theme\n\n\n",
+      "readme": "# ic-theme\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -16761,7 +16733,7 @@
       "filePath": "src/components/ic-toast/ic-toast.tsx",
       "encapsulation": "shadow",
       "tag": "ic-toast",
-      "readme": "# ic-toast\n\n\n",
+      "readme": "# ic-toast\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -16786,7 +16758,7 @@
           "mutable": true,
           "attr": "auto-dismiss-timeout",
           "reflectToAttr": false,
-          "docs": "If toast dismissMode is set to `automatic`, use this prop to define the time before the toast dismisses (in MILLISECONDS)\n(NOTE: Has a minimum value of `5000ms`)",
+          "docs": "If toast dismissMode is set to `automatic`, use this prop to define the time before the toast dismisses (in MILLISECONDS)\r\n(NOTE: Has a minimum value of `5000ms`)",
           "docsTags": [],
           "default": "5000",
           "values": [
@@ -17046,7 +17018,7 @@
       "filePath": "src/components/ic-toast-region/ic-toast-region.tsx",
       "encapsulation": "none",
       "tag": "ic-toast-region",
-      "readme": "# ic-toast-region\n\n\n",
+      "readme": "# ic-toast-region\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -17146,7 +17118,7 @@
       "filePath": "src/components/ic-toggle-button/ic-toggle-button.tsx",
       "encapsulation": "shadow",
       "tag": "ic-toggle-button",
-      "readme": "# ic-toggle-button\n\n\n",
+      "readme": "# ic-toggle-button\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -17429,7 +17401,7 @@
           "detail": "{ checked: boolean; }",
           "bubbles": true,
           "complexType": {
-            "original": "{\n    checked: boolean;\n  }",
+            "original": "{\r\n    checked: boolean;\r\n  }",
             "resolved": "{ checked: boolean; }",
             "references": {}
           },
@@ -17482,7 +17454,7 @@
       "filePath": "src/components/ic-toggle-button-group/ic-toggle-button-group.tsx",
       "encapsulation": "shadow",
       "tag": "ic-toggle-button-group",
-      "readme": "# ic-toggle-button-group\n\n\n",
+      "readme": "# ic-toggle-button-group\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -17814,7 +17786,7 @@
       "filePath": "src/components/ic-tooltip/ic-tooltip.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tooltip",
-      "readme": "# ic-tooltip\n\n\n",
+      "readme": "# ic-tooltip\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -18079,7 +18051,7 @@
       "filePath": "src/components/ic-top-navigation/ic-top-navigation.tsx",
       "encapsulation": "shadow",
       "tag": "ic-top-navigation",
-      "readme": "# ic-top-navigation\n\n\n",
+      "readme": "# ic-top-navigation\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -18438,7 +18410,7 @@
       "filePath": "src/components/ic-typography/ic-typography.tsx",
       "encapsulation": "shadow",
       "tag": "ic-typography",
-      "readme": "# ic-typography\n\n\n",
+      "readme": "# ic-typography\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -18476,7 +18448,7 @@
           "mutable": false,
           "attr": "bold",
           "reflectToAttr": false,
-          "docs": "If `true`, the typography will have a bold font weight.\nNote: This will have no impact on variants that already use an equivalent or higher font weight (h1, h2, and subtitle-large).",
+          "docs": "If `true`, the typography will have a bold font weight.\r\nNote: This will have no impact on variants that already use an equivalent or higher font weight (h1, h2, and subtitle-large).",
           "docsTags": [],
           "default": "false",
           "values": [

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -811,11 +811,11 @@ export namespace Components {
          */
         "disableBackgroundParallax"?: boolean;
         /**
-          * The heading of the hero.
+          * The heading of the hero. An <h2> level heading.
          */
         "heading": string;
         /**
-          * The optional secondary heading, replaced by slotted right content.
+          * The optional secondary heading, an <h3> level heading. Replaced by slotted right content.
          */
         "secondaryHeading"?: string;
         /**
@@ -826,10 +826,6 @@ export namespace Components {
           * The size of the hero component.
          */
         "size"?: IcSizesNoLarge;
-        /**
-          * @deprecated This prop should not be used anymore. Set prop `size` to "small" instead.
-         */
-        "small"?: boolean;
         /**
           * The description for the hero.
          */
@@ -4111,11 +4107,11 @@ declare namespace LocalJSX {
          */
         "disableBackgroundParallax"?: boolean;
         /**
-          * The heading of the hero.
+          * The heading of the hero. An <h2> level heading.
          */
         "heading"?: string;
         /**
-          * The optional secondary heading, replaced by slotted right content.
+          * The optional secondary heading, an <h3> level heading. Replaced by slotted right content.
          */
         "secondaryHeading"?: string;
         /**
@@ -4126,10 +4122,6 @@ declare namespace LocalJSX {
           * The size of the hero component.
          */
         "size"?: IcSizesNoLarge;
-        /**
-          * @deprecated This prop should not be used anymore. Set prop `size` to "small" instead.
-         */
-        "small"?: boolean;
         /**
           * The description for the hero.
          */

--- a/packages/web-components/src/components/ic-hero/ic-hero.tsx
+++ b/packages/web-components/src/components/ic-hero/ic-hero.tsx
@@ -66,12 +66,12 @@ export class Hero {
   @Prop() disableBackgroundParallax?: boolean = false;
 
   /**
-   * The heading of the hero.
+   * The heading of the hero. An <h2> level heading.
    */
   @Prop() heading: string;
 
   /**
-   * The optional secondary heading, replaced by slotted right content.
+   * The optional secondary heading, an <h3> level heading. Replaced by slotted right content.
    */
   @Prop() secondaryHeading?: string;
 
@@ -84,11 +84,6 @@ export class Hero {
    * The size of the hero component.
    */
   @Prop() size?: IcSizesNoLarge = "default";
-
-  /**
-   * @deprecated This prop should not be used anymore. Set prop `size` to "small" instead.
-   */
-  @Prop() small?: boolean = false;
 
   /**
    * The description for the hero.
@@ -132,7 +127,6 @@ export class Hero {
   render() {
     const {
       aligned,
-      small,
       size,
       heading,
       subheading,
@@ -158,7 +152,7 @@ export class Hero {
           [`ic-hero-${IcThemeForegroundEnum.Dark}`]:
             foregroundColor === IcThemeForegroundEnum.Dark,
           ["has-background-image"]: backgroundImage !== undefined,
-          ["ic-hero-small"]: small || size === "small",
+          ["ic-hero-small"]: size === "small",
           ["secondary-heading"]: !!secondaryHeading,
         }}
         style={style}
@@ -177,12 +171,12 @@ export class Hero {
             <div class="heading">
               <slot name="heading">
                 <ic-typography
-                  variant={small || size === "small" ? "h2" : "h1"}
+                  variant={size === "small" ? "h2" : "h1"}
                   class={{
-                    ["heading-bottom-spacing"]: !small && size !== "small",
+                    ["heading-bottom-spacing"]: size !== "small",
                   }}
                 >
-                  {heading}
+                  <h2>{heading}</h2>
                 </ic-typography>
               </slot>
             </div>
@@ -202,7 +196,7 @@ export class Hero {
                   <div class="secondary-container">
                     <div class="secondary-heading">
                       <ic-typography variant="h4">
-                        {secondaryHeading}
+                        <h3>{secondaryHeading}</h3>
                       </ic-typography>
                     </div>
                     <div class="secondary-subheading">

--- a/packages/web-components/src/components/ic-hero/readme.md
+++ b/packages/web-components/src/components/ic-hero/readme.md
@@ -7,18 +7,17 @@
 
 ## Properties
 
-| Property                    | Attribute                     | Description                                                                                                                         | Type                                 | Default     |
-| --------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------- |
-| `aligned`                   | `aligned`                     | The alignment of the hero.                                                                                                          | `"center" \| "full-width" \| "left"` | `"left"`    |
-| `backgroundImage`           | `background-image`            | The optional background image.                                                                                                      | `string`                             | `undefined` |
-| `contentAligned`            | `content-aligned`             | The alignment of the hero content.                                                                                                  | `"center" \| "left"`                 | `"left"`    |
-| `disableBackgroundParallax` | `disable-background-parallax` | If `true`, the background image (if set) will not scroll using a parallax effect.                                                   | `boolean`                            | `false`     |
-| `heading`                   | `heading`                     | The heading of the hero.                                                                                                            | `string`                             | `undefined` |
-| `secondaryHeading`          | `secondary-heading`           | The optional secondary heading, replaced by slotted right content.                                                                  | `string`                             | `undefined` |
-| `secondarySubheading`       | `secondary-subheading`        | The optional secondary subheading, replaced by slotted right content.                                                               | `string`                             | `undefined` |
-| `size`                      | `size`                        | The size of the hero component.                                                                                                     | `"default" \| "small"`               | `"default"` |
-| `small`                     | `small`                       | <span style="color:red">**[DEPRECATED]**</span> This prop should not be used anymore. Set prop `size` to "small" instead.<br/><br/> | `boolean`                            | `false`     |
-| `subheading`                | `subheading`                  | The description for the hero.                                                                                                       | `string`                             | `undefined` |
+| Property                    | Attribute                     | Description                                                                               | Type                                 | Default     |
+| --------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ | ----------- |
+| `aligned`                   | `aligned`                     | The alignment of the hero.                                                                | `"center" \| "full-width" \| "left"` | `"left"`    |
+| `backgroundImage`           | `background-image`            | The optional background image.                                                            | `string`                             | `undefined` |
+| `contentAligned`            | `content-aligned`             | The alignment of the hero content.                                                        | `"center" \| "left"`                 | `"left"`    |
+| `disableBackgroundParallax` | `disable-background-parallax` | If `true`, the background image (if set) will not scroll using a parallax effect.         | `boolean`                            | `false`     |
+| `heading`                   | `heading`                     | The heading of the hero. An <h2> level heading.                                           | `string`                             | `undefined` |
+| `secondaryHeading`          | `secondary-heading`           | The optional secondary heading, an <h3> level heading. Replaced by slotted right content. | `string`                             | `undefined` |
+| `secondarySubheading`       | `secondary-subheading`        | The optional secondary subheading, replaced by slotted right content.                     | `string`                             | `undefined` |
+| `size`                      | `size`                        | The size of the hero component.                                                           | `"default" \| "small"`               | `"default"` |
+| `subheading`                | `subheading`                  | The description for the hero.                                                             | `string`                             | `undefined` |
 
 
 ## Slots

--- a/packages/web-components/src/components/ic-hero/test/basic/__snapshots__/ic-hero.spec.ts.snap
+++ b/packages/web-components/src/components/ic-hero/test/basic/__snapshots__/ic-hero.spec.ts.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ic-hero component should render small: renders-small-variant 1`] = `
-<ic-hero class="ic-hero-small" heading="Test title" small="" subheading="Test text">
+exports[`ic-hero component should render at size small: renders-small-variant 1`] = `
+<ic-hero class="ic-hero-small" heading="Test title" size="small" subheading="Test text">
   <mock:shadow-root>
     <ic-section-container aligned="left" class="section-container" fullheight="">
       <div class="left-container left-container-full-width">
         <div class="heading">
           <slot name="heading">
             <ic-typography variant="h2">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -36,7 +38,9 @@ exports[`ic-hero component should render with a background image when given: ren
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -68,7 +72,9 @@ exports[`ic-hero component should render with a secondary heading: renders-with-
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -88,7 +94,9 @@ exports[`ic-hero component should render with a secondary heading: renders-with-
           <div class="secondary-container">
             <div class="secondary-heading">
               <ic-typography variant="h4">
-                Test title
+                <h3>
+                  Test title
+                </h3>
               </ic-typography>
             </div>
             <div class="secondary-subheading">
@@ -112,7 +120,9 @@ exports[`ic-hero component should render with interaction content: renders-with-
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -143,7 +153,9 @@ exports[`ic-hero component should render with secondary content: renders-with-se
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -175,7 +187,9 @@ exports[`ic-hero component should render: renders 1`] = `
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -203,7 +217,9 @@ exports[`ic-hero component should use not parallax on scroll when a background i
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>
@@ -235,7 +251,9 @@ exports[`ic-hero component should use parallax on scroll when a background image
         <div class="heading">
           <slot name="heading">
             <ic-typography class="heading-bottom-spacing" variant="h1">
-              Test title
+              <h2>
+                Test title
+              </h2>
             </ic-typography>
           </slot>
         </div>

--- a/packages/web-components/src/components/ic-hero/test/basic/ic-hero.spec.ts
+++ b/packages/web-components/src/components/ic-hero/test/basic/ic-hero.spec.ts
@@ -77,10 +77,10 @@ describe("ic-hero component", () => {
     );
   });
 
-  it("should render small", async () => {
+  it("should render at size small", async () => {
     const page = await newSpecPage({
       components: [Hero],
-      html: `<ic-hero small heading="Test title" subheading="Test text"></ic-hero>`,
+      html: `<ic-hero size="small" heading="Test title" subheading="Test text"></ic-hero>`,
     });
 
     expect(page.root).toMatchSnapshot("renders-small-variant");


### PR DESCRIPTION
Set heading prop to h2 and secondaryHeading to h3 semantic elements in Hero component

BREAKING CHANGE: Heading hierarchy of the component has changed, which might affect accessibility compliance when integrated

## Related issue
re #1687 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Visual testing against Figma component specification completed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### Testing content extremes

- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.