### PR TITLE
fix(web-components): restore slotted-svg styles in footer link

### DIFF
--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -39,14 +39,6 @@
   fill: var(--ic-hyperlink);
 }
 
-.ic-link.dark > .ic-link-open-in-new-icon {
-  fill: var(--ic-color-primary-text);
-}
-
-.ic-link.light > .ic-link-open-in-new-icon {
-  fill: var(--ic-color-white-text);
-}
-
 .ic-link-open-in-new-icon > svg {
   width: var(--ic-space-md);
   height: var(--ic-space-md);
@@ -89,4 +81,16 @@
 
 :host(.breadcrumb-link.current-page) .ic-link:visited {
   color: var(--ic-color-primary-text);
+}
+
+:host(.footer-link-light) ::slotted(svg),
+:host(.footer-link-dark) ::slotted(svg) {
+  fill: var(--ic-theme-text);
+}
+
+@media (forced-colors: active) {
+  :host(.footer-link-light) ::slotted(svg),
+  :host(.footer-link-dark) ::slotted(svg) {
+    fill: currentcolor;
+  }
 }


### PR DESCRIPTION
Restored some CSS in footer-link to style slotted SVG icons correctly in theme switcher

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
See the slottedSVG displaying incorrectly in black on v3.0.0/develop branch:
<img width="498" alt="Screenshot 2024-08-19 at 16 11 08" src="https://github.com/user-attachments/assets/67d56830-265c-423e-b723-3015097cf636">
