### PR TITLE
fix(web-components): extra check to default & remove dupe conditional

### DIFF
--- a/packages/react/src/component-tests/IcClassificationBanner/IcClassificationBanner.cy.tsx
+++ b/packages/react/src/component-tests/IcClassificationBanner/IcClassificationBanner.cy.tsx
@@ -29,6 +29,23 @@ describe("IcClassificationButton visual and a11y testing", () => {
     });
   });
 
+  it("should render undefined props to default design", () => {
+    mount(
+      <IcClassificationBanner
+        classification={undefined}
+        country={undefined}
+        additionalSelectors={undefined}
+      ></IcClassificationBanner>
+    );
+    cy.checkHydrated(BANNER);
+
+    cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "undefined",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.013),
+    });
+  });
+
   it("should test official classification banner", () => {
     mount(
       <IcClassificationBanner classification="official"></IcClassificationBanner>

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.tsx
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.tsx
@@ -37,7 +37,17 @@ export class ClassificationBanner {
   @Prop() upTo?: boolean = false;
 
   render() {
-    const { classification, inline, country, upTo, additionalSelectors } = this;
+    const { inline, upTo } = this;
+
+    // In case of unrecognized props, fallback to default
+    let { country, additionalSelectors, classification } = this;
+    if (!country) country = "";
+    if (!additionalSelectors) additionalSelectors = "";
+    if (
+      !classification ||
+      (classification && !classificationText[classification])
+    )
+      classification = "default";
 
     return (
       <Host class={{ ["inline"]: inline }}>
@@ -57,9 +67,9 @@ export class ClassificationBanner {
             {classification === "default"
               ? classificationText[classification]
               : `${upTo ? "up to" : ""} 
-               ${country !== "" ? country : ""} 
+               ${country} 
                ${classificationText[classification]} 
-               ${additionalSelectors !== "" ? additionalSelectors : ""}`}
+               ${additionalSelectors}`}
           </ic-typography>
         </banner>
       </Host>

--- a/packages/web-components/src/components/ic-classification-banner/test/basic/ic-classification-banner.spec.ts
+++ b/packages/web-components/src/components/ic-classification-banner/test/basic/ic-classification-banner.spec.ts
@@ -138,6 +138,57 @@ describe("ic-classification-banner component", () => {
         </ic-classification-banner>`);
   });
 
+  it("should render default banner if no props are passed", async () => {
+    const page = await newSpecPage({
+      components: [ClassificationBanner],
+      html: `<ic-classification-banner></ic-classification-banner>`,
+    });
+    expect(page.root).toEqualHtml(`
+        <ic-classification-banner>
+          <mock:shadow-root>
+            <banner aria-label="Protective marking" class="classification-banner default">
+              <ic-typography variant="caption-uppercase">
+                protective marking not set
+              </ic-typography>
+            </banner>
+          </mock:shadow-root>
+        </ic-classification-banner>`);
+  });
+
+  it("should render default banner if props with empty strings are passed", async () => {
+    const page = await newSpecPage({
+      components: [ClassificationBanner],
+      html: `<ic-classification-banner classification="" country="" additionalSelectors=""></ic-classification-banner>`,
+    });
+    expect(page.root).toEqualHtml(`
+        <ic-classification-banner classification="" country="" additionalSelectors="">
+          <mock:shadow-root>
+            <banner aria-label="Protective marking" class="classification-banner default">
+              <ic-typography variant="caption-uppercase">
+                protective marking not set
+              </ic-typography>
+            </banner>
+          </mock:shadow-root>
+        </ic-classification-banner>`);
+  });
+
+  it("should render default banner if props with undefined are passed", async () => {
+    const page = await newSpecPage({
+      components: [ClassificationBanner],
+      html: `<ic-classification-banner classification=${undefined} country=${undefined} additionalSelectors=${undefined}></ic-classification-banner>`,
+    });
+    expect(page.root).toEqualHtml(`
+        <ic-classification-banner classification="undefined" country="undefined" additionalSelectors="undefined">
+          <mock:shadow-root>
+            <banner aria-label="Protective marking" class="classification-banner default">
+              <ic-typography variant="caption-uppercase">
+                protective marking not set
+              </ic-typography>
+            </banner>
+          </mock:shadow-root>
+        </ic-classification-banner>`);
+  });
+
   it("should render with additional selectors after classification when supplied", async () => {
     const page = await newSpecPage({
       components: [ClassificationBanner],


### PR DESCRIPTION
## Summary of the changes
Wasn't able to reproduce the bug, but I believe an extra check in the render should do the trick. If you can show me code to make the reproduction viable, I can adjust the PR to that (https://github.com/evenstensberg/banner-repro-ic/blob/master/src/HelloWorldComponent.js)

## Related issue
#2177

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.