### PR TITLE
Ic-radio-option: fix click event not working on components in additional field slot

### DIFF
--- a/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
@@ -206,6 +206,17 @@ describe("IcRadio end-to-end tests", () => {
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should("be.visible");
   });
 
+  it("should call onclick function of component in additional-field slot when slotted component is clicked", () => {
+    mount(<ConditionalDynamic />);
+    cy.get(RADIO_SELECTOR).eq(0).find(".container").click();
+    cy.get(TEXT_FIELD_SELECTOR).eq(0).click();
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
+    cy.get("@spyWinConsoleLog").should(
+      HAVE_BEEN_CALLED_WITH,
+      "Textfield clicked"
+    );
+  });
+
   it("should emit icChange and icCheck events when radio option is selected", () => {
     mount(<Default />);
 

--- a/packages/react/src/component-tests/IcRadio/IcRadioTestData.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadioTestData.tsx
@@ -313,6 +313,9 @@ export const ConditionalStatic = () => {
 };
 
 export const ConditionalDynamic = () => {
+  const handleTextfieldClicked = () => {
+    console.log("Textfield clicked");
+  };
   return (
     <div style={{ padding: "10px" }}>
       <IcRadioGroup
@@ -329,6 +332,7 @@ export const ConditionalDynamic = () => {
             slot="additional-field"
             placeholder="Placeholder"
             label="What's your favourite type of coffee?"
+            onClick={handleTextfieldClicked}
           />
         </IcRadioOption>
         <IcRadioOption

--- a/packages/react/src/stories/ic-radio-group.stories.mdx
+++ b/packages/react/src/stories/ic-radio-group.stories.mdx
@@ -136,13 +136,14 @@ import { useState, useEffect, useRef } from "react";
       <IcRadioOption
         additionalFieldDisplay="dynamic"
         value="valueName3"
-        label="option3"
+        label="option3 - clickable component"
       >
-        <IcTextField
+        <IcButton
           slot="additional-field"
-          placeholder="Placeholder"
-          label="What's your favourite type of coffee? "
-        />
+          onClick={()=>alert("Button clicked!")}
+        >
+          Click me for an alert!
+        </IcButton>
       </IcRadioOption>
     </IcRadioGroup>
   </Story>

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.mdx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.mdx
@@ -152,6 +152,12 @@ import readme from "./readme.md";
           function handleIcChange(ev) {
             console.log(ev.detail.selectedOption);
           }
+          function handleClick() {
+            alert("Button clicked!");
+          }
+          document
+            .querySelector("ic-button")
+            .addEventListener("click", handleClick);
           document
             .querySelector("ic-radio-group")
             .addEventListener("icChange", handleIcChange);
@@ -186,13 +192,9 @@ import readme from "./readme.md";
           <ic-radio-option
             additional-field-display="dynamic"
             value="valueName3"
-            label="option3"
+            label="option3 - clickable component"
           >
-            <ic-text-field
-              slot="additional-field"
-              placeholder="Placeholder"
-              label="What's your favourite type of coffee?"
-            ></ic-text-field>
+            <ic-button slot="additional-field"> Click me! </ic-button>
           </ic-radio-option>
         </ic-radio-group>
       `

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
@@ -225,7 +225,7 @@ describe("ic-radio-group", () => {
 
     const callbackFn = jest.fn();
     page.doc.addEventListener("icCheck", callbackFn);
-    page.rootInstance.textfieldValueHandler({
+    page.rootInstance.additionalFieldValueHandler({
       detail: { value: "value" },
       stopImmediatePropagation: jest.fn(),
     });
@@ -244,7 +244,7 @@ describe("ic-radio-group", () => {
 
     const callbackFn = jest.fn();
     page.doc.addEventListener("icCheck", callbackFn);
-    page.rootInstance.textfieldValueHandler({
+    page.rootInstance.additionalFieldValueHandler({
       detail: { value: "" },
       stopImmediatePropagation: jest.fn(),
     });

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
@@ -19,6 +19,7 @@ ic-radio-option.ic-radio-option-disabled {
 /* Focus states */
 
 .container input:focus + span.checkmark,
+.container:active input:focus + span.checkmark,
 :host(:focus) .container input:checked + span.checkmark {
   box-shadow: var(--ic-border-focus);
 }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

fix click event not being emitted properly on components that are in the additional field slot

## Related issue

fix #2514 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.