### PR TITLE
1967 date input unable to deal with browser input suggestions

### DIFF
--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.css
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.css
@@ -15,6 +15,10 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
 
+input:-webkit-autofill {
+  box-shadow: 0 0 0 var(--ic-space-sm) var(--ic-architectural-white) inset;
+}
+
 ic-input-component-container {
   cursor: text;
 }

--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
@@ -562,7 +562,7 @@ export class DateInput {
   private handleKeyDown = (event: KeyboardEvent, isInputPrevented: boolean) => {
     const input = event.target as HTMLInputElement;
 
-    const eventKey = event.key.toLowerCase();
+    const eventKey = event.key?.toLowerCase();
     // Regex required due to FF allowing all characters as values for number text field.
     const regex =
       /-?\d*\.?\d+(e[-+]?\d+)?|[/-]|arrowup|arrowdown|arrowleft|arrowright|shift|tab|backspace|delete/;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add check to event.key to ensure it exists in date input so that browser input suggestions can be accepted

## Related issue
#1967

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.