### PR TITLE
fix(web-components): make dot type badges read to screenreaders

### DIFF
--- a/packages/web-components/src/components/ic-badge/ic-badge.css
+++ b/packages/web-components/src/components/ic-badge/ic-badge.css
@@ -153,6 +153,11 @@
   transition: visibility var(--ic-transition-duration-slow);
 }
 
+.sr-only {
+  position: absolute;
+  left: -9999px;
+}
+
 @keyframes expand {
   from {
     opacity: 0;

--- a/packages/web-components/src/components/ic-badge/ic-badge.tsx
+++ b/packages/web-components/src/components/ic-badge/ic-badge.tsx
@@ -252,6 +252,7 @@ export class Badge {
             {getTextLabel()}
           </ic-typography>
         )}
+        {type === "dot" && <span class="sr-only">badge</span>}
       </Host>
     );
   }

--- a/packages/web-components/src/components/ic-badge/test/basic/__snapshots__/ic-badge.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-badge/test/basic/__snapshots__/ic-badge.spec.tsx.snap
@@ -284,7 +284,11 @@ exports[`ic-badge should render type dot: should render type dot 1`] = `
   </mock:shadow-root>
   Button
   <ic-badge class="default dot far foreground-light neutral show" role="status" slot="badge" type="dot">
-    <mock:shadow-root></mock:shadow-root>
+    <mock:shadow-root>
+      <span class="sr-only">
+        badge
+      </span>
+    </mock:shadow-root>
   </ic-badge>
 </ic-button>
 `;


### PR DESCRIPTION
## Summary of the changes
I've added a screenreader-only label to type="dot" badges. This makes them read a little better to NVDA screenreader.

Please read the ticket (linked below) to see mine and @GCHQ-Developer-847 's experience with this issue. I don't think there's much more that can be done for NVDA - all the badges can be read by NVDA users, but it is an inferior experience to Voiceover. This change makes Dot badges readable as "badge".

## Related issue
#1717 

## Checklist

### Testing

- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Correct roles used and ARIA attributes used correctly where required. 

### System modes

- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 