### PR TITLE
fix(web-components): make card contents stop overflowing when text size increased

### DIFF
--- a/packages/react/src/stories/ic-card.stories.mdx
+++ b/packages/react/src/stories/ic-card.stories.mdx
@@ -412,14 +412,15 @@ import { NavLink, MemoryRouter, Switch, Route, Routes } from "react-router-dom";
   </Story>
 </Canvas>
 
-### Reduced width
+### Custom width
 
 <Canvas>
-  <Story name="Reduced width">
+  <Story name="Custom width">
+    <div style={{ display: "flex", gap: "16px", flexDirection: "column" }}>
     <IcCard
       heading="This is the card heading"
       subheading="This is the subheading"
-      message="This is an example of a new card component with text included and a reduced width."
+      message="This is an example of a reduced width card component."
       style={{ width: "300px" }}
       expandable
     >
@@ -444,6 +445,7 @@ import { NavLink, MemoryRouter, Switch, Route, Routes } from "react-router-dom";
         slot="image-mid"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 1600 900"
+        style={{ height: "326px", width: "326px" }}
       >
         <rect fill="#ff7700" width="1600" height="1600" y="-350" />
         <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
@@ -484,6 +486,76 @@ import { NavLink, MemoryRouter, Switch, Route, Routes } from "react-router-dom";
         Hide
       </IcButton>
     </IcCard>
+    <IcCard
+      heading="This is the card heading"
+      subheading="This is the subheading"
+      message="This is an example of an increased width card component."
+      style={{ width: "500px" }}
+      expandable
+    >
+      <IcStatusTag slot="adornment" label="Neutral" size="small" />
+      <IcButton
+        variant="icon"
+        title="More information"
+        slot="interaction-button"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          class="bi bi-three-dots-vertical"
+          viewBox="0 0 16 16"
+        >
+          <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
+        </svg>
+      </IcButton>
+      <svg
+        slot="image-mid"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 1600 900"
+        style={{ height: "526px", width: "526px" }}
+      >
+        <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+        <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+        <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+        <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+        <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+        <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+        <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+        <polygon fill="#b80066" points="641 695 886 900 367 900" />
+        <polygon fill="#960052" points="587 900 641 695 886 900" />
+        <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+        <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+        <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+        <polygon fill="#880088" points="943 900 1210 900 971 687" />
+      </svg>
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        fill="#000000"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+      </svg>
+      <IcButton slot="interaction-controls" variant="primary">
+        Learn more
+      </IcButton>
+      <IcButton slot="interaction-controls" variant="secondary">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <title>heart-outline</title>
+          <path d="M12.1,18.55L12,18.65L11.89,18.55C7.14,14.24 4,11.39 4,8.5C4,6.5 5.5,5 7.5,5C9.04,5 10.54,6 11.07,7.36H12.93C13.46,6 14.96,5 16.5,5C18.5,5 20,6.5 20,8.5C20,11.39 16.86,14.24 12.1,18.55M16.5,3C14.76,3 13.09,3.81 12,5.08C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.41 2,8.5C2,12.27 5.4,15.36 10.55,20.03L12,21.35L13.45,20.03C18.6,15.36 22,12.27 22,8.5C22,5.41 19.58,3 16.5,3Z" />
+        </svg>
+        Add to favourites
+      </IcButton>
+      <IcButton slot="interaction-controls" variant="secondary">
+        Hide
+      </IcButton>
+    </IcCard>
+    </div>
   </Story>
 </Canvas>
 
@@ -836,7 +908,7 @@ export const defaultArgs = {
     name="Playground"
   >
     {(args) => (
-    <IcCard 
+    <IcCard
       clickable={args.clickable}
       disabled={args.disabled}
       expandable={args.expandable}

--- a/packages/web-components/src/components/ic-card/ic-card.css
+++ b/packages/web-components/src/components/ic-card/ic-card.css
@@ -26,8 +26,11 @@ button {
   text-align: left;
   color: var(--ic-architechtural-black);
   transition: var(--ic-easing-transition-fast);
-  width: inherit;
   position: relative;
+  width: inherit;
+  min-width: fit-content;
+  height: fit-content;
+  min-height: 100%;
 }
 
 .dark.card,

--- a/packages/web-components/src/components/ic-card/ic-card.stories.mdx
+++ b/packages/web-components/src/components/ic-card/ic-card.stories.mdx
@@ -459,91 +459,176 @@ import Button from "../ic-button/readme.md";
   </Story>
 </Canvas>
 
-### Reduced width
+### Custom width
 
 <Canvas>
-  <Story name="Reduced width" parameters={{ loki: { skip: true } }}>
-    {html`<ic-card
-      heading="This is the card heading"
-      subheading="This is the subheading"
-      message="This is an example of a new card component with text included and a reduced width."
-      style="width:300px;"
-      expandable="true"
-    >
-      <ic-status-tag
-        slot="adornment"
-        label="Neutral"
-        size="small"
-      ></ic-status-tag>
-      <ic-button
-        variant="icon"
-        title="More information"
-        slot="interaction-button"
+  <Story name="Custom width" parameters={{ loki: { skip: true } }}>
+    {html`<div style="display: flex; gap: 16px; flex-direction: column;">
+      <ic-card
+        heading="This is the card heading"
+        subheading="This is the subheading"
+        message="This is an example of a reduced width card component."
+        style="width:300px;"
+        expandable="true"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          fill="currentColor"
-          class="bi bi-three-dots-vertical"
-          viewBox="0 0 16 16"
+        <ic-status-tag
+          slot="adornment"
+          label="Neutral"
+          size="small"
+        ></ic-status-tag>
+        <ic-button
+          variant="icon"
+          title="More information"
+          slot="interaction-button"
         >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-three-dots-vertical"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+            />
+          </svg>
+        </ic-button>
+        <svg
+          slot="image-mid"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 1600 900"
+          style="height:326px;width:326px;"
+        >
+          <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+          <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+          <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+          <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+          <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+          <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+          <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+          <polygon fill="#b80066" points="641 695 886 900 367 900" />
+          <polygon fill="#960052" points="587 900 641 695 886 900" />
+          <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+          <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+          <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+          <polygon fill="#880088" points="943 900 1210 900 971 687" />
+        </svg>
+        <svg
+          slot="icon"
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
           <path
-            d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
           />
         </svg>
-      </ic-button>
-      <svg
-        slot="image-mid"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 1600 900"
-      >
-        <rect fill="#ff7700" width="1600" height="1600" y="-350" />
-        <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
-        <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
-        <polygon fill="#c50022" points="-60 900 398 662 816 900" />
-        <polygon fill="#a3001b" points="337 900 398 662 816 900" />
-        <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
-        <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
-        <polygon fill="#b80066" points="641 695 886 900 367 900" />
-        <polygon fill="#960052" points="587 900 641 695 886 900" />
-        <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
-        <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
-        <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
-        <polygon fill="#880088" points="943 900 1210 900 971 687" />
-      </svg>
-      <svg
-        slot="icon"
-        xmlns="http://www.w3.org/2000/svg"
-        height="24px"
-        viewBox="0 0 24 24"
-        width="24px"
-        fill="#000000"
-      >
-        <path d="M0 0h24v24H0V0z" fill="none" />
-        <path
-          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-        />
-      </svg>
-      <ic-button slot="interaction-controls" variant="primary"
-        >Learn more</ic-button
-      >
-      <ic-button slot="interaction-controls" variant="secondary"
-        ><svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          slot="left-icon"
+        <ic-button slot="interaction-controls" variant="primary"
+          >Learn more</ic-button
         >
-          <title>heart-outline</title>
+        <ic-button slot="interaction-controls" variant="secondary"
+          ><svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            slot="left-icon"
+          >
+            <title>heart-outline</title>
+            <path
+              d="M12.1,18.55L12,18.65L11.89,18.55C7.14,14.24 4,11.39 4,8.5C4,6.5 5.5,5 7.5,5C9.04,5 10.54,6 11.07,7.36H12.93C13.46,6 14.96,5 16.5,5C18.5,5 20,6.5 20,8.5C20,11.39 16.86,14.24 12.1,18.55M16.5,3C14.76,3 13.09,3.81 12,5.08C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.41 2,8.5C2,12.27 5.4,15.36 10.55,20.03L12,21.35L13.45,20.03C18.6,15.36 22,12.27 22,8.5C22,5.41 19.58,3 16.5,3Z"
+            /></svg
+          >Add to favourites</ic-button
+        >
+        <ic-button slot="interaction-controls" variant="secondary"
+          >Hide</ic-button
+        >
+      </ic-card>
+      <ic-card
+        heading="This is the card heading"
+        subheading="This is the subheading"
+        message="This is an example of an increased width card component."
+        style="width:500px;"
+        expandable="true"
+      >
+        <ic-status-tag
+          slot="adornment"
+          label="Neutral"
+          size="small"
+        ></ic-status-tag>
+        <ic-button
+          variant="icon"
+          title="More information"
+          slot="interaction-button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            class="bi bi-three-dots-vertical"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+            />
+          </svg>
+        </ic-button>
+        <svg
+          slot="image-mid"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 1600 900"
+          style="height:526px;width:526px;"
+        >
+          <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+          <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+          <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+          <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+          <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+          <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+          <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+          <polygon fill="#b80066" points="641 695 886 900 367 900" />
+          <polygon fill="#960052" points="587 900 641 695 886 900" />
+          <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+          <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+          <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+          <polygon fill="#880088" points="943 900 1210 900 971 687" />
+        </svg>
+        <svg
+          slot="icon"
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
           <path
-            d="M12.1,18.55L12,18.65L11.89,18.55C7.14,14.24 4,11.39 4,8.5C4,6.5 5.5,5 7.5,5C9.04,5 10.54,6 11.07,7.36H12.93C13.46,6 14.96,5 16.5,5C18.5,5 20,6.5 20,8.5C20,11.39 16.86,14.24 12.1,18.55M16.5,3C14.76,3 13.09,3.81 12,5.08C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.41 2,8.5C2,12.27 5.4,15.36 10.55,20.03L12,21.35L13.45,20.03C18.6,15.36 22,12.27 22,8.5C22,5.41 19.58,3 16.5,3Z"
-          /></svg
-        >Add to favourites</ic-button
-      >
-      <ic-button slot="interaction-controls" variant="secondary"
-        >Hide</ic-button
-      >
-    </ic-card>`}
+            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+          />
+        </svg>
+        <ic-button slot="interaction-controls" variant="primary"
+          >Learn more</ic-button
+        >
+        <ic-button slot="interaction-controls" variant="secondary"
+          ><svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            slot="left-icon"
+          >
+            <title>heart-outline</title>
+            <path
+              d="M12.1,18.55L12,18.65L11.89,18.55C7.14,14.24 4,11.39 4,8.5C4,6.5 5.5,5 7.5,5C9.04,5 10.54,6 11.07,7.36H12.93C13.46,6 14.96,5 16.5,5C18.5,5 20,6.5 20,8.5C20,11.39 16.86,14.24 12.1,18.55M16.5,3C14.76,3 13.09,3.81 12,5.08C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.41 2,8.5C2,12.27 5.4,15.36 10.55,20.03L12,21.35L13.45,20.03C18.6,15.36 22,12.27 22,8.5C22,5.41 19.58,3 16.5,3Z"
+            /></svg
+          >Add to favourites</ic-button
+        >
+        <ic-button slot="interaction-controls" variant="secondary"
+          >Hide</ic-button
+        >
+      </ic-card>
+    </div>`}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
## Summary of the changes
- Added CSS to card component to stop its contents overflowing when it has a set height or width and the text size is increased. 
- Change 'Reduced width' card stories to include an increased width card as well to help with checking that changing the text size works for different widths.
- ^ Changed text to fewer words to help with checking the cards aren't wrapping to the width of the text.
- Added sizes to the images as not having a size was causing the images to not display in Safari.

To test this, go to the 'Reduced width' and 'Additional height' card stories and increase the text size in the browser (e.g. in Chrome, Settings > Appearance > Font size).

## Related issue
#1860 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.