### PR TITLE
chore(root): excludes spec files from cspell checks

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -163,6 +163,7 @@
       "packages/**/loader/**",
       "packages/**/.stencil/**",
       "packages/**/CHANGELOG.md",
+      "packages/**/src/components/**/test/basic/*.spec.*",
       "packages/**/src/components/**/test/basic/__snapshots__/*.spec.*.snap",
       "packages/react/cypress-image-diff-html-report/**",
       "vscode-data.json"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Config change to exclude test spec files from cspell checks

## Related issue
N/A
