### PR TITLE
fix(web-components): fixes issue with showDefaultIcon in gatsby

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -81,6 +81,11 @@
   display: inline-block;
 }
 
+/* required for Gatsby as prop does not seem to work when set to false */
+:host([showdefaulticon="false"]) .icon-neutral {
+  display: none;
+}
+
 .icon-neutral > svg,
 ::slotted(svg) {
   height: var(--ic-space-lg);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
fixes issue where icon not hidden in gatsby even though showDefaultIcon = false
sets `display:none` when showdefaulticon="false" is on the host element

## Related issue
N/A

