### PR TITLE
test(react): update Cypress e2e tests after v2 -> v3 rebase

### DIFF
--- a/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
@@ -149,9 +149,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.findShadowEl(RADIO_SELECTOR, "input")
-      .eq(0)
-      .should(HAVE_ATTR, "tabindex", 0);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(0).should(HAVE_ATTR, "tabindex", 0);
   });
 
   it("should not be clickable when disabled", () => {
@@ -160,10 +158,10 @@ describe("IcRadio end-to-end tests", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
 
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).find(".container").click();
     cy.realPress("ArrowDown");
     cy.get(RADIO_SELECTOR).eq(2).should(HAVE_PROP, "selected", false);
     cy.realPress("ArrowUp");
@@ -176,11 +174,11 @@ describe("IcRadio end-to-end tests", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", true);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", false);
     cy.findShadowEl(TEXT_FIELD_SELECTOR, INPUT).type("test");
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "value", "test");
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).find(".container").click();
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", true);
   });
 
@@ -192,17 +190,17 @@ describe("IcRadio end-to-end tests", () => {
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should(NOT_BE_VISIBLE);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should("be.visible");
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should(NOT_BE_VISIBLE);
 
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).find(".container").click();
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should("be.visible");
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should(NOT_BE_VISIBLE);
 
-    cy.get(RADIO_SELECTOR).eq(2).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(2).find(".container").click();
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should("be.visible");
@@ -223,7 +221,7 @@ describe("IcRadio end-to-end tests", () => {
       cy.stub().as("icCheck")
     );
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
 
     cy.get("@icChange").should(HAVE_BEEN_CALLED);
@@ -237,7 +235,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.get(BUTTON).focus();
     cy.realPress("Tab");
-    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(0).should(HAVE_FOCUS);
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
     cy.realPress("Space");
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
@@ -250,7 +248,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.get(BUTTON).focus();
     cy.realPress("Tab");
-    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(0).should(HAVE_FOCUS);
     cy.realPress("ArrowDown");
     cy.get(RADIO_SELECTOR).eq(1).should(HAVE_PROP, "selected", true);
   });
@@ -262,7 +260,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.get(BUTTON).focus();
     cy.realPress("Tab");
-    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(0).should(HAVE_FOCUS);
     cy.realPress("ArrowRight");
     cy.get(RADIO_SELECTOR).eq(1).should(HAVE_PROP, "selected", true);
   });
@@ -274,7 +272,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.get(BUTTON).focus();
     cy.realPress("Tab");
-    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(0).should(HAVE_FOCUS);
     cy.realPress("ArrowUp");
     cy.get(RADIO_SELECTOR).eq(3).should(HAVE_PROP, "selected", true);
   });
@@ -286,7 +284,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.get(BUTTON).focus();
     cy.realPress("Tab");
-    cy.get(RADIO_SELECTOR).eq(0).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(0).should(HAVE_FOCUS);
     cy.realPress("ArrowLeft");
     cy.get(RADIO_SELECTOR).eq(3).should(HAVE_PROP, "selected", true);
   });
@@ -298,7 +296,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.get(BUTTON).focus();
     cy.realPress("Tab");
-    cy.get(RADIO_SELECTOR).eq(1).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(1).should(HAVE_FOCUS);
   });
 
   it("should move focus to the dynamically displayed field when tabbing on from the radio group", () => {
@@ -306,7 +304,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
     cy.realPress("Tab");
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(HAVE_FOCUS);
@@ -317,11 +315,11 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", false);
     cy.realPress("ArrowDown");
-    cy.get(RADIO_SELECTOR).eq(1).should(HAVE_FOCUS);
+    cy.get(RADIO_SELECTOR).find(INPUT).eq(1).should(HAVE_FOCUS);
   });
 
   it("should pass the value of radio button correctly when already selected", () => {
@@ -347,7 +345,7 @@ describe("IcRadio end-to-end tests", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
     cy.spy(window.console, "log").as("spyWinConsoleLog");
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
     cy.get("input[type='submit']").click();
     cy.get("@spyWinConsoleLog").should(
@@ -361,7 +359,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
 
     cy.get("input[type='reset']").click();

--- a/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
+++ b/packages/react/src/component-tests/IcSearchBar/IcSearchBar.cy.tsx
@@ -124,7 +124,7 @@ describe("IcSearchBar end-to-end tests", () => {
     cy.findShadowEl(SEARCH_SELECTOR, IC_MENU_LI).should(NOT_EXIST);
     cy.findShadowEl(SEARCH_SELECTOR, "#search-submit-button").should(
       HAVE_CLASS,
-      "disabled"
+      "ic-button-disabled"
     );
 
     cy.findShadowEl(SEARCH_SELECTOR, TEXT_FIELD_SELECTOR)
@@ -595,7 +595,7 @@ describe("IcSearchBar end-to-end tests", () => {
       .type("Ga");
     cy.findShadowEl(SEARCH_SELECTOR, "#search-submit-button").should(
       HAVE_CLASS,
-      "disabled"
+      "ic-button-disabled"
     );
   });
 
@@ -851,7 +851,7 @@ describe("IcSearchBar end-to-end tests", () => {
     cy.findShadowEl(SEARCH_SELECTOR, "#retry-button").should("exist");
     cy.findShadowEl(SEARCH_SELECTOR, "#search-submit-button").should(
       HAVE_CLASS,
-      "disabled"
+      "ic-button-disabled"
     );
   });
 

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -195,16 +195,22 @@ export class RadioGroup {
         totalWidth = 0;
       }
 
-      if (
-        this.currentOrientation === this.RADIO_HORIZONTAL &&
-        totalWidth > this.radioContainer.clientWidth
-      ) {
-        this.currentOrientation = this.RADIO_VERTICAL;
-      } else if (
-        this.currentOrientation === this.RADIO_VERTICAL &&
-        totalWidth < this.radioContainer.clientWidth
-      ) {
-        this.currentOrientation = this.RADIO_HORIZONTAL;
+      if (this.initialOrientation == this.RADIO_HORIZONTAL) {
+        if (
+          this.radioOptions !== undefined &&
+          (this.radioOptions.length > 2 ||
+            (this.radioOptions.length === 2 &&
+              (slotHasContent(this.radioOptions[0], this.ADDITIONAL_FIELD) ||
+                slotHasContent(this.radioOptions[1], this.ADDITIONAL_FIELD))))
+        ) {
+          this.currentOrientation = this.RADIO_VERTICAL;
+        } else {
+          if (totalWidth >= this.radioContainer?.clientWidth) {
+            this.currentOrientation = this.RADIO_VERTICAL;
+          } else if (totalWidth < this.radioContainer?.clientWidth) {
+            this.currentOrientation = this.RADIO_HORIZONTAL;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

- Removed shadow from radio tests
- Updated to v3 class names 
- Restore orientation overrides

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.