### PR TITLE
fix(web-components): add list role to ic-footer-link and listitem role to ic-footer-link-group

### DIFF
--- a/packages/web-components/src/components/ic-footer-link-group/ic-footer-link-group.tsx
+++ b/packages/web-components/src/components/ic-footer-link-group/ic-footer-link-group.tsx
@@ -87,11 +87,12 @@ export class FooterLinkGroup {
           ["footer-link-group footer-link-group-sparse"]: true,
           [`footer-link-group-${this.dropdownIconStyle}`]: true,
         }}
+        role="listitem"
       >
         <div class="footer-link-group-title">
           <ic-typography variant="subtitle-small">{groupTitle}</ic-typography>
         </div>
-        <div class="footer-link-group-links">
+        <div class="footer-link-group-links" role="list">
           <slot />
         </div>
       </Host>
@@ -148,7 +149,7 @@ export class FooterLinkGroup {
             )}
           </div>
           {this.expanded && (
-            <div class="footer-link-group-links">
+            <div class="footer-link-group-links" role="list">
               <slot />
             </div>
           )}

--- a/packages/web-components/src/components/ic-footer-link-group/test/basic/__snapshots__/ic-footer-link-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-footer-link-group/test/basic/__snapshots__/ic-footer-link-group.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`ic-footer-link-group should render small: footer-link-group-small 1`] =
         </div>
       </ic-section-container>
     </mock:shadow-root>
-    <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-small" href="/">
+    <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-small" href="/" role="listitem">
       <mock:shadow-root>
         <a href="/">
           <slot></slot>
@@ -44,6 +44,29 @@ exports[`ic-footer-link-group should render small: footer-link-group-small 1`] =
     </ic-footer-link>
   </ic-footer-link-group>
 </ic-footer>
+`;
+
+exports[`ic-footer-link-group should render with links: footer-link-group-with-links 1`] = `
+<ic-footer-link-group class="footer-link-group footer-link-group-light footer-link-group-sparse" group-title="Link group" role="listitem">
+  <mock:shadow-root>
+    <div class="footer-link-group-title">
+      <ic-typography variant="subtitle-small">
+        Link group
+      </ic-typography>
+    </div>
+    <div class="footer-link-group-links" role="list">
+      <slot></slot>
+    </div>
+  </mock:shadow-root>
+  <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-sparse" href="/" role="listitem">
+    <mock:shadow-root>
+      <a href="/">
+        <slot></slot>
+      </a>
+    </mock:shadow-root>
+    Link
+  </ic-footer-link>
+</ic-footer-link-group>
 `;
 
 exports[`ic-footer-link-group should render within footer: footer-link-group-in-footer 1`] = `
@@ -63,18 +86,18 @@ exports[`ic-footer-link-group should render within footer: footer-link-group-in-
       </div>
     </footer>
   </mock:shadow-root>
-  <ic-footer-link-group class="footer-link-group footer-link-group-light footer-link-group-sparse" group-title="Link group">
+  <ic-footer-link-group class="footer-link-group footer-link-group-light footer-link-group-sparse" group-title="Link group" role="listitem">
     <mock:shadow-root>
       <div class="footer-link-group-title">
         <ic-typography variant="subtitle-small">
           Link group
         </ic-typography>
       </div>
-      <div class="footer-link-group-links">
+      <div class="footer-link-group-links" role="list">
         <slot></slot>
       </div>
     </mock:shadow-root>
-    <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-sparse" href="/">
+    <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-sparse" href="/" role="listitem">
       <mock:shadow-root>
         <a href="/">
           <slot></slot>
@@ -101,4 +124,19 @@ exports[`ic-footer-link-group should render within footer: footer-link-group-in-
     </mock:shadow-root>
   </ic-footer>
 </ic-footer>
+`;
+
+exports[`ic-footer-link-group should render: footer-link-group 1`] = `
+<ic-footer-link-group class="footer-link-group footer-link-group-light footer-link-group-sparse" group-title="Link group" role="listitem">
+  <mock:shadow-root>
+    <div class="footer-link-group-title">
+      <ic-typography variant="subtitle-small">
+        Link group
+      </ic-typography>
+    </div>
+    <div class="footer-link-group-links" role="list">
+      <slot></slot>
+    </div>
+  </mock:shadow-root>
+</ic-footer-link-group>
 `;

--- a/packages/web-components/src/components/ic-footer-link-group/test/basic/ic-footer-link-group.spec.ts
+++ b/packages/web-components/src/components/ic-footer-link-group/test/basic/ic-footer-link-group.spec.ts
@@ -10,19 +10,7 @@ describe("ic-footer-link-group", () => {
       html: `<ic-footer-link-group group-title="Link group"></ic-footer-link-group>`,
     });
 
-    expect(page.root).toEqualHtml(`
-    <ic-footer-link-group class="footer-link-group footer-link-group-light footer-link-group-sparse" group-title="Link group">
-        <mock:shadow-root>
-            <div class="footer-link-group-title">
-                <ic-typography variant="subtitle-small">
-                    Link group
-                </ic-typography>
-            </div>
-            <div class="footer-link-group-links">
-                <slot></slot>
-            </div>
-        </mock:shadow-root>
-    </ic-footer-link-group>`);
+    expect(page.root).toMatchSnapshot("footer-link-group");
   });
 
   it("should render with links", async () => {
@@ -31,27 +19,7 @@ describe("ic-footer-link-group", () => {
       html: `<ic-footer-link-group group-title="Link group"><ic-footer-link href="/">Link</ic-footer-link></ic-footer-link-group>`,
     });
 
-    expect(page.root).toEqualHtml(`
-    <ic-footer-link-group class="footer-link-group footer-link-group-light footer-link-group-sparse" group-title="Link group">
-        <mock:shadow-root>
-            <div class="footer-link-group-title">
-                <ic-typography variant="subtitle-small">
-                    Link group
-                </ic-typography>
-            </div>
-            <div class="footer-link-group-links">
-                <slot></slot>
-            </div>
-        </mock:shadow-root>
-        <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-sparse" href="/">
-            <mock:shadow-root>
-                <a href="/">
-                    <slot></slot>
-                </a>
-            </mock:shadow-root>
-            Link
-        </ic-footer-link>
-    </ic-footer-link-group>`);
+    expect(page.root).toMatchSnapshot("footer-link-group-with-links");
   });
 
   it("should render within footer", async () => {

--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.tsx
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.tsx
@@ -109,6 +109,7 @@ export class FooterLink {
           }`]: true,
           [`footer-link-${this.foregroundColor}`]: true,
         }}
+        role="listitem"
       >
         <a
           href={href}

--- a/packages/web-components/src/components/ic-footer-link/test/basic/__snapshots__/ic-footer-link.spec.ts.snap
+++ b/packages/web-components/src/components/ic-footer-link/test/basic/__snapshots__/ic-footer-link.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ic-footer-link should render small with grouped links: small-footer-link-with-grouped-links 1`] = `
+<ic-footer-link class="footer-link footer-link-grouped-small footer-link-light" href="/" role="listitem">
+  <mock:shadow-root>
+    <a href="/">
+      <slot></slot>
+    </a>
+  </mock:shadow-root>
+  Link
+</ic-footer-link>
+`;
+
+exports[`ic-footer-link should render: footer-link 1`] = `
+<ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-sparse" href="/" role="listitem">
+  <mock:shadow-root>
+    <a href="/">
+      <slot></slot>
+    </a>
+  </mock:shadow-root>
+  Link
+</ic-footer-link>
+`;

--- a/packages/web-components/src/components/ic-footer-link/test/basic/ic-footer-link.spec.ts
+++ b/packages/web-components/src/components/ic-footer-link/test/basic/ic-footer-link.spec.ts
@@ -8,15 +8,7 @@ describe("ic-footer-link", () => {
       html: `<ic-footer-link href="/">Link</ic-footer-link>`,
     });
 
-    expect(page.root).toEqualHtml(`
-    <ic-footer-link class="footer-link footer-link-light footer-link-ungrouped-sparse" href="/">
-        <mock:shadow-root>
-            <a href="/">
-                <slot></slot>
-            </a>
-        </mock:shadow-root>
-            Link
-    </ic-footer-link>`);
+    expect(page.root).toMatchSnapshot("footer-link");
   });
 
   it("should render small with grouped links", async () => {
@@ -28,15 +20,7 @@ describe("ic-footer-link", () => {
     page.rootInstance.footerConfig = { small: true, grouped: true };
     await page.waitForChanges();
 
-    expect(page.root).toEqualHtml(`
-        <ic-footer-link class="footer-link footer-link-light footer-link-grouped-small" href="/">
-            <mock:shadow-root>
-                <a href="/">
-                    <slot></slot>
-                </a>
-            </mock:shadow-root>
-                Link
-        </ic-footer-link>`);
+    expect(page.root).toMatchSnapshot("small-footer-link-with-grouped-links");
   });
 
   it("should set foregroundColor on theme change", async () => {

--- a/packages/web-components/src/components/ic-footer/ic-footer.tsx
+++ b/packages/web-components/src/components/ic-footer/ic-footer.tsx
@@ -176,12 +176,12 @@ export class Footer {
           {isSlotUsed(this.el, "link") && (
             <div class="footer-links">
               {groupLinks && small ? (
-                <div class="footer-links-inner">
+                <div class="footer-links-inner" role="list">
                   <slot name="link" />
                 </div>
               ) : (
                 <ic-section-container fullHeight aligned={aligned}>
-                  <div class="footer-links-inner">
+                  <div class="footer-links-inner" role="list">
                     <slot name="link" />
                   </div>
                 </ic-section-container>

--- a/packages/web-components/src/components/ic-footer/test/basic/__snapshots__/ic-footer.spec.ts.snap
+++ b/packages/web-components/src/components/ic-footer/test/basic/__snapshots__/ic-footer.spec.ts.snap
@@ -175,7 +175,7 @@ exports[`ic-footer should render with link groups 1`] = `
       </div>
       <div class="footer-links">
         <ic-section-container aligned="left" fullheight="">
-          <div class="footer-links-inner">
+          <div class="footer-links-inner" role="list">
             <slot name="link"></slot>
           </div>
         </ic-section-container>
@@ -228,7 +228,7 @@ exports[`ic-footer should render with links 1`] = `
       </div>
       <div class="footer-links">
         <ic-section-container aligned="left" fullheight="">
-          <div class="footer-links-inner">
+          <div class="footer-links-inner" role="list">
             <slot name="link"></slot>
           </div>
         </ic-section-container>


### PR DESCRIPTION
## Summary of the changes
Add semantic roles to ic-footer-link and ic-footer-link-group for accessibility. Update tests following this change

## Related issue
#1686

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
