### PR TITLE
test(react): added long label tooltip test

### DIFF
--- a/packages/react/src/component-tests/IcTooltip/IcTooltip.cy.tsx
+++ b/packages/react/src/component-tests/IcTooltip/IcTooltip.cy.tsx
@@ -15,6 +15,7 @@ import {
   DisableHover,
   ExternalNoPersist,
   External,
+  LargeLabel,
 } from "./IcTooltipTestData";
 import {
   BE_VISIBLE,
@@ -237,6 +238,20 @@ describe("IcTooltip visual regression and a11y tests", () => {
       name: "default",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.002),
       delay: 200,
+    });
+  });
+
+  it("should render a IcTooltip with a large label", () => {
+    mount(<LargeLabel />);
+
+    cy.checkHydrated(TOOLTIP_SELECTOR);
+    cy.get("button").realHover("mouse");
+
+    cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "very-large-label",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.081),
+      delay: 500,
     });
   });
 

--- a/packages/react/src/component-tests/IcTooltip/IcTooltipTestData.tsx
+++ b/packages/react/src/component-tests/IcTooltip/IcTooltipTestData.tsx
@@ -225,6 +225,26 @@ export const Truncation = () => {
   );
 };
 
+export const LargeLabel = () => {
+  return (
+    <div style={{ margin: "40px" }}>
+      <IcTooltip
+        label="This is a body of text that is purposefully long to test whether text is being wrapped within the tooltip. It has been wrapped based on the necessity to prevent future bugs and that the user may read the entire body of text. The number of lines in the text is clamped to the number passed through the maxLines prop."
+        maxLines={10}
+        id="ic-tooltip-test-button-large-label"
+        target="test-button-large-label"
+      >
+        <button
+          aria-describedby="ic-tooltip-test-button-large-label"
+          id="test-button-large-label"
+        >
+          Default
+        </button>
+      </IcTooltip>
+    </div>
+  );
+};
+
 export const Chip = () => {
   return (
     <div style={{ margin: "40px" }}>


### PR DESCRIPTION


## Summary of the changes
Created a long label tooltip test in react

## Related issue
#2540 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.