### PR TITLE
2408 pagination page number

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -3469,6 +3469,28 @@
           "required": false
         },
         {
+          "name": "currentPage",
+          "type": "number",
+          "complexType": {
+            "original": "number",
+            "resolved": "number",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "current-page",
+          "reflectToAttr": false,
+          "docs": "The current page number to be displayed on the pagination bar.",
+          "docsTags": [],
+          "default": "1",
+          "values": [
+            {
+              "type": "number"
+            }
+          ],
+          "optional": true,
+          "required": false
+        },
+        {
           "name": "hideRangeLabel",
           "type": "boolean",
           "complexType": {
@@ -3704,16 +3726,22 @@
         },
         {
           "event": "icPageChange",
-          "detail": "{ value: number; }",
+          "detail": "IcPageChangeEventDetail",
           "bubbles": true,
           "complexType": {
-            "original": "{ value: number }",
-            "resolved": "{ value: number; }",
-            "references": {}
+            "original": "IcPageChangeEventDetail",
+            "resolved": "IcPageChangeEventDetail",
+            "references": {
+              "IcPageChangeEventDetail": {
+                "location": "import",
+                "path": "./ic-pagination-bar.types",
+                "id": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts::IcPageChangeEventDetail"
+              }
+            }
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when a page is navigated to via the 'go to' input.",
+          "docs": "Emitted when a page is navigated to via the 'go to' input.\nThe `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.",
           "docsTags": []
         }
       ],
@@ -5406,6 +5434,11 @@
       "declaration": "export type IcPaginationLabelTypes = \"page\" | \"data\";",
       "docstring": "",
       "path": "../web-components/dist/types/components/ic-pagination/ic-pagination.types.d.ts"
+    },
+    "src/components/ic-pagination-bar/ic-pagination-bar.types.ts::IcPageChangeEventDetail": {
+      "declaration": "export interface IcPageChangeEventDetail {\n  value: number;\n  fromItemsPerPage?: boolean;\n}",
+      "docstring": "",
+      "path": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDensityUpdateEventDetail": {
       "declaration": "export interface IcDensityUpdateEventDetail {\n  value: IcDataTableDensityOptions;\n}",

--- a/packages/canary-react/src/stories/ic-pagination-bar.stories.mdx
+++ b/packages/canary-react/src/stories/ic-pagination-bar.stories.mdx
@@ -1,6 +1,8 @@
 import { Meta, Description, Canvas, Story } from "@storybook/addon-docs";
 import { IcPaginationBar } from "../components";
+import { IcLink } from "@ukic/react";
 import readme from "../../../canary-web-components/src/components/ic-pagination-bar/readme.md";
+import { useArgs } from '@storybook/client-api';
 
 <Meta
   title="React Components/Pagination Bar"
@@ -442,3 +444,78 @@ const PaginationBar = () => (
 
 export default PaginationBar;
 ```
+
+
+### Playground
+
+Go to the <IcLink href="/?path=/story/react-components-pagination-bar--playground">separate page for the playground example</IcLink> to view the prop controls.
+
+export const defaultArgs = {
+  alignment: "right",
+  appearance: "default",
+  currentPage: 1,
+  hideRangeLabel: false,
+  itemLabel: "Item",
+  itemsPerPageOptions: [
+    { label: "10", value: "10" },
+    { label: "25", value: "25" },
+    { label: "50", value: "50" },
+  ],
+  pageLabel: "Page",
+  rangeLabelType: "page",
+  showItemsPerPageControl: false,
+  showGoToPageControl: false,
+  totalItems: 100,
+  type: "simple",
+};
+
+<Canvas withSource="none">
+  <Story
+    args={defaultArgs}
+    argTypes={{
+       alignment: {
+        options: ["left", "right", "space-between"],
+        control: { type: "inline-radio" },
+      },
+      appearance: {
+        options: ["default", "dark", "light"],
+        control: { type: "inline-radio" },
+      },
+      rangeLabelType: {
+        options: ["page", "data"],
+        control: { type: "inline-radio" },
+      },
+      type: {
+        options: ["simple", "complex"],
+        control: { type: "inline-radio" },
+      },     
+    }}
+    name="Playground"
+  >
+    {(args) => {
+      const [{ value }, updateArgs] = useArgs();
+
+      const updatePageNum = (ev) => {
+        updateArgs({ currentPage: ev.detail.value });
+      }; 
+      return (
+        <IcPaginationBar
+          alignment={args.alignment}
+          appearance={args.appearance}
+          currentPage={args.currentPage}
+          hideRangeLabel={args.hideRangeLabel}
+          itemLabel={args.itemLabel}
+          itemsPerPageOptions={args.itemsPerPageOptions}
+          pageLabel={args.pageLabel}
+          rangeLabelType={args.rangeLabelType}
+          showItemsPerPageControl={args.showItemsPerPageControl}
+          showGoToPageControl={args.showGoToPageControl}
+          totalItems={args.totalItems}
+          type={args.type}
+          onIcPageChange={updatePageNum}
+        >
+        </IcPaginationBar>
+      )
+    }}
+  </Story>
+</Canvas>

--- a/packages/canary-web-components/src/components.d.ts
+++ b/packages/canary-web-components/src/components.d.ts
@@ -12,6 +12,7 @@ import { IcDateFormat, IcInformationStatusOrEmpty, IcPaginationBarOptions, IcSea
 import { IcMenuChangeEventDetail, IcMenuOptionIdEventDetail, IcOptionSelectEventDetail, IcSearchBarSearchModes } from "@ukic/web-components/dist/types/components";
 import { IcPaginationAlignmentOptions, IcPaginationLabelTypes, IcPaginationTypes } from "@ukic/web-components/dist/types/components/ic-pagination/ic-pagination.types";
 import { IcThemeForeground } from "@ukic/web-components/dist/types/interface";
+import { IcPageChangeEventDetail } from "./components/ic-pagination-bar/ic-pagination-bar.types";
 export { IcCardSizes } from "./components/ic-card-horizontal/ic-card-horizontal.types";
 export { IcDataTableColumnObject, IcDataTableDataType, IcDataTableDensityOptions, IcDataTableRowHeights, IcDataTableSortOrderOptions, IcDataTableTruncationTypes, IcDensityUpdateEventDetail, IcSortEventDetail } from "./components/ic-data-table/ic-data-table.types";
 export { IcActivationTypes, IcMenuOption, IcThemeForegroundNoDefault } from "@ukic/web-components/dist/types/utils/types";
@@ -19,6 +20,7 @@ export { IcDateFormat, IcInformationStatusOrEmpty, IcPaginationBarOptions, IcSea
 export { IcMenuChangeEventDetail, IcMenuOptionIdEventDetail, IcOptionSelectEventDetail, IcSearchBarSearchModes } from "@ukic/web-components/dist/types/components";
 export { IcPaginationAlignmentOptions, IcPaginationLabelTypes, IcPaginationTypes } from "@ukic/web-components/dist/types/components/ic-pagination/ic-pagination.types";
 export { IcThemeForeground } from "@ukic/web-components/dist/types/interface";
+export { IcPageChangeEventDetail } from "./components/ic-pagination-bar/ic-pagination-bar.types";
 export namespace Components {
     interface IcCardHorizontal {
         /**
@@ -499,6 +501,10 @@ export namespace Components {
          */
         "appearance"?: IcThemeForeground;
         /**
+          * The current page number to be displayed on the pagination bar.
+         */
+        "currentPage"?: number;
+        /**
           * If `true`, the number of total items and current item range or number of total pages and current page will be hidden.
          */
         "hideRangeLabel"?: boolean;
@@ -883,7 +889,7 @@ declare global {
         new (): HTMLIcMenuWithMultiElement;
     };
     interface HTMLIcPaginationBarElementEventMap {
-        "icPageChange": { value: number };
+        "icPageChange": IcPageChangeEventDetail;
         "icItemsPerPageChange": { value: number };
     }
     interface HTMLIcPaginationBarElement extends Components.IcPaginationBar, HTMLStencilElement {
@@ -1453,6 +1459,10 @@ declare namespace LocalJSX {
          */
         "appearance"?: IcThemeForeground;
         /**
+          * The current page number to be displayed on the pagination bar.
+         */
+        "currentPage"?: number;
+        /**
           * If `true`, the number of total items and current item range or number of total pages and current page will be hidden.
          */
         "hideRangeLabel"?: boolean;
@@ -1472,9 +1482,9 @@ declare namespace LocalJSX {
          */
         "onIcItemsPerPageChange"?: (event: IcPaginationBarCustomEvent<{ value: number }>) => void;
         /**
-          * Emitted when a page is navigated to via the 'go to' input.
+          * Emitted when a page is navigated to via the 'go to' input. The `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.
          */
-        "onIcPageChange"?: (event: IcPaginationBarCustomEvent<{ value: number }>) => void;
+        "onIcPageChange"?: (event: IcPaginationBarCustomEvent<IcPageChangeEventDetail>) => void;
         /**
           * The text which will be used in place of 'Page' on the pagination bar.
          */

--- a/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.types.ts
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.types.ts
@@ -1,0 +1,4 @@
+export interface IcPageChangeEventDetail {
+  value: number;
+  fromItemsPerPage?: boolean;
+}

--- a/packages/canary-web-components/src/components/ic-pagination-bar/readme.md
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/readme.md
@@ -11,6 +11,7 @@
 | ------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | ----------- |
 | `alignment`               | `alignment`                   | Sets the alignment of the items in the pagination bar.                                                                                                                         | `"left" \| "right" \| "space-between"` | `"right"`   |
 | `appearance`              | `appearance`                  | Sets the styling for the items in the pagination bar.                                                                                                                          | `"dark" \| "default" \| "light"`       | `"default"` |
+| `currentPage`             | `current-page`                | The current page number to be displayed on the pagination bar.                                                                                                                 | `number`                               | `1`         |
 | `hideRangeLabel`          | `hide-range-label`            | If `true`, the number of total items and current item range or number of total pages and current page will be hidden.                                                          | `boolean`                              | `false`     |
 | `itemLabel`               | `item-label`                  | The text which will be used in place of 'Item' on the pagination bar.                                                                                                          | `string`                               | `"Item"`    |
 | `itemsPerPageOptions`     | --                            | The options which will be displayed for 'items per page' select input. Set a maximum of 4 options including a required 'All' option with value equal to total number of items. | `{ label: string; value: string; }[]`  | `undefined` |
@@ -24,10 +25,10 @@
 
 ## Events
 
-| Event                  | Description                                                | Type                              |
-| ---------------------- | ---------------------------------------------------------- | --------------------------------- |
-| `icItemsPerPageChange` | Emitted when the items per page option is changed.         | `CustomEvent<{ value: number; }>` |
-| `icPageChange`         | Emitted when a page is navigated to via the 'go to' input. | `CustomEvent<{ value: number; }>` |
+| Event                  | Description                                                                                                                                                                                                                                       | Type                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `icItemsPerPageChange` | Emitted when the items per page option is changed.                                                                                                                                                                                                | `CustomEvent<{ value: number; }>`      |
+| `icPageChange`         | Emitted when a page is navigated to via the 'go to' input. The `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring. | `CustomEvent<IcPageChangeEventDetail>` |
 
 
 ## Dependencies

--- a/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/__snapshots__/ic-pagination-bar.spec.ts.snap
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/__snapshots__/ic-pagination-bar.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`ic-pagination-bar should only allow a maximum of 4 custom items per pag
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="6" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="6" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -36,7 +36,7 @@ exports[`ic-pagination-bar should render 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -55,7 +55,7 @@ exports[`ic-pagination-bar should render with a custom item label 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -74,7 +74,7 @@ exports[`ic-pagination-bar should render with a custom page label 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Sheet" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Sheet" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -142,7 +142,7 @@ exports[`ic-pagination-bar should render with custom items per page options 1`] 
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="7" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="7" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -161,7 +161,7 @@ exports[`ic-pagination-bar should render with dark appearance 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -180,7 +180,7 @@ exports[`ic-pagination-bar should render with data pagination type 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -199,7 +199,7 @@ exports[`ic-pagination-bar should render with go to page controls 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
         <div class="go-to-page-holder">
           <ic-typography class="pagination-text-default" variant="label">
@@ -235,7 +235,7 @@ exports[`ic-pagination-bar should render with items per page controls 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -254,7 +254,7 @@ exports[`ic-pagination-bar should render with left alignment 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -273,7 +273,7 @@ exports[`ic-pagination-bar should render with light appearance 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="light" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="light" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -292,7 +292,7 @@ exports[`ic-pagination-bar should render with space between alignment 1`] = `
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -306,7 +306,81 @@ exports[`ic-pagination-bar should render without range text 1`] = `
     <div class="pagination-bar pagination-bar-right">
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+</ic-pagination-bar>
+`;
+
+exports[`ic-pagination-bar should update page details when currentPage prop is changed 1`] = `
+<ic-pagination-bar total-items="100">
+  <mock:shadow-root>
+    <div class="pagination-bar pagination-bar-right">
+      <div class="item-controls">
+        <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
+          Page 1 of 10
+        </ic-typography>
+      </div>
+      <div class="pagination-controls">
+        <div class="pagination-holder">
+          <ic-pagination>
+            <mock:shadow-root>
+              <nav aria-label="Pagination Navigation" role="navigation">
+                <ic-button appearance="default" aria-label="Go to first page" class="first-last page-button" disabled="" id="first-page-button" variant="icon">
+                  svg
+                </ic-button>
+                <ic-button appearance="default" aria-label="Go to previous page" class="flip next-previous page-button" disabled="" id="previous-page-button" variant="icon">
+                  svg
+                </ic-button>
+                <ic-pagination-item appearance="default" label="Page" page="1" pages="10" type="simple-current"></ic-pagination-item>
+                <ic-button appearance="default" aria-label="Go to next page" class="next-previous page-button" id="next-page-button" variant="icon">
+                  svg
+                </ic-button>
+                <ic-button appearance="default" aria-label="Go to last page" class="first-last flip page-button" id="last-page-button" variant="icon">
+                  svg
+                </ic-button>
+              </nav>
+            </mock:shadow-root>
+          </ic-pagination>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+</ic-pagination-bar>
+`;
+
+exports[`ic-pagination-bar should update page details when currentPage prop is changed 2`] = `
+<ic-pagination-bar total-items="100">
+  <mock:shadow-root>
+    <div class="pagination-bar pagination-bar-right">
+      <div class="item-controls">
+        <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
+          Page 4 of 10
+        </ic-typography>
+      </div>
+      <div class="pagination-controls">
+        <div class="pagination-holder">
+          <ic-pagination>
+            <mock:shadow-root>
+              <nav aria-label="Pagination Navigation" role="navigation">
+                <ic-button appearance="default" aria-label="Go to first page" class="first-last page-button" id="first-page-button" variant="icon">
+                  svg
+                </ic-button>
+                <ic-button appearance="default" aria-label="Go to previous page" class="flip next-previous page-button" id="previous-page-button" variant="icon">
+                  svg
+                </ic-button>
+                <ic-pagination-item appearance="default" label="Page" page="4" pages="10" type="simple-current"></ic-pagination-item>
+                <ic-button appearance="default" aria-label="Go to next page" class="next-previous page-button" id="next-page-button" variant="icon">
+                  svg
+                </ic-button>
+                <ic-button appearance="default" aria-label="Go to last page" class="first-last flip page-button" id="last-page-button" variant="icon">
+                  svg
+                </ic-button>
+              </nav>
+            </mock:shadow-root>
+          </ic-pagination>
         </div>
       </div>
     </div>
@@ -325,7 +399,7 @@ exports[`ic-pagination-bar should update pagination when number of item changes 
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="1" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="1" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -344,7 +418,7 @@ exports[`ic-pagination-bar should update pagination when number of item changes 
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="10" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="10" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
@@ -363,153 +437,10 @@ exports[`ic-pagination-bar should update pagination when number of item changes 
       </div>
       <div class="pagination-controls">
         <div class="pagination-holder">
-          <ic-pagination appearance="default" label="Page" pages="5" type="simple"></ic-pagination>
+          <ic-pagination appearance="default" currentpage="1" label="Page" pages="5" type="simple"></ic-pagination>
         </div>
       </div>
     </div>
   </mock:shadow-root>
 </ic-pagination-bar>
-`;
-
-exports[`ic-pagination-bar should wrap pagination when the device size is small 1`] = `
-Object {
-  "body": <body>
-  <ic-pagination-bar show-go-to-page-control="true" total-items="100">
-    <mock:shadow-root>
-      <div class="pagination-bar pagination-bar-right">
-        <div class="item-controls">
-          <ic-typography aria-live="polite" class="page-pagination-label pagination-text-default" variant="label">
-            Page 1 of 10
-          </ic-typography>
-        </div>
-        <div class="pagination-controls">
-          <div class="pagination-holder">
-            <ic-pagination>
-              <mock:shadow-root>
-                <nav aria-label="Pagination Navigation" role="navigation">
-                  <ic-button appearance="default" aria-label="Go to first page" class="first-last page-button" disabled="" id="first-page-button" variant="icon">
-                    svg
-                  </ic-button>
-                  <ic-button appearance="default" aria-label="Go to previous page" class="flip next-previous page-button" disabled="" id="previous-page-button" variant="icon">
-                    svg
-                  </ic-button>
-                  <ic-pagination-item appearance="default" label="Page" page="1" type="simple-current"></ic-pagination-item>
-                  <ic-button appearance="default" aria-label="Go to next page" class="next-previous page-button" id="next-page-button" variant="icon">
-                    svg
-                  </ic-button>
-                  <ic-button appearance="default" aria-label="Go to last page" class="first-last flip page-button" id="last-page-button" variant="icon">
-                    svg
-                  </ic-button>
-                </nav>
-              </mock:shadow-root>
-            </ic-pagination>
-          </div>
-          <div class="go-to-page-holder">
-            <ic-typography class="pagination-text-default" variant="label">
-              Go to page
-            </ic-typography>
-            <ic-tooltip disableclick="" disablehover="" label="Please enter a valid page" target="#go-to-page-input">
-              <ic-text-field class="go-to-page-input" hidelabel="" id="go-to-page-input" label="go-to-page-input" max="10" min="1" size="small" type="number" validationinlineinternal=""></ic-text-field>
-            </ic-tooltip>
-            <ic-button appearance="default" class="go-to-page-button" size="small" variant="secondary">
-              Go
-            </ic-button>
-          </div>
-        </div>
-      </div>
-    </mock:shadow-root>
-  </ic-pagination-bar>
-</body>,
-  "build": Object {
-    "allRenderFn": true,
-    "appendChildSlotFix": false,
-    "asyncLoading": true,
-    "asyncQueue": true,
-    "attachStyles": false,
-    "cloneNodeFix": false,
-    "cmpDidLoad": true,
-    "cmpDidRender": true,
-    "cmpDidUnload": true,
-    "cmpDidUpdate": true,
-    "cmpShouldUpdate": true,
-    "cmpWillLoad": true,
-    "cmpWillRender": true,
-    "cmpWillUpdate": true,
-    "connectedCallback": true,
-    "constructableCSS": true,
-    "cssAnnotations": false,
-    "devTools": false,
-    "disconnectedCallback": true,
-    "element": true,
-    "event": true,
-    "experimentalScopedSlotChanges": false,
-    "experimentalSlotFixes": false,
-    "formAssociated": true,
-    "hasRenderFn": true,
-    "hostListener": true,
-    "hostListenerTarget": true,
-    "hostListenerTargetBody": true,
-    "hostListenerTargetDocument": true,
-    "hostListenerTargetParent": true,
-    "hostListenerTargetWindow": true,
-    "hotModuleReplacement": false,
-    "hydrateClientSide": false,
-    "hydrateServerSide": false,
-    "hydratedAttribute": false,
-    "hydratedClass": true,
-    "initializeNextTick": true,
-    "invisiblePrehydration": true,
-    "isDebug": false,
-    "isDev": true,
-    "isTesting": true,
-    "lazyLoad": true,
-    "lifecycle": true,
-    "lifecycleDOMEvents": true,
-    "member": true,
-    "method": true,
-    "mode": true,
-    "observeAttribute": true,
-    "profile": true,
-    "prop": true,
-    "propBoolean": true,
-    "propMutable": true,
-    "propNumber": true,
-    "propString": true,
-    "reflect": true,
-    "scoped": true,
-    "scopedSlotTextContentFix": false,
-    "scriptDataOpts": false,
-    "shadowDelegatesFocus": true,
-    "shadowDom": true,
-    "shadowDomShim": false,
-    "slot": true,
-    "slotChildNodesFix": false,
-    "slotRelocation": true,
-    "state": true,
-    "style": true,
-    "svg": true,
-    "taskQueue": true,
-    "transformTagName": true,
-    "updatable": true,
-    "vdomAttribute": true,
-    "vdomClass": true,
-    "vdomFunctional": true,
-    "vdomKey": true,
-    "vdomListener": true,
-    "vdomPropOrAttr": true,
-    "vdomRef": true,
-    "vdomRender": true,
-    "vdomStyle": true,
-    "vdomText": true,
-    "vdomXlink": true,
-    "watchCallback": true,
-  },
-  "doc": ,
-  "flushLoadModule": [Function],
-  "flushQueue": [Function],
-  "setContent": [Function],
-  "styles": Map {},
-  "waitForChanges": [Function],
-  "win": [MockWindow],
-}
 `;

--- a/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/ic-pagination-bar.spec.ts
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/test/basic/ic-pagination-bar.spec.ts
@@ -174,8 +174,6 @@ describe("ic-pagination-bar", () => {
       { label: "All", value: "150" },
     ];
 
-    page.rootInstance.trimItemsPerPageOptions();
-
     await page.waitForChanges();
 
     expect(page.rootInstance.displayedItemsPerPageOptions).toEqual([
@@ -210,6 +208,21 @@ describe("ic-pagination-bar", () => {
       { label: "50", value: "50" },
       { label: "All", value: "100" },
     ]);
+  });
+
+  it("should update page details when currentPage prop is changed", async () => {
+    const page = await newSpecPage({
+      components: [PaginationBar, IcPagination],
+      html: `<ic-pagination-bar total-items="100"></ic-pagination-bar>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.root.currentPage = 4;
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
   });
 
   it("should wrap pagination when the device size is small", async () => {
@@ -251,17 +264,31 @@ describe("ic-pagination-bar", () => {
 
     expect(text.textContent).toEqual("Page 1 of 10");
 
+    const eventSpy = jest.fn();
+
+    paginationBar.addEventListener("icPageChange", eventSpy);
+
     select.value = "25";
+    expect(eventSpy).toHaveBeenCalledTimes(0);
 
     page.rootInstance.changeItemsPerPage();
-
-    page.rootInstance.setNumberPages();
 
     await page.waitForChanges();
 
     expect(select.value).toEqual("25");
 
     expect(text.textContent).toEqual("Page 1 of 4");
+
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          value: 1,
+          fromItemsPerPage: true,
+        }),
+      })
+    );
   });
 
   it("should change page when the pagination controls are clicked", async () => {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Adds `currentPage` prop to pagination bar to control the page number currently displayed
Adds additional `fromItemsPerPage` in `icPageChange` event to allow user to determine what action triggered the page change
Adds React storybook playground

## Related issue
#2407, #2408 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.