### PR TITLE
fix(web-components): breadcrumb group collapsed prop issue

### DIFF
--- a/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumb.cy.tsx
+++ b/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumb.cy.tsx
@@ -9,6 +9,8 @@ import {
   WithCurrentPage,
   Collapsed,
   Appearance,
+  ToggleCollapsed,
+  ToggleBackBreadcrumb,
 } from "./IcBreadcrumbTestData";
 import {
   BE_VISIBLE,
@@ -56,6 +58,23 @@ describe("IcBreadcrumb end-to-end tests", () => {
     cy.get('[page-title="Coffee"]').should(NOT_BE_VISIBLE);
   });
 
+  it("should switch from default view to back arrow with parent breadcrumb when backBreadcrumbOnly prop is set on IcBreadcrumbGroup and revert when prop is removed", () => {
+    mount(<ToggleBackBreadcrumb />);
+
+    cy.checkHydrated(IC_BREADCRUMB_LABEL);
+    cy.get("ic-button").click();
+    cy.get('ic-breadcrumb[page-title="Beverages"]').should(
+      HAVE_ATTR,
+      "show-back-icon"
+    );
+    cy.get("ic-button").click();
+    cy.get('ic-breadcrumb[page-title="Beverages"]').should(
+      HAVE_ATTR,
+      "show-back-icon",
+      "false"
+    );
+  });
+
   it("should render breadcrumb with icons", () => {
     mount(<WithIcons />);
 
@@ -99,6 +118,16 @@ describe("IcBreadcrumb end-to-end tests", () => {
     cy.get("#collapsed-ellipsis").click();
     cy.get('[page-title="Beverages"]').should(BE_VISIBLE);
     cy.get("#collapsed-ellipsis").should(NOT_EXIST);
+  });
+
+  it("should render collapsed breadcrumb when toggled", () => {
+    mount(<ToggleCollapsed />);
+
+    cy.checkHydrated(IC_BREADCRUMB_LABEL);
+    cy.get("ic-button").click();
+    cy.get("ic-button").click();
+    cy.get("ic-button").click();
+    cy.get(".collapsed-breadcrumb").should("have.length", 1);
   });
 });
 

--- a/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumbTestData.tsx
+++ b/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumbTestData.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { IcBreadcrumb, IcBreadcrumbGroup } from "../../components";
+import { IcBreadcrumb, IcBreadcrumbGroup, IcButton } from "../../components";
 import { SlottedSVG } from "../../react-component-lib/slottedSVG";
 
 const ReusableSlottedIcon = (): ReactElement => (
@@ -35,6 +35,22 @@ export const BackBreadcrumb = (): ReactElement => {
       <IcBreadcrumb pageTitle="Beverages" href="#" />
       <IcBreadcrumb current pageTitle="Coffee" href="#" />
     </IcBreadcrumbGroup>
+  );
+};
+
+export const ToggleBackBreadcrumb = (): ReactElement => {
+  const [backBreadcrumbOnly, setBackBreadcrumbOnly] = React.useState(false);
+  const switchBackBreadCrumbOnly = () =>
+    setBackBreadcrumbOnly((value) => !value);
+  return (
+    <div>
+      <IcBreadcrumbGroup backBreadcrumbOnly={backBreadcrumbOnly}>
+        <IcBreadcrumb pageTitle="Home" href="#" />
+        <IcBreadcrumb pageTitle="Beverages" href="#" />
+        <IcBreadcrumb current pageTitle="Coffee" href="#" />
+      </IcBreadcrumbGroup>
+      <IcButton onClick={switchBackBreadCrumbOnly}>Toggle</IcButton>
+    </div>
   );
 };
 
@@ -95,6 +111,21 @@ export const Collapsed = (): ReactElement => {
       <IcBreadcrumb pageTitle="Beverages" href="#" />
       <IcBreadcrumb pageTitle="Coffee" current href="#" />
     </IcBreadcrumbGroup>
+  );
+};
+
+export const ToggleCollapsed = (): ReactElement => {
+  const [collapsed, setCollapsed] = React.useState(false);
+  const switchCollapsed = () => setCollapsed((value) => !value);
+  return (
+    <div>
+      <IcBreadcrumbGroup collapsed={collapsed} style={{ margin: "16px" }}>
+        <IcBreadcrumb pageTitle="Home" href="#" />
+        <IcBreadcrumb pageTitle="Beverages" href="#" />
+        <IcBreadcrumb pageTitle="Coffee" current href="#" />
+      </IcBreadcrumbGroup>
+      <IcButton onClick={switchCollapsed}>Toggle</IcButton>
+    </div>
   );
 };
 

--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
@@ -51,6 +51,10 @@ export class BreadcrumbGroup {
    * If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.
    */
   @Prop() collapsed: boolean = false;
+  @Watch("collapsed")
+  watchCollapsedHandler(): void {
+    this.setCollapsed();
+  }
 
   componentWillLoad(): void {
     const allBreadcrumbs = Array.from(
@@ -65,15 +69,11 @@ export class BreadcrumbGroup {
       checkResizeObserver(this.runResizeObserver);
     }
 
-    if (this.collapsed) {
-      this.collapsedBreadcrumbWrapper = this.renderCollapsedBreadcrumb();
-
-      if (allBreadcrumbs.length > 2) {
-        if (getCurrentDeviceSize() === DEVICE_SIZES.S) {
-          this.setLastParentCollapsedBackBreadcrumb();
-        } else {
-          this.setCollapsed();
-        }
+    if (this.collapsed && allBreadcrumbs.length > 2) {
+      if (getCurrentDeviceSize() === DEVICE_SIZES.S) {
+        this.setLastParentCollapsedBackBreadcrumb();
+      } else {
+        this.setCollapsed();
       }
     }
   }
@@ -104,7 +104,9 @@ export class BreadcrumbGroup {
 
   private setBackBreadcrumb = () => {
     if (this.backBreadcrumbOnly) {
-      this.setBackBreadcrumbAttr();
+      this.setLastParentCollapsedBackBreadcrumb();
+    } else {
+      this.revertLastParentCollapsedBreadcrumb();
     }
   };
 
@@ -124,10 +126,8 @@ export class BreadcrumbGroup {
       return null;
     }
 
-    this.breadcrumbs = allBreadcrumbs.filter(
-      (breadcrumb) => !breadcrumb.getAttribute("current")
-    );
-    this.breadcrumb = this.breadcrumbs[this.breadcrumbs.length - 1];
+    this.breadcrumbs = allBreadcrumbs;
+    this.breadcrumb = this.breadcrumbs[this.breadcrumbs.length - 2];
 
     return this.breadcrumb;
   };
@@ -144,22 +144,31 @@ export class BreadcrumbGroup {
   };
 
   private setCollapsed = () => {
+    const allBreadcrumbs: HTMLIcBreadcrumbElement[] = Array.from(
+      this.el.querySelectorAll(this.IC_BREADCRUMB)
+    );
+    const firstBreadcrumb = allBreadcrumbs[0];
+    if (this.collapsedBreadcrumbs) {
+      this.collapsedBreadcrumbs.forEach((breadcrumb) => {
+        breadcrumb.classList.remove("visuallyhidden");
+        breadcrumb.classList.remove("fade");
+      });
+    }
+
     if (this.collapsed) {
-      const allBreadcrumbs: HTMLIcBreadcrumbElement[] = Array.from(
-        this.el.querySelectorAll(this.IC_BREADCRUMB)
-      );
+      this.renderCollapsedBreadcrumb();
+
       this.collapsedBreadcrumbs = allBreadcrumbs
         .splice(1, allBreadcrumbs.length - 2)
         .filter(
           (breadcrumb) =>
             !breadcrumb.classList.contains("collapsed-breadcrumb-wrapper")
         );
-
-      this.collapsedBreadcrumbs.forEach((breadcrumb) =>
-        breadcrumb.classList.add("hide")
-      );
-
-      const firstBreadcrumb = allBreadcrumbs[0];
+      if (!this.backBreadcrumbOnly) {
+        this.collapsedBreadcrumbs.forEach((breadcrumb) =>
+          breadcrumb.classList.add("hide")
+        );
+      }
 
       if (firstBreadcrumb) {
         firstBreadcrumb.insertAdjacentElement(
@@ -167,11 +176,13 @@ export class BreadcrumbGroup {
           this.collapsedBreadcrumbWrapper
         );
       }
+    } else {
+      this.collapsedBreadcrumbWrapper.remove();
     }
   };
 
   private clickHandler = () => {
-    this.handleHiddenCollapsedBreadcrumbs(this.collapsedBreadcrumbWrapper);
+    this.handleHiddenCollapsedBreadcrumbs();
   };
 
   private renderCollapsedBreadcrumb = () => {
@@ -211,10 +222,8 @@ export class BreadcrumbGroup {
     return this.collapsedBreadcrumbWrapper;
   };
 
-  private handleHiddenCollapsedBreadcrumbs = (
-    collapsedBreadcrumbWrapper: HTMLIcBreadcrumbElement
-  ) => {
-    collapsedBreadcrumbWrapper.remove();
+  private handleHiddenCollapsedBreadcrumbs = () => {
+    this.collapsedBreadcrumbWrapper.remove();
     this.collapsedBreadcrumbs.forEach((breadcrumb) => {
       breadcrumb.classList.add("visuallyhidden");
       breadcrumb.classList.remove("hide");
@@ -240,12 +249,19 @@ export class BreadcrumbGroup {
   };
 
   private setLastParentCollapsedBackBreadcrumb = () => {
+    this.lastParentBreadcrumb = this.getLastParentBreadcrumb();
     this.setBackBreadcrumbAttr();
-    this.lastParentBreadcrumb.classList.remove("hide");
+    if (this.lastParentBreadcrumb) {
+      this.lastParentBreadcrumb.classList.remove("hide");
+      this.lastParentBreadcrumb.classList.add("show");
+    }
   };
 
   private revertLastParentCollapsedBreadcrumb = () => {
     this.lastParentBreadcrumb.setAttribute(this.SHOW_BACK_ICON, "false");
+    if (this.collapsed) {
+      this.lastParentBreadcrumb.classList.add("hide");
+    }
   };
 
   private resizeObserverCallback = (currSize: number) => {

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
@@ -81,31 +81,31 @@ exports[`ic-breadcrumb-group should render collapse on already small devices: sh
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb appearance="default" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+  <ic-breadcrumb appearance="default" class="back show" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem" show-back-icon="true">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
           svg
         </span>
-        <ic-link appearance="default" class="breadcrumb-link" href="/breadcrumb-3">
+        <span class="hide" id="breadcrumb-3-describedby">
+          Back to Breadcrumb 3
+        </span>
+        <ic-link appearance="default" aria-describedby="breadcrumb-3-describedby" class="breadcrumb-link" href="/breadcrumb-3">
+          <div class="back-icon">
+            svg
+          </div>
           Breadcrumb 3
         </ic-link>
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb appearance="default" class="back show" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem" show-back-icon="true">
+  <ic-breadcrumb appearance="default" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
           svg
         </span>
-        <span class="hide" id="breadcrumb-4-describedby">
-          Back to Breadcrumb 4
-        </span>
-        <ic-link appearance="default" aria-describedby="breadcrumb-4-describedby" class="breadcrumb-link" href="/breadcrumb-4">
-          <div class="back-icon">
-            svg
-          </div>
+        <ic-link appearance="default" class="breadcrumb-link" href="/breadcrumb-4">
           Breadcrumb 4
         </ic-link>
       </div>
@@ -323,7 +323,7 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb appearance="default" class="hide" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+  <ic-breadcrumb appearance="default" class="show" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem" show-back-icon="true">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">
@@ -335,7 +335,7 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
-  <ic-breadcrumb appearance="default" class="show" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem" show-back-icon="true">
+  <ic-breadcrumb appearance="default" href="/breadcrumb-4" page-title="Breadcrumb 4" role="listitem">
     <mock:shadow-root>
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">


### PR DESCRIPTION
Fixed the issue with the breadcrumb group collapsed prop not toggling properly and fixed the back arrow not turning back into a chevron

fix #1998 
fix #2028

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixed the issue where the breadcrumb group prop would, when toggled, not remove the collapsed ellipses element so they would just stack up
Also fixed the issue where, when toggled back and forth, the back arrow for the 'back breadcrumb only' prop would not switch back to a chevron icon

## Related issue
#1998 
#2028 