### PR TITLE
test(react): install storybook performance addon to react

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Tell us the issue number. If suggesting an improvement or component, please disc
 - [ ] Relevant unit tests and visual regression tests added. 
 - [ ] Visual testing against Figma component specification completed. 
 - [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
+- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.
 
 ### Accessibility 
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -18,13 +18,6 @@ This also applies to canary components, where the `docs.json` in `canary-docs` s
 
 If you have added a new feature, or fixed a bug, it is likely that in the ticket you followed, there was an acceptance criteria section. Any acceptance criteria within that section should be met, or discussed with the author of the issue.
 
-### Playground stories in React Storybook up to date
-
-Every component should have a comprehensive Playground storybook that allows users to modify every property to manual test for issues. 
-If you have added or modified the properties of a component you need to make sure the corresponding Playground is updated.
-
-React Storybooks are found in `packages/react/src/stories`. You can run storybook locally with `npm run storybook`, and react will be on [port 6007](http://localhost:6007)
-
 ## Testing
 
 ### Relevant unit tests and visual regression tests added
@@ -48,6 +41,17 @@ To test this, you should check for:
 - Active states
 - Prop names
 - Figma Prototype functionality vs. implemented functionality
+
+### Playground stories in React Storybook up to date
+
+Every component should have a comprehensive Playground storybook that allows users to modify every property to manual test for issues. 
+If you have added or modified the properties of a component you need to make sure the corresponding Playground is updated.
+
+React Storybooks are found in `packages/react/src/stories`. You can run storybook locally with `npm run storybook`, and react will be on [port 6007](http://localhost:6007)
+
+### Compare performance of modified components against develop
+
+Within the Addon panel in React Storybook we can test the render times of any Story. By running these performance checks on [the develop branch's Storybook](https://mi6.github.io/ic-ui-kit/branches/develop/react/) and comparing with Stories on your branch you can identify any significant performance impacts. Any significant increases in render time should be investigated.
 
 ## Accessibility
 

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -16,7 +16,8 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-postcss",
     "@storybook/addon-a11y",
-    "@storybook/addon-mdx-gfm"
+    "@storybook/addon-mdx-gfm",
+    "storybook-addon-performance"
   ],
 
   "framework": {

--- a/packages/react/.storybook/preview.js
+++ b/packages/react/.storybook/preview.js
@@ -1,6 +1,7 @@
 import "../dist/core/normalize.css";
 import "@ukic/fonts/dist/fonts.css";
 import "../dist/core/core.css";
+import { withPerformance } from 'storybook-addon-performance';
 
 export const parameters = {
     controls: { 
@@ -11,3 +12,5 @@ export const parameters = {
       hideNoControlsWarning: true
     }
   }
+
+export const decorators = [withPerformance];

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -47,6 +47,7 @@
         "react-hook-form": "^7.38.0",
         "react-router-dom": "^6.3.0",
         "storybook": "^7.6.7",
+        "storybook-addon-performance": "^0.17.3",
         "ts-loader": "^9.5.0",
         "typescript": "^4.9.5",
         "webpack": "^5.89.0"
@@ -5934,6 +5935,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@storybook/client-logger": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.20.tgz",
+      "integrity": "sha512-NwG0VIJQCmKrSaN5GBDFyQgTAHLNishUPLW1NrzqTDNAhfZUoef64rPQlinbopa0H4OXmlB+QxbQIb3ubeXmSQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/codemod": {
       "version": "7.6.10",
       "dev": true,
@@ -8333,6 +8347,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/@storybook/theming": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.6.20.tgz",
+      "integrity": "sha512-iT1pXHkSkd35JsCte6Qbanmprx5flkqtSHC6Gi6Umqoxlg9IjiLPmpHbaIXzoC06DSW93hPj5Zbi1lPlTvRC7Q==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@storybook/client-logger": "7.6.20",
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@storybook/types": {
       "version": "7.6.10",
       "dev": true,
@@ -8924,9 +8958,9 @@
       "peer": true
     },
     "node_modules/@ukic/web-components": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.18.1.tgz",
-      "integrity": "sha512-gSdVdvwDQsFJe2c/2b0VWebhzp5nhRY0Y7ehNXaW1r7y8crTvoqGl6hHI52QgMEEQUMxjSNIAzzzKj0y4mdirA==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.24.0.tgz",
+      "integrity": "sha512-Lin2Z+61C2YocViLbhnG3VdT0T45klYDpcD3Rfo++C5hbkGnmL2/EaXTmEanCm1Af2NtmKoMCnt01Q4syuV07g==",
       "dependencies": {
         "@popperjs/core": "^2.11.2",
         "@stencil/core": "^4.9.0"
@@ -9070,6 +9104,29 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xstate/react": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.2.2.tgz",
+      "integrity": "sha512-feghXWLedyq8JeL13yda3XnHPZKwYDN5HPBLykpLeuNpr9178tQd2/3d0NrH6gSd0sG5mLuLeuD+ck830fgzLQ==",
+      "dev": true,
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@xstate/fsm": "^2.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "xstate": "^4.37.2"
+      },
+      "peerDependenciesMeta": {
+        "@xstate/fsm": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -20108,6 +20165,26 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/storybook-addon-performance": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/storybook-addon-performance/-/storybook-addon-performance-0.17.3.tgz",
+      "integrity": "sha512-N0l790tvRf3LarCP9u/GMWVMvb2+x4eaJLtoAHguXBwab5Zgc5wPARTWOrtzS1DlLwwQPxbkzGVixEYntZKEFA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/manager-api": "^7.6.10",
+        "@storybook/theming": "^7.6.10",
+        "@storybook/types": "^7.6.10",
+        "@xstate/react": "^3.2.2",
+        "xstate": "^4.38.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "dev": true,
@@ -21354,6 +21431,20 @@
         }
       }
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-resize-observer": {
       "version": "9.1.0",
       "dev": true,
@@ -21385,6 +21476,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -21918,6 +22018,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xstate": {
+      "version": "4.38.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
+      "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
       }
     },
     "node_modules/xtend": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -78,6 +78,7 @@
     "react-hook-form": "^7.38.0",
     "react-router-dom": "^6.3.0",
     "storybook": "^7.6.7",
+    "storybook-addon-performance": "^0.17.3",
     "ts-loader": "^9.5.0",
     "typescript": "^4.9.5",
     "webpack": "^5.89.0"


### PR DESCRIPTION
Add the storybook-addon-performance package to react. Now the performance tab is visible in react storybook

ref #2087

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
First commit added the performance addon to React storybook.
Potentially follow up commits will add an 'Interaction' (as per [the addon's documentation](https://storybook.js.org/addons/storybook-addon-performance) ) to one of the Stories

As of yet i'm unsure how we can make use of this package. The docs mention using a 'Save API' to save results, but there's no example given. I think this is purely going to be a manual test, and in the browser is the only place i've found the ability to Save results. 

<img width="1897" alt="Screenshot 2024-07-17 at 15 22 44" src="https://github.com/user-attachments/assets/170e3685-94de-4540-8a82-9c5b579902c8">


## Related issue
#2087 
