### PR TITLE
[ic-page-header]: removed margin-bottom from heading (v3)

### DIFF
--- a/packages/web-components/src/components/ic-alert/ic-alert.css
+++ b/packages/web-components/src/components/ic-alert/ic-alert.css
@@ -89,7 +89,7 @@
 /* required for Gatsby as prop does not seem to work when set to false */
 :host([showdefaulticon="false"]) .icon-neutral {
   visibility: hidden;
-  width: 0px;
+  width: 0;
   margin-left: 0.625rem;
 }
 

--- a/packages/web-components/src/components/ic-page-header/ic-page-header.css
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.css
@@ -56,7 +56,6 @@ header.tabs {
   align-items: center;
   width: 100%;
   flex-wrap: wrap;
-  margin-bottom: var(--ic-space-xs);
   column-gap: var(--ic-space-md);
 }
 
@@ -66,8 +65,12 @@ header.tabs {
   hyphens: auto;
 }
 
-.subheading.small {
+.subheading-content {
   margin-top: var(--ic-space-xs);
+}
+
+.subheading-content.small {
+  margin-top: var(--ic-space-md);
 }
 
 .action-area {

--- a/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
@@ -205,19 +205,15 @@ export class PageHeader {
                   </slot>
                   <slot name="heading-adornment" />
                 </div>
-                <div>
+                <div
+                  class={{
+                    ["subheading-content"]:
+                      !!subheading || isSlotUsed(this.el, "subheading"),
+                    ["small"]: size === "small",
+                  }}
+                >
                   <slot name="subheading">
-                    {subheading && (
-                      <ic-typography
-                        variant="body"
-                        class={{
-                          ["subheading"]: true,
-                          ["small"]: size === "small",
-                        }}
-                      >
-                        {subheading}
-                      </ic-typography>
-                    )}
+                    <ic-typography variant="body">{subheading}</ic-typography>
                   </slot>
                 </div>
               </div>

--- a/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
+++ b/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
@@ -18,7 +18,9 @@ exports[`ic-page-header component renders additional functionality should render
               <slot name="heading-adornment"></slot>
             </div>
             <div>
-              <slot name="subheading"></slot>
+              <slot name="subheading">
+                <ic-typography variant="body"></ic-typography>
+              </slot>
             </div>
           </div>
         </div>
@@ -53,9 +55,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -110,9 +112,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -170,9 +172,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -214,9 +216,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -251,9 +253,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -295,9 +297,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -330,9 +332,9 @@ exports[`ic-page-header component renders additional functionality should render
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>
@@ -395,9 +397,9 @@ exports[`simple ic-page-header renders should render with a heading & sub-headin
               </slot>
               <slot name="heading-adornment"></slot>
             </div>
-            <div>
+            <div class="subheading-content">
               <slot name="subheading">
-                <ic-typography class="subheading" variant="body">
+                <ic-typography variant="body">
                   This is a simple page header component and this is the text.
                 </ic-typography>
               </slot>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Removed margin-bottom from heading and added margin-top to subheading so the heading appears centred vertically when no subheading has been set

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

N/A

### Resize/zoom behaviour 

N/A

### System modes

N/A

### Testing content extremes

- [x] All prop combinations work without issue. 
- [x] Props/slots can be updated after initial render.