### PR TITLE
test(react): adding a11y checks to existing HCM visual regression tests

### DIFF
--- a/packages/react/src/component-tests/IcPageHeader/IcPageHeader.cy.tsx
+++ b/packages/react/src/component-tests/IcPageHeader/IcPageHeader.cy.tsx
@@ -17,9 +17,11 @@ import {
   PageHeaderSlottedHeadings,
 } from "./IcPageHeaderTestData";
 import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
+
+const IC_PAGE_HEADER_SELECTOR = "ic-page-header";
 const DEFAULT_TEST_THRESHOLD = 0.042;
 
-describe("IcPageHeader", () => {
+describe("IcPageHeader visual regression and a11y tests", () => {
   beforeEach(() => {
     cy.injectAxe();
     cy.viewport(1450, 500);
@@ -32,7 +34,7 @@ describe("IcPageHeader", () => {
   it("should render default", () => {
     mount(<PageHeaderDefault />);
 
-    cy.checkHydrated("ic-page-header");
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
 
     cy.checkA11yWithWait();
     cy.compareSnapshot({
@@ -61,7 +63,7 @@ describe("IcPageHeader", () => {
     cy.viewport("iphone-6");
     mount(<DesktopScrollablePageVariant />);
 
-    cy.checkHydrated("ic-page-header");
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
 
     cy.scrollTo("bottom");
 
@@ -78,6 +80,8 @@ describe("IcPageHeader", () => {
   it("should render center aligned", () => {
     mount(PageheaderAlign("center"));
 
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
     cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "center-page-header",
@@ -87,6 +91,8 @@ describe("IcPageHeader", () => {
 
   it("should render small", () => {
     mount(<PageHeaderSmallSize />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
 
     cy.checkA11yWithWait();
     cy.compareSnapshot({
@@ -98,6 +104,8 @@ describe("IcPageHeader", () => {
   it("should render full width", () => {
     mount(PageheaderAlign("full-width"));
 
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
     cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "full-width-page-header",
@@ -107,6 +115,8 @@ describe("IcPageHeader", () => {
 
   it("should render without border", () => {
     mount(<PageHeaderWithoutBorder />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
 
     cy.checkA11yWithWait();
     cy.compareSnapshot({
@@ -142,6 +152,9 @@ describe("IcPageHeader", () => {
 
   it("should render with breadcrumbs", () => {
     mount(<PageHeaderWithBreadcrumbNav />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
     cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "with-breadcrumb",
@@ -151,6 +164,9 @@ describe("IcPageHeader", () => {
 
   it("should render with slotted headings", () => {
     mount(<PageHeaderSlottedHeadings />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
     cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "with-slotted-headings",
@@ -158,58 +174,82 @@ describe("IcPageHeader", () => {
     });
   });
 
-  describe("IcPageHeader visual regression in high contrast mode", () => {
-    before(() => {
-      cy.enableForcedColors();
-    });
-
-    after(() => {
-      cy.disableForcedColors();
-    });
-
-    afterEach(() => {
-      cy.task("generateReport");
-    });
-
-    it("should render", () => {
-      mount(<PageHeaderDefault />);
-      cy.compareSnapshot({
-        name: "default-high-contrast",
-        testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.037),
-      });
-    });
-
-    it("should render with actions, input and tabs", () => {
-      mount(<PageHeaderWithActionsInputTabs />);
-      cy.compareSnapshot({
-        name: "actions-input-tabs-high-contrast",
-        testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.048),
-      });
-    });
-
-    it("should render with breadcrumbs", () => {
-      mount(<PageHeaderWithBreadcrumbNav />);
-      cy.compareSnapshot({
-        name: "breadcrumbs-high-contrast",
-        testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.039),
-      });
-    });
-
-    it("should render with stepper", () => {
-      mount(<PageHeaderWithStepper />);
-      cy.compareSnapshot({
-        name: "stepper-high-contrast",
-        testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.011),
-      });
-    });
-  });
-
   it("should render with slotted headings", () => {
     mount(<PageHeaderSlottedHeadings />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
     cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "with-slotted-headings",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
+    });
+  });
+});
+
+describe("IcPageHeader visual regression tests in high contrast mode", () => {
+  before(() => {
+    cy.enableForcedColors();
+  });
+
+  beforeEach(() => {
+    cy.injectAxe();
+    cy.viewport(1450, 500);
+  });
+
+  afterEach(() => {
+    cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
+  });
+
+  it("should render default in high contrast mode", () => {
+    mount(<PageHeaderDefault />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
+    //cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "default-high-contrast",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.037),
+    });
+  });
+
+  it("should render with actions, input and tabs in high contrast mode", () => {
+    mount(<PageHeaderWithActionsInputTabs />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
+    //cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "actions-input-tabs-high-contrast",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.048),
+    });
+  });
+
+  it("should render with breadcrumbs in high contrast mode", () => {
+    mount(<PageHeaderWithBreadcrumbNav />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
+    //cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "breadcrumbs-high-contrast",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.039),
+    });
+  });
+
+  it("should render with stepper in high contrast mode", () => {
+    mount(<PageHeaderWithStepper />);
+
+    cy.checkHydrated(IC_PAGE_HEADER_SELECTOR);
+
+    //cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "stepper-high-contrast",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.011),
     });
   });
 });

--- a/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
@@ -296,12 +296,16 @@ describe("IcRadio visual regression tests in high contrast mode", () => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render default IcRadio in high contrast mode", () => {
@@ -309,6 +313,7 @@ describe("IcRadio visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "default-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.017),
@@ -321,6 +326,7 @@ describe("IcRadio visual regression tests in high contrast mode", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
     cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "conditional-dynamic-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.064),

--- a/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
+++ b/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
@@ -336,18 +336,24 @@ describe("IcSearchBar visual regression tests in high contrast mode", () => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
   });
 
+  after(() => {
+    cy.disableForcedColors();
+  });
+
   it("should render default search bar in high contrast mode", () => {
     mount(<Default />);
 
     cy.checkHydrated(SEARCH_SELECTOR);
+
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "default-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.018),
@@ -358,6 +364,8 @@ describe("IcSearchBar visual regression tests in high contrast mode", () => {
     mount(<Disabled />);
 
     cy.checkHydrated(SEARCH_SELECTOR);
+
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "disabled-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.018),
@@ -374,6 +382,7 @@ describe("IcSearchBar visual regression tests in high contrast mode", () => {
       .find(SEARCH_INPUT)
       .focus();
 
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "focused-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.016),
@@ -394,6 +403,7 @@ describe("IcSearchBar visual regression tests in high contrast mode", () => {
     cy.get("@input").focus();
     cy.realType("La").wait(200);
 
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "options-no-filtering-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.042),

--- a/packages/react/src/component-tests/IcStatusTag/IcStatusTag.cy.tsx
+++ b/packages/react/src/component-tests/IcStatusTag/IcStatusTag.cy.tsx
@@ -105,12 +105,16 @@ describe("IcStatusTag visual regression tests in high contrast mode", () => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render all status tags in high contrast mode", () => {
@@ -118,6 +122,7 @@ describe("IcStatusTag visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(STATUS_TAG_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.033),

--- a/packages/react/src/component-tests/IcStepper/IcStepper.cy.tsx
+++ b/packages/react/src/component-tests/IcStepper/IcStepper.cy.tsx
@@ -151,14 +151,15 @@ describe("IcStepper visual regression tests in high contrast mode", () => {
 
   beforeEach(() => {
     cy.viewport(1024, 500);
-  });
-
-  after(() => {
-    cy.disableForcedColors();
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render a compact stepper in high contrast mode", () => {
@@ -166,6 +167,7 @@ describe("IcStepper visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(STEPPER_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "compact-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.022),
@@ -177,6 +179,7 @@ describe("IcStepper visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(STEPPER_SELECTOR);
 
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "full-width-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.015),
@@ -190,6 +193,7 @@ describe("IcStepper visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(STEPPER_SELECTOR);
 
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "custom-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.049),

--- a/packages/react/src/component-tests/IcSwitch/IcSwitch.cy.tsx
+++ b/packages/react/src/component-tests/IcSwitch/IcSwitch.cy.tsx
@@ -145,12 +145,16 @@ describe("IcSwitch visual regression tests in high contrast mode", () => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render an unchecked switch in high contrast mode", () => {
@@ -158,6 +162,7 @@ describe("IcSwitch visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(SWITCH_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "unchecked-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.019),
@@ -169,6 +174,7 @@ describe("IcSwitch visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(SWITCH_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "checked-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.018),
@@ -180,6 +186,7 @@ describe("IcSwitch visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(SWITCH_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "disabled-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.026),
@@ -191,6 +198,7 @@ describe("IcSwitch visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(SWITCH_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "helper-text-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.038),

--- a/packages/react/src/component-tests/IcTabs/IcTabs.cy.tsx
+++ b/packages/react/src/component-tests/IcTabs/IcTabs.cy.tsx
@@ -597,17 +597,21 @@ describe("IcTab visual regression tests", () => {
   });
 });
 
-describe("IcTabs visual regression in high contrast mode", () => {
+describe("IcTabs visual regression tests in high contrast mode", () => {
   before(() => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render a tab group with tab focussed", () => {
@@ -617,6 +621,7 @@ describe("IcTabs visual regression in high contrast mode", () => {
     cy.focused().as("activeElement");
     cy.get("@activeElement").should(CONTAIN_TEXT, "Method");
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "focused-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.012),
@@ -626,6 +631,7 @@ describe("IcTabs visual regression in high contrast mode", () => {
   it("should render disabled tab", () => {
     mount(<DisabledTab />);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "disabled-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.008),
@@ -635,6 +641,7 @@ describe("IcTabs visual regression in high contrast mode", () => {
   it("should render inline tab group", () => {
     mount(<InlineTabGroup />);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "inline-prop-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.012),

--- a/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
@@ -448,52 +448,60 @@ describe("IcTextField visual regression tests", () => {
   });
 });
 
-describe("IcTextField visual regression in high contrast mode", () => {
+describe("IcTextField visual regression tests in high contrast mode", () => {
   before(() => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
   });
 
-  it("renders a text field with input focused", () => {
+  after(() => {
+    cy.disableForcedColors();
+  });
+
+  it("renders a text field with input focused in high contrast mode", () => {
     mount(<SimpleTextField />);
 
     cy.findShadowEl(IC_TEXTFIELD, TEXTFIELD_INPUT).click();
     cy.get(IC_TEXTFIELD).should(HAVE_FOCUS);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "focused-input-text-field-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
     });
   });
 
-  it("renders disabled", () => {
+  it("renders disabled text field in high contrast mode", () => {
     mount(<DisabledTextField />);
 
+    cy.checkA11yWithWait();
     cy.wait(100).compareSnapshot({
       name: "disabled-text-field-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.027),
     });
   });
 
-  it("renders a readonly text field", () => {
+  it("renders a readonly text field in high cobtrast mode", () => {
     mount(<ReadonlyTextField />);
 
+    cy.checkA11yWithWait();
     cy.wait(100).compareSnapshot({
       name: "readonly-text-field-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.031),
     });
   });
 
-  it("renders validation status and text", () => {
+  it("renders validation status and text in high contrast mode", () => {
     mount(<TextFieldWithValidation />);
 
+    cy.checkA11yWithWait();
     cy.wait(100).compareSnapshot({
       name: "validation-text-field-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.115),

--- a/packages/react/src/component-tests/IcToggleButtonGroup/IcToggleButtonGroup.cy.tsx
+++ b/packages/react/src/component-tests/IcToggleButtonGroup/IcToggleButtonGroup.cy.tsx
@@ -54,7 +54,7 @@ const TOGGLE_BUTTON_AXE_OPTIONS = {
 const WIN_CONSOLE_SPY = "@spyWinConsoleLog";
 
 describe("IcToggleButtonGroup", () => {
-  describe("E2E", () => {
+  describe("End-to-end tests", () => {
     it("should check single/manual on only one toggle", () => {
       mount(<ToggleGroupSingle />);
       cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
@@ -65,6 +65,7 @@ describe("IcToggleButtonGroup", () => {
       getToggle(0).should(NOT_HAVE_ATTR, "toggle-checked");
       getToggle(2).should(HAVE_ATTR, "toggle-checked");
     });
+
     it("should check multi on several toggles", () => {
       mount(<ToggleGroupMulti />);
       cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
@@ -76,6 +77,7 @@ describe("IcToggleButtonGroup", () => {
       getToggle(1).click();
       getToggle(1).should(HAVE_ATTR, "toggle-checked");
     });
+
     it("should focus parent but not interact with toggle when disabled", () => {
       cy.spy(window.console, "log").as("spyWinConsoleLog");
       mount(<ToggleGroupDisabled />);
@@ -86,6 +88,7 @@ describe("IcToggleButtonGroup", () => {
       getToggle(1).click({ force: true });
       cy.get(WIN_CONSOLE_SPY).should(NOT_HAVE_BEEN_CALLED);
     });
+
     it("should focus toggle but not check with toggle when loading", () => {
       cy.spy(window.console, "log").as("spyWinConsoleLog");
       mount(<ToggleGroupLoading />);
@@ -96,6 +99,7 @@ describe("IcToggleButtonGroup", () => {
       getToggle(1).click({ force: true });
       cy.get(WIN_CONSOLE_SPY).should(NOT_HAVE_BEEN_CALLED);
     });
+
     it("should tab through toggles and check focus and selection state", () => {
       mount(<ToggleGroupSingle />);
       cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
@@ -104,7 +108,8 @@ describe("IcToggleButtonGroup", () => {
       cy.get(IC_TOGGLE_BUTTON_GROUP).should(HAVE_FOCUS);
     });
   });
-  describe("screenshots", () => {
+
+  describe("Visual regression and a11y tests", () => {
     beforeEach(() => {
       cy.injectAxe();
       cy.viewport(500, 500);
@@ -117,6 +122,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render default", () => {
       mount(<ToggleGroupSingle />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -129,6 +135,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render multiple checked", () => {
       mount(<ToggleGroupMulti />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(1).click();
       getToggle(0).click();
 
@@ -142,6 +149,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render small", () => {
       mount(<ToggleGroupSmall />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -154,6 +162,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render large", () => {
       mount(<ToggleGroupLarge />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -166,6 +175,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render full-width", () => {
       mount(<ToggleGroupFullWidth />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -178,6 +188,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render custom width", () => {
       mount(<ToggleGroupCustomWidth />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -190,6 +201,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render toggle with large label", () => {
       mount(<ToggleGroupLargeLabel />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -206,6 +218,7 @@ describe("IcToggleButtonGroup", () => {
         </div>
       );
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -218,6 +231,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render dark", () => {
       mount(<ToggleGroupDark />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -230,6 +244,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render disabled", () => {
       mount(<ToggleGroupDisabled />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
       cy.compareSnapshot({
         name: "disabled",
@@ -240,6 +255,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render loading", () => {
       mount(<ToggleGroupLoading />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       cy.checkA11yWithWait(undefined, 200, TOGGLE_BUTTON_AXE_OPTIONS);
       cy.compareSnapshot({
         name: "loading",
@@ -255,6 +271,7 @@ describe("IcToggleButtonGroup", () => {
         </div>
       );
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       cy.checkA11yWithWait(undefined, 200, TOGGLE_BUTTON_AXE_OPTIONS);
       cy.compareSnapshot({
         name: "loading-light",
@@ -266,6 +283,7 @@ describe("IcToggleButtonGroup", () => {
     it("should render loading dark", () => {
       mount(<ToggleGroupLoadingDark />);
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       cy.checkA11yWithWait(undefined, 200, TOGGLE_BUTTON_AXE_OPTIONS);
       cy.compareSnapshot({
         name: "loading-dark",
@@ -283,6 +301,7 @@ describe("IcToggleButtonGroup", () => {
         </div>
       );
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -300,6 +319,7 @@ describe("IcToggleButtonGroup", () => {
         </div>
       );
 
+      cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
       getToggle(0).click();
 
       cy.checkA11yWithWait(undefined, undefined, TOGGLE_BUTTON_AXE_OPTIONS);
@@ -307,26 +327,34 @@ describe("IcToggleButtonGroup", () => {
   });
 });
 
-describe("IcToggleButtonGroup visual regression in high contrast mode", () => {
+describe("IcToggleButtonGroup visual regression tests in high contrast mode", () => {
   before(() => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
   });
 
+  after(() => {
+    cy.disableForcedColors();
+  });
+
   it("renders a toggle-button group with first button checked and second button focussed", () => {
     mount(<ToggleGroupSingle />);
+
+    cy.checkHydrated(IC_TOGGLE_BUTTON_GROUP);
+
     const toggle = getToggle(0);
     toggle.click();
     cy.realPress("ArrowDown");
     getToggle(1).should(HAVE_FOCUS).wait(200);
 
+    //cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "focused-toggle-checked-toggle-group-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.036),
@@ -338,6 +366,7 @@ describe("IcToggleButtonGroup visual regression in high contrast mode", () => {
     mount(<ToggleGroupDisabled />);
     cy.wait(100);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "disabled-toggle-group-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.012),

--- a/packages/react/src/component-tests/IcTooltip/IcTooltip.cy.tsx
+++ b/packages/react/src/component-tests/IcTooltip/IcTooltip.cy.tsx
@@ -261,12 +261,16 @@ describe("IcTooltip visual regression tests in high contrast mode", () => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render a default IcTooltip in high contrast mode", () => {
@@ -275,6 +279,7 @@ describe("IcTooltip visual regression tests in high contrast mode", () => {
     cy.checkHydrated(TOOLTIP_SELECTOR);
     cy.get("button").realHover("mouse");
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "default-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.003),
@@ -288,6 +293,7 @@ describe("IcTooltip visual regression tests in high contrast mode", () => {
     cy.checkHydrated(TOOLTIP_SELECTOR);
     cy.get("#test-button-left").realHover("mouse");
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "left-placement-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.006),

--- a/packages/react/src/component-tests/IcTypography/IcTypography.cy.tsx
+++ b/packages/react/src/component-tests/IcTypography/IcTypography.cy.tsx
@@ -182,12 +182,16 @@ describe("IcTypography visual regression tests in high contrast mode", () => {
     cy.enableForcedColors();
   });
 
-  after(() => {
-    cy.disableForcedColors();
+  beforeEach(() => {
+    cy.injectAxe();
   });
 
   afterEach(() => {
     cy.task("generateReport");
+  });
+
+  after(() => {
+    cy.disableForcedColors();
   });
 
   it("should render all variants of IcTypography in high contrast mode", () => {
@@ -195,6 +199,7 @@ describe("IcTypography visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(TYPOGRAPHY_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "variants-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.066),
@@ -206,6 +211,7 @@ describe("IcTypography visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(TYPOGRAPHY_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "truncation-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.062),
@@ -217,6 +223,7 @@ describe("IcTypography visual regression tests in high contrast mode", () => {
 
     cy.checkHydrated(TYPOGRAPHY_SELECTOR);
 
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "all-prop-text-styles-high-contrast",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.071),


### PR DESCRIPTION
## Summary of the changes
Adding a11y checks to existing high contrast mode visual regression tests.

## Related issue
#2057 