### PR TITLE
chore: move webpack to its own folder

### DIFF
--- a/packages/canary-react/.webpack/webpack.config.js
+++ b/packages/canary-react/.webpack/webpack.config.js
@@ -1,6 +1,10 @@
 const path = require('path');
 
 module.exports = {
+    context: path.join(__dirname, '..'),
+    output: {
+        path: path.join(__dirname, '..', 'dist')
+    },
     module: {
         rules: [
             {

--- a/packages/canary-react/cypress/plugins/index.js
+++ b/packages/canary-react/cypress/plugins/index.js
@@ -3,7 +3,7 @@ module.exports = on => {
   const options = {
     // send in the options from your webpack.config.js, so it works the same
     // as your app's code
-    webpackOptions: require('../../webpack.config'),
+    webpackOptions: require('../../.webpack/webpack.config'),
     watchOptions: {}
   }
 

--- a/packages/fonts/.webpack/webpack.config.js
+++ b/packages/fonts/.webpack/webpack.config.js
@@ -2,11 +2,12 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
+  context: path.join(__dirname, '..'),
   entry: './src/fonts.js',
   output: {
     filename: 'fonts.js',
     assetModuleFilename: '[name][ext]',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, '..', 'dist')
   },
   mode: 'production',
   plugins: [new MiniCssExtractPlugin({

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -3,7 +3,7 @@
   "version": "2.6.0",
   "description": "Typography assets for @ukic components",
   "scripts": {
-    "build": "rimraf ./dist && webpack --config webpack.config.js",
+    "build": "rimraf ./dist && webpack --config .webpack/webpack.config.js",
     "audit": "echo 'Audit for: @ukic/fonts' && audit-ci -m --config ../../audit-ci.json"
   },
   "license": "MIT",

--- a/packages/nextjs/.webpack/webpack.config.js
+++ b/packages/nextjs/.webpack/webpack.config.js
@@ -1,6 +1,10 @@
 const path = require('path');
 
 module.exports = {
+    context: path.join(__dirname, '..'),
+    output: {
+        path: path.join(__dirname, '..', 'dist')
+    },
     module: {
         rules: [
             {

--- a/packages/react/.webpack/webpack.config.js
+++ b/packages/react/.webpack/webpack.config.js
@@ -1,6 +1,10 @@
 const path = require('path');
 
 module.exports = {
+    context: path.join(__dirname, '..'),
+    output: {
+        path: path.join(__dirname, '..', 'dist')
+    },
     module: {
         rules: [
             {
@@ -10,7 +14,7 @@ module.exports = {
             },
             {
                 test: /\.css$/i,
-                use: ["style-loader", "css-loader"],
+                use: ['style-loader', 'css-loader'],
             },
         ]
     },

--- a/packages/react/cypress.config.ts
+++ b/packages/react/cypress.config.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { defineConfig } from "cypress";
+import webpackConfig from "./.webpack/webpack.config";
 
 export const config: Cypress.ConfigOptions = {
   component: {
     devServer: {
       framework: "react",
       bundler: "webpack",
+      webpackConfig
     },
     fixturesFolder: "./src/component-tests",
     setupNodeEvents(on, config) {

--- a/packages/react/cypress/plugins/index.js
+++ b/packages/react/cypress/plugins/index.js
@@ -1,9 +1,10 @@
 import webpack from '@cypress/webpack-preprocessor'
+
 export default on => {
   const options = {
     // send in the options from your webpack.config.js, so it works the same
     // as your app's code
-    webpackOptions: require('../../webpack.config'),
+    webpackOptions: require('../../.webpack/webpack.config'),
     watchOptions: {}
   }
 


### PR DESCRIPTION
## Summary of the changes
Moves webpack to dedicated folder.

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.