### PR TITLE
fix: dont add timestamps in docs generation

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -1,5 +1,4 @@
 {
-  "timestamp": "2024-09-05T11:01:59",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.9.0",

--- a/packages/canary-web-components/stencil.config.ts
+++ b/packages/canary-web-components/stencil.config.ts
@@ -1,9 +1,15 @@
 import { Config } from "@stencil/core";
+import { JsonDocs } from "@stencil/core/internal";
 import autoprefixer from "autoprefixer";
 import { inlineSvg } from "stencil-inline-svg";
 import { postcss } from "@stencil/postcss";
 import { reactOutputTarget } from "@stencil/react-output-target";
 import { excludeComps } from "../web-components/comps-list";
+
+// If timestamp is undefined, it deletes timestamp from the json doc instead of empty string
+interface StencilOverride extends Omit<JsonDocs, "timestamp"> {
+  timestamp: string | undefined
+}
 
 export const config: Config = {
   namespace: "core",
@@ -42,6 +48,12 @@ export const config: Config = {
     {
       type: "docs-json",
       file: "../canary-docs/docs.json",
+    },
+    {
+      type: "docs-custom",
+      generator: (docs: StencilOverride) => {
+        docs.timestamp = undefined;
+      }
     },
   ],
   testing: {

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1,5 +1,4 @@
 {
-  "timestamp": "2024-09-06T08:36:21",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.10.0",

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -1,8 +1,14 @@
 import { Config } from "@stencil/core";
+import { JsonDocs } from "@stencil/core/internal";
 import autoprefixer from "autoprefixer";
 import { inlineSvg } from "stencil-inline-svg";
 import { postcss } from "@stencil/postcss";
 import { reactOutputTarget } from "@stencil/react-output-target";
+
+// If timestamp is undefined, it deletes timestamp from the json doc instead of empty string
+interface StencilOverride extends Omit<JsonDocs, "timestamp"> {
+  timestamp: string | undefined
+}
 
 export const config: Config = {
   namespace: "core",
@@ -36,6 +42,12 @@ export const config: Config = {
     {
       type: "docs-json",
       file: "../docs/docs.json",
+    },
+    {
+      type: "docs-custom",
+      generator: (docs: StencilOverride) => {
+        docs.timestamp = undefined;
+      }
     },
     {
       type: "docs-vscode",


### PR DESCRIPTION
## Summary of the changes
Adds a custom handler that deletes timestamp from the built json docs

## Related issue
- https://github.com/mi6/ic-ui-kit/issues/2391

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.