### PR TITLE
1912 aria expanded

### DIFF
--- a/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
+++ b/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
@@ -156,7 +156,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.checkHydrated(SEARCH_SELECTOR);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "default",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.021),
@@ -180,7 +180,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.checkHydrated(SEARCH_SELECTOR);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "full-width",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.061),
@@ -192,7 +192,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.checkHydrated(SEARCH_SELECTOR);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "helper-text",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.045),
@@ -204,7 +204,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.checkHydrated(SEARCH_SELECTOR);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "hidden-label",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
@@ -219,13 +219,10 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
       .shadow()
-      .find(SEARCH_INPUT)
-      .as("input");
+      .find(IC_INPUT_CONTAINER)
+      .type("La");
 
-    cy.get("@input").focus();
-    cy.realType("La").wait(200);
-
-    //cy.checkA11yWithWait();
+    // cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "options-no-filtering",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.05),
@@ -243,13 +240,10 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
       .shadow()
-      .find(SEARCH_INPUT)
-      .as("input");
+      .find(IC_INPUT_CONTAINER)
+      .type("Macchiato");
 
-    cy.get("@input").focus();
-    cy.realType("Macchiato").wait(200);
-
-    //cy.checkA11yWithWait();
+    // cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "empty-option-list-text",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.038),
@@ -269,7 +263,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
       .find(IC_INPUT_CONTAINER)
       .type("Lat");
 
-    //cy.checkA11yWithWait();
+    // cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "characters-until-suggestion-no-show",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.022),
@@ -286,7 +280,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
       .find(IC_INPUT_CONTAINER)
       .type("Latte");
 
-    //cy.checkA11yWithWait();
+    // cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "characters-until-suggestion-show",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.025),
@@ -298,7 +292,7 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.checkHydrated(SEARCH_SELECTOR);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "small",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.021),
@@ -313,13 +307,10 @@ describe("IcSearchBar visual regression and a11y tests", () => {
 
     cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
       .shadow()
-      .find(SEARCH_INPUT)
-      .as("input");
+      .find(IC_INPUT_CONTAINER)
+      .type("es");
 
-    cy.get("@input").focus();
-    cy.realType("es").wait(200);
-
-    //cy.checkA11yWithWait();
+    // cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "long-option-label",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.078),

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -798,7 +798,7 @@ export class SearchBar {
       filteredOptions,
     } = this;
 
-    const disabledMode = readonly || disabled ? true : false;
+    const disabledMode = readonly || disabled;
 
     const describedBy = getInputDescribedByText(
       inputId,
@@ -818,37 +818,27 @@ export class SearchBar {
       describedById = undefined;
     }
 
-    const disabledText = disabledMode && !readonly;
-    const hasSuggestedSearch = value && this.hasOptionsOrFilterDisabled();
+    const hasSuggestedSearch = !!value && this.hasOptionsOrFilterDisabled();
     const menuOpen = hasSuggestedSearch && open && filteredOptions.length > 0;
     const menuRendered =
       menuOpen && value.length >= this.charactersUntilSuggestion;
-    const isOrHasLoaded =
-      this.filteredOptions.length === 1 &&
-      (this.filteredOptions[0][this.labelField] === this.loadingLabel ||
-        filteredOptions[0][this.labelField] === this.loadingErrorLabel);
 
-    let expanded;
-
-    if (options.length > 0) {
-      if (menuOpen) {
-        expanded = "true";
-      } else {
-        expanded = "false";
-      }
-    } else {
-      expanded = undefined;
-    }
+    const labelValue = getLabelFromValue(
+      value,
+      options,
+      this.valueField,
+      this.labelField
+    );
 
     renderHiddenInput(true, this.el, name, value, disabledMode);
 
     return (
       <Host
         class={{
-          ["search"]: true,
-          ["fullwidth"]: fullWidth,
-          ["disabled"]: disabled,
-          ["small"]: size === "small",
+          search: true,
+          fullwidth: fullWidth,
+          disabled,
+          small: size === "small",
         }}
         onFocus={this.handleHostFocus}
         onBlur={this.handleHostBlur}
@@ -859,29 +849,14 @@ export class SearchBar {
           label={label}
           helperText={helperText}
           required={required}
-          disabled={disabledText}
+          disabled={disabledMode && !readonly}
           readonly={readonly}
           size={size}
           hideLabel={hideLabel}
           fullWidth={fullWidth}
           name={name}
           truncateValue={truncateValue}
-          value={
-            options &&
-            !!getLabelFromValue(
-              value,
-              options,
-              this.valueField,
-              this.labelField
-            )
-              ? getLabelFromValue(
-                  value,
-                  options,
-                  this.valueField,
-                  this.labelField
-                )
-              : value
-          }
+          value={options && !!labelValue ? labelValue : value}
           placeholder={placeholder}
           onInput={this.onInput}
           onBlur={this.onInputBlur}
@@ -889,11 +864,12 @@ export class SearchBar {
           aria-label={hideLabel ? label : ""}
           aria-describedby={describedById}
           aria-owns={menuRendered ? menuId : undefined}
+          aria-controls={menuRendered ? menuId : undefined}
           aria-haspopup={options.length > 0 ? "listbox" : undefined}
-          ariaExpanded={expanded}
+          ariaExpanded={options.length > 0 ? `${menuOpen}` : undefined}
           ariaActiveDescendant={ariaActiveDescendant}
           aria-autocomplete={hasSuggestedSearch ? "list" : undefined}
-          role={hasSuggestedSearch ? "combobox" : undefined}
+          role={options.length > 0 ? "combobox" : undefined}
           autocomplete={autocomplete}
           autocapitalize={autocapitalize}
           autoFocus={autofocus}
@@ -972,7 +948,13 @@ export class SearchBar {
             {menuRendered && (
               <ic-menu
                 class={{
-                  "no-results": this.hadNoOptions() || isOrHasLoaded,
+                  "no-results":
+                    this.hadNoOptions() ||
+                    (filteredOptions.length === 1 &&
+                      (filteredOptions[0][this.labelField] ===
+                        this.loadingLabel ||
+                        filteredOptions[0][this.labelField] ===
+                          this.loadingErrorLabel)),
                 }}
                 activationType="manual"
                 anchorEl={this.anchorEl}

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -1033,8 +1033,7 @@ export class Select {
       disabled
     );
 
-    const invalid =
-      validationStatus === IcInformationStatus.Error ? "true" : "false";
+    const invalid = `${validationStatus === IcInformationStatus.Error}`;
 
     const describedBy = getInputDescribedByText(
       this.inputId,
@@ -1050,9 +1049,9 @@ export class Select {
     return (
       <Host
         class={{
-          disabled: disabled,
-          searchable: searchable,
-          small: small,
+          disabled,
+          searchable,
+          small,
           [size]: size !== "default",
           "full-width": fullWidth,
         }}
@@ -1151,9 +1150,9 @@ export class Select {
                   aria-describedby={describedBy}
                   aria-activedescendant={this.ariaActiveDescendant}
                   aria-autocomplete="list"
-                  aria-expanded={this.open ? "true" : "false"}
+                  aria-expanded={`${this.open}`}
                   aria-invalid={invalid}
-                  aria-required={required ? "true" : "false"}
+                  aria-required={`${required}`}
                   aria-controls={menuId}
                   ref={(el) => (this.searchableSelectElement = el)}
                   id={this.inputId}

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -494,7 +494,7 @@ export class TextField {
       hiddenInput,
     } = this;
 
-    const disabledMode = readonly ? true : disabled;
+    const disabledMode = readonly || disabled;
 
     const currentStatus =
       maxLengthExceeded ||


### PR DESCRIPTION
## Summary of the changes
- Changed condition for when to apply combobox role to the input of ic-search-bar. Now matches aria-expanded condition to ensure they are applied at the same time.
- Added back missing a11y checks to cypress tests

## Related issue
#1912
Still some a11y violations on certain tests, that will be covered in [this ticket](https://github.com/mi6/ic-ui-kit/issues/2015)

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.