### PR TITLE
Navigation item aria label not read out in NVDA

### DIFF
--- a/packages/react/src/stories/ic-page-header.stories.mdx
+++ b/packages/react/src/stories/ic-page-header.stories.mdx
@@ -481,11 +481,13 @@ export const defaultArgs = {
         label="All recipes"
         href="?path=/story/web-components-page-header--with-tabs"
         selected
+        aria-label="This page shows all the recipes"
       />
       <IcNavigationItem
         slot="tabs"
         label="Favourites"
         href="?path=/story/web-components-page-header--with-tabs"
+        aria-label="Show your favourite recipes"
       />
       <IcNavigationItem
         slot="tabs"

--- a/packages/web-components/src/components/ic-navigation-item/test/basic/__snapshots__/ic-navigation-item.spec.ts.snap
+++ b/packages/web-components/src/components/ic-navigation-item/test/basic/__snapshots__/ic-navigation-item.spec.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ic-navigation-item should render with aria-label: renders-with-aria-label 1`] = `
+<ic-navigation-item aria-label="navigation item description" class="light navigation-item" href="#link" label="Item label" role="listitem">
+  <mock:shadow-root>
+    <ic-tooltip class="tooltip-navigation-item" label="Item label" placement="right" target="navigation-item">
+      <a aria-label="navigation item description" class="link" href="#link" part="link">
+        <ic-typography variant="label">
+          Item label
+        </ic-typography>
+        <div class="chevron-container"></div>
+      </a>
+    </ic-tooltip>
+  </mock:shadow-root>
+</ic-navigation-item>
+`;
+
+exports[`ic-navigation-item should render with aria-label: renders-with-new-aria-label 1`] = `
+<ic-navigation-item aria-label="New item description" class="light navigation-item" href="#link" label="Item label" role="listitem">
+  <mock:shadow-root>
+    <ic-tooltip class="tooltip-navigation-item" label="Item label" placement="right" target="navigation-item">
+      <a aria-label="New item description" class="link" href="#link" part="link">
+        <ic-typography variant="label">
+          Item label
+        </ic-typography>
+        <div class="chevron-container"></div>
+      </a>
+    </ic-tooltip>
+  </mock:shadow-root>
+</ic-navigation-item>
+`;
+
 exports[`ic-navigation-item should render with label: renders-with-label 1`] = `
 <ic-navigation-item class="light navigation-item" label="Item label" role="listitem">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-navigation-item/test/basic/ic-navigation-item.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-item/test/basic/ic-navigation-item.spec.ts
@@ -14,6 +14,22 @@ describe("ic-navigation-item", () => {
     expect(page.root).toMatchSnapshot("renders-with-label");
   });
 
+  it("should render with aria-label", async () => {
+    const page = await newSpecPage({
+      components: [NavigationItem],
+      html: `<ic-navigation-item href="#link" label="Item label" aria-label="navigation item description"></ic-navigation-item>`,
+    });
+    expect(page.root).toMatchSnapshot("renders-with-aria-label");
+
+    page.root.setAttribute("aria-label", "New item description");
+    await page.waitForChanges();
+
+    page.rootInstance.hostMutationCallback([{ attributeName: "aria-label" }]);
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot("renders-with-new-aria-label");
+  });
+
   it("should test theme change", async () => {
     const page = await newSpecPage({
       components: [NavigationItem],

--- a/packages/web-components/src/components/ic-page-header/ic-page-header.stories.mdx
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.stories.mdx
@@ -372,11 +372,13 @@ import readme from "./readme.md";
           label="All recipes"
           href="?path=/story/web-components-page-header--with-tabs"
           selected
+          aria-label="This page shows all the recipes"
         ></ic-navigation-item>
         <ic-navigation-item
           slot="tabs"
           label="Favourites"
           href="?path=/story/web-components-page-header--with-tabs"
+          aria-label="Show your favourite recipes"
         ></ic-navigation-item>
         <ic-navigation-item
           slot="tabs"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes nav-item screen reader issue where aria-label was not being read out in NVDA
Now also supports the aria-label being changed after initial render

## Related issue
#2579

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.