### PR TITLE
Add buttons to back to top 'Page example' stories

### DIFF
--- a/packages/react/src/stories/ic-back-to-top.stories.mdx
+++ b/packages/react/src/stories/ic-back-to-top.stories.mdx
@@ -8,6 +8,7 @@ import {
 
 import {
   IcBackToTop,
+  IcButton,
   IcClassificationBanner,
   IcTypography,
 } from "../components";
@@ -41,12 +42,13 @@ Please switch to the Canvas and then choose to open the canvas in a new tab to s
       id="header"
       style={{
         width: "100%",
-        height: "80px",
+        height: "100px",
         backgroundColor: "#23508e",
         color: "var(--ic-architectural-white)",
       }}
     >
       <IcTypography variant="h1">Header</IcTypography>
+      <IcButton variant="secondary" appearance="light">Button</IcButton>
     </div>
     <div id="topPageEl">
       <IcTypography variant="h2">Top of the page</IcTypography>
@@ -60,6 +62,8 @@ Please switch to the Canvas and then choose to open the canvas in a new tab to s
       quis rutrum id, vulputate eget diam. Integer mattis quis nisi id blandit.
       Duis nisi lectus, suscipit elementum iaculis sed, porta et risus.
     </p>
+    <br />
+    <IcButton>Button</IcButton>
     <br />
     <br />
     <br />
@@ -176,7 +180,7 @@ Please switch to the Canvas and then choose to open the canvas in a new tab to s
 export const defaultArgs = {
   target: "topEl",
   variant: "default",
-};       
+};
 
 <Canvas>
   <Story

--- a/packages/web-components/src/components/ic-back-to-top/ic-back-to-top.stories.mdx
+++ b/packages/web-components/src/components/ic-back-to-top/ic-back-to-top.stories.mdx
@@ -46,9 +46,10 @@ Please switch to the Canvas and then choose to open the canvas in a new tab to s
     {html`
       <div
         id="header"
-        style="width:100%;height:80px;background-color:#23508e;color:var(--ic-architectural-white)"
+        style="width:100%;height:100px;background-color:#23508e;color:var(--ic-architectural-white)"
       >
         <ic-typography variant="h1">Header</ic-typography>
+        <ic-button variant="secondary" appearance="light">Button</ic-button>
       </div>
       <div id="topPageEl">
         <ic-typography variant="h2">Top of the page</ic-typography>
@@ -63,6 +64,8 @@ Please switch to the Canvas and then choose to open the canvas in a new tab to s
         blandit. Duis nisi lectus, suscipit elementum iaculis sed, porta et
         risus.
       </p>
+      <br />
+      <ic-button>Button</ic-button>
       <br />
       <br />
       <br />


### PR DESCRIPTION
## Summary of the changes
Added buttons to back to top 'Page example' stories to make it easier to test the focus behaviour. Half of ticket #1846.

## Related issue
#1846 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.