### PR TITLE
[ic-tree-item]: changed usage of variable to string

### DIFF
--- a/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
@@ -307,7 +307,7 @@ export class TreeItem {
       typographyEl.classList.add("ic-text-overflow");
 
       if (!tooltip) {
-        const tooltipEl = document.createElement(this.TOOLTIP);
+        const tooltipEl = document.createElement("ic-tooltip");
         tooltipEl.setAttribute("target", this.el.id);
         tooltipEl.setAttribute("label", typographyEl.textContent);
         tooltipEl.classList.add("ic-tooltip-overflow");


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Changed usage of variable to string in tree-item so `ic-tooltip` appears as a dependency within the canary `docs.json`

## Related issue
N/A

## Checklist
N/A