### PR TITLE
safari links dont get focus

### DIFF
--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
@@ -92,7 +92,7 @@ ic-link {
   }
 }
 
-@supports (text-decoration-thickness: 25%) {
+@supports (text-underline-offset: 25%) {
   ic-link {
     --breadcrumb-link-display: flex;
   }

--- a/packages/web-components/src/components/ic-card/ic-card.css
+++ b/packages/web-components/src/components/ic-card/ic-card.css
@@ -92,7 +92,7 @@ button {
   text-decoration: none;
 }
 
-@supports (text-decoration-thickness: 25%) {
+@supports (text-underline-offset: 25%) {
   .card.clickable:hover .card-title,
   .card.clickable:focus .card-title,
   .card.clickable.focussed .card-title {

--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -85,7 +85,7 @@ a:link:visited > ::slotted(svg) {
   text-decoration: none;
 }
 
-@supports (text-decoration-thickness: 25%) {
+@supports (text-underline-offset: 25%) {
   :host(.footer-link) a:link:hover,
   :host(.footer-link) a:link:focus,
   :host(.footer-link) a ::slotted(a:link:hover),

--- a/packages/web-components/src/components/ic-link/ic-link.css
+++ b/packages/web-components/src/components/ic-link/ic-link.css
@@ -33,7 +33,7 @@
   text-decoration: none;
 }
 
-@supports (text-decoration-thickness: 25%) {
+@supports (text-underline-offset: 10%) {
   :host(.link) .ic-link:hover,
   :host(.link) .ic-link:focus,
   :host(.link) ::slotted(a:hover),

--- a/packages/web-components/src/components/ic-typography/ic-typography.css
+++ b/packages/web-components/src/components/ic-typography/ic-typography.css
@@ -184,7 +184,7 @@
   font-weight: var(--ic-font-weight-bold);
 }
 
-@supports (text-decoration-thickness: 25%) {
+@supports (text-underline-offset: 25%) {
   .trunc-btn:hover,
   .trunc-btn.focus {
     text-decoration-line: underline;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update footer link, breadcrumb, card, link and typography support css so that focus underline appears on focus and hover

## Related issue
#1869, #1910, #1855, #1861 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.