### PR TITLE
Auto loading toasts

### DIFF
--- a/packages/react/src/component-tests/IcToast/IcToast.cy.tsx
+++ b/packages/react/src/component-tests/IcToast/IcToast.cy.tsx
@@ -13,6 +13,7 @@ import {
   HAVE_BEEN_CALLED_ONCE,
 } from "../utils/constants";
 import {
+  AutoLoadToast,
   DismissAriaLabelToast,
   HeadingOnlyToast,
   MultilineMessageToast,
@@ -118,6 +119,11 @@ describe("IcToast end-to-end tests", () => {
     cy.clickOnShadowEl(IC_TOAST_SELECTOR, DISMISS_BUTTON_SELECTOR);
     cy.get(IC_TOAST_SELECTOR).should(HAVE_CLASS, "hidden");
     cy.get("@icDismiss").should(HAVE_BEEN_CALLED_ONCE);
+  });
+
+  it("should render a toast on page load if openToast is set early", () => {
+    mount(<AutoLoadToast />);
+    cy.get(IC_TOAST_SELECTOR).should(NOT_HAVE_CLASS, "hidden");
   });
 });
 

--- a/packages/react/src/component-tests/IcToast/IcToastTestData.tsx
+++ b/packages/react/src/component-tests/IcToast/IcToastTestData.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { IcToast, IcButton, IcToastRegion, SlottedSVG, IcLink } from "../..";
 
 export const SimpleToast = () => {
@@ -213,5 +213,22 @@ export const DismissAriaLabelToast = () => {
         />
       </IcToastRegion>
     </>
+  );
+};
+
+export const AutoLoadToast = (): JSX.Element => {
+  const toastRegionEl = useRef<HTMLIcToastRegionElement>(null);
+  const shareToastEl = useRef<HTMLIcToastElement>(null);
+
+  useEffect(() => {
+    if (toastRegionEl.current && shareToastEl.current) {
+      toastRegionEl.current.openToast = shareToastEl.current;
+    }
+  }, []);
+
+  return (
+    <IcToastRegion ref={toastRegionEl}>
+      <IcToast heading="My toast heading" ref={shareToastEl} />
+    </IcToastRegion>
   );
 };

--- a/packages/react/src/stories/ic-toast.stories.mdx
+++ b/packages/react/src/stories/ic-toast.stories.mdx
@@ -6,6 +6,7 @@ import {
   IcButton,
   IcTypography,
 } from "../components";
+import { useEffect, useRef } from "react";
 import readme from "../../../web-components/src/components/ic-toast/readme.md";
 
 <Meta title="Toast" component={IcToast} />
@@ -335,6 +336,31 @@ import readme from "../../../web-components/src/components/ic-toast/readme.md";
         </>
       );
     }}
+  </Story>
+</Canvas>
+
+### Display on page load
+
+export const AutoLoadToast = () => {
+  const toastRegionEl = useRef(null);
+  const shareToastEl = useRef(null);
+
+  useEffect(() => {
+    if (toastRegionEl.current && shareToastEl.current) {
+      toastRegionEl.current.openToast = shareToastEl.current;
+    }
+  }, []);
+
+  return (
+    <IcToastRegion ref={toastRegionEl}>
+      <IcToast heading="My toast heading" ref={shareToastEl} />
+    </IcToastRegion>
+  );
+};
+
+<Canvas>
+  <Story name="Display on page load">
+    <AutoLoadToast />
   </Story>
 </Canvas>
 

--- a/packages/web-components/src/components/ic-toast-region/ic-toast-region.tsx
+++ b/packages/web-components/src/components/ic-toast-region/ic-toast-region.tsx
@@ -28,6 +28,13 @@ export class ToastRegion {
     }
   }
 
+  componentDidLoad(): void {
+    if (this.openToast) {
+      this.showToast(this.openToast);
+      this.openToast = undefined;
+    }
+  }
+
   @Listen("icDismiss", { capture: true })
   handleDismissedToast(): void {
     if (this.pendingVisibility.length > 0) {


### PR DESCRIPTION
## Summary of the changes
- Added componentDidLoad to ic-toast-region to check whether openToast is set when the component is rendered, to immediately show it.
- Added cypress test.

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.