### PR TITLE
fix(web-components): fixes accordion using wrong text color

### DIFF
--- a/packages/web-components/src/components/ic-accordion-group/ic-accordion-group.css
+++ b/packages/web-components/src/components/ic-accordion-group/ic-accordion-group.css
@@ -16,9 +16,9 @@
 }
 
 :host(.light) {
-  color: var(--ic-architectural-white);
+  color: var(--ic-color-white-text);
 }
 
 :host(.accordion-group.dark) ::slotted(ic-accordion) {
-  color: var(--ic-architectural-white);
+  color: var(--ic-color-white-text);
 }

--- a/packages/web-components/src/components/ic-accordion/ic-accordion.css
+++ b/packages/web-components/src/components/ic-accordion/ic-accordion.css
@@ -5,11 +5,16 @@
   border-bottom: var(--ic-border-default);
 }
 
+:host ic-typography,
+:host .expand-chevron {
+  color: var(--ic-color-primary-text);
+}
+
 :host(.light) ic-typography,
 :host(.light) .expanded-content,
 :host(.light) .icon-container,
 :host(.light) .expand-chevron {
-  color: var(--ic-architectural-white);
+  color: var(--ic-color-white-text);
 }
 
 :host(.disabled) ic-typography,


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Now using primary text color as per designs

## Related issue
#2210 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.