### PR TITLE
Add IcToggleChecked event to IcMenuItem and change toggleChecked state to prop

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -8562,6 +8562,28 @@
           "required": false
         },
         {
+          "name": "toggleChecked",
+          "type": "boolean",
+          "complexType": {
+            "original": "boolean",
+            "resolved": "boolean",
+            "references": {}
+          },
+          "mutable": true,
+          "attr": "toggle-checked",
+          "reflectToAttr": true,
+          "docs": "If `true`, the menu item will be in a checked state. This is only applicable when variant is set to `toggle`.",
+          "docsTags": [],
+          "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
           "name": "variant",
           "type": "\"default\" | \"destructive\" | \"toggle\"",
           "complexType": {
@@ -8600,7 +8622,22 @@
         }
       ],
       "methods": [],
-      "events": [],
+      "events": [
+        {
+          "event": "icToggleChecked",
+          "detail": "{ checked: boolean; }",
+          "bubbles": true,
+          "complexType": {
+            "original": "{\n    checked: boolean;\n  }",
+            "resolved": "{ checked: boolean; }",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Emitted when the user clicks a menu item that is set to the toggle variant.",
+          "docsTags": []
+        }
+      ],
       "listeners": [
         {
           "event": "click",

--- a/packages/react/src/component-tests/IcPopoverMenu/IcPopoverMenu.cy.tsx
+++ b/packages/react/src/component-tests/IcPopoverMenu/IcPopoverMenu.cy.tsx
@@ -20,8 +20,10 @@ import {
   PopoverWithMenuGroups,
 } from "./IcPopoverMenuData";
 
-const POPOVER_SELECTOR = "ic-popover-menu";
 const BUTTON_SELECTOR = "ic-button";
+const MENU_ITEM_SELECTOR = "ic-menu-item";
+const POPOVER_SELECTOR = "ic-popover-menu";
+
 const DEFAULT_TEST_THRESHOLD = 0.016;
 
 describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
@@ -77,9 +79,9 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     );
 
     cy.get(BUTTON_SELECTOR).click();
-    cy.get("ic-menu-item").eq(0).click({ force: true });
-    cy.get("ic-menu-item").eq(1).click({ force: true });
-    cy.get("ic-menu-item").eq(2).click({ force: true });
+    cy.get(MENU_ITEM_SELECTOR).eq(0).click({ force: true });
+    cy.get(MENU_ITEM_SELECTOR).eq(1).click({ force: true });
+    cy.get(MENU_ITEM_SELECTOR).eq(2).click({ force: true });
 
     cy.get("@handleMenuItemClick").should(NOT_HAVE_BEEN_CALLED);
     cy.get("@triggerPopoverMenuInstance").should(NOT_BE_CALLED_ONCE);
@@ -246,7 +248,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     );
 
     cy.get(BUTTON_SELECTOR).click();
-    cy.get("ic-menu-item").eq(0).click();
+    cy.get(MENU_ITEM_SELECTOR).eq(0).click();
 
     cy.get("@icPopoverClosed").should(HAVE_BEEN_CALLED_ONCE);
   });
@@ -288,9 +290,24 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     );
 
     cy.get(BUTTON_SELECTOR).click();
-    cy.get("ic-menu-item").eq(0).click();
+    cy.get(MENU_ITEM_SELECTOR).eq(0).click();
 
     cy.get("@handleMenuItemClick").should(HAVE_BEEN_CALLED_ONCE);
+  });
+
+  it("should emit icToggleChecked when a user clicks a toggle menu item", () => {
+    mount(<PopoverMenuWithVariants />);
+
+    cy.checkHydrated(POPOVER_SELECTOR);
+
+    cy.get(MENU_ITEM_SELECTOR)
+      .eq(3)
+      .invoke("on", "icToggleChecked", cy.stub().as("icToggleChecked"));
+
+    cy.get(BUTTON_SELECTOR).click();
+    cy.get(MENU_ITEM_SELECTOR).eq(3).click();
+
+    cy.get("@icToggleChecked").should(HAVE_BEEN_CALLED_ONCE);
   });
 });
 

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -1163,6 +1163,10 @@ export namespace Components {
          */
         "target"?: string;
         /**
+          * If `true`, the menu item will be in a checked state. This is only applicable when variant is set to `toggle`.
+         */
+        "toggleChecked": boolean;
+        /**
           * The variant of the menu item.
          */
         "variant": IcMenuItemVariants;
@@ -2850,6 +2854,9 @@ declare global {
     label: string;
     hasSubMenu: boolean;
   };
+        "icToggleChecked": {
+    checked: boolean;
+  };
         "triggerPopoverMenuInstance": void;
     }
     interface HTMLIcMenuItemElement extends Components.IcMenuItem, HTMLStencilElement {
@@ -4488,6 +4495,12 @@ declare namespace LocalJSX {
     label: string;
     hasSubMenu: boolean;
   }>) => void;
+        /**
+          * Emitted when the user clicks a menu item that is set to the toggle variant.
+         */
+        "onIcToggleChecked"?: (event: IcMenuItemCustomEvent<{
+    checked: boolean;
+  }>) => void;
         "onTriggerPopoverMenuInstance"?: (event: IcMenuItemCustomEvent<void>) => void;
         /**
           * How much of the referrer to send when following the link.
@@ -4505,6 +4518,10 @@ declare namespace LocalJSX {
           * The place to display the linked URL, as the name for a browsing context (a tab, window, or iframe).
          */
         "target"?: string;
+        /**
+          * If `true`, the menu item will be in a checked state. This is only applicable when variant is set to `toggle`.
+         */
+        "toggleChecked"?: boolean;
         /**
           * The variant of the menu item.
          */

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -4,7 +4,6 @@ import {
   Host,
   Prop,
   h,
-  State,
   Event,
   EventEmitter,
   Listen,
@@ -32,8 +31,6 @@ import Chevron from "../../assets/chevron-icon.svg";
 })
 export class MenuItem {
   @Element() el: HTMLIcMenuItemElement;
-
-  @State() toggleChecked: boolean = false;
 
   /**
    * The description displayed in the menu item, below the label.
@@ -86,6 +83,11 @@ export class MenuItem {
   @Prop() target?: string;
 
   /**
+   * If `true`, the menu item will be in a checked state. This is only applicable when variant is set to `toggle`.
+   */
+  @Prop({ mutable: true, reflect: true }) toggleChecked: boolean = false;
+
+  /**
    * The variant of the menu item.
    */
   @Prop({ mutable: true, reflect: true }) variant: IcMenuItemVariants =
@@ -102,6 +104,13 @@ export class MenuItem {
   @Event() handleMenuItemClick: EventEmitter<{
     label: string;
     hasSubMenu: boolean;
+  }>;
+
+  /**
+   * Emitted when the user clicks a menu item that is set to the toggle variant.
+   */
+  @Event() icToggleChecked: EventEmitter<{
+    checked: boolean;
   }>;
 
   /**
@@ -137,6 +146,9 @@ export class MenuItem {
     } else if (this.variant === "toggle") {
       e.preventDefault();
       this.toggleChecked = !this.toggleChecked;
+      this.icToggleChecked.emit({
+        checked: this.toggleChecked,
+      });
     }
     this.handleMenuItemClick.emit({
       label: this.label,

--- a/packages/web-components/src/components/ic-menu-item/readme.md
+++ b/packages/web-components/src/components/ic-menu-item/readme.md
@@ -19,7 +19,15 @@
 | `rel`                | `rel`                 | The relationship of the linked URL as space-separated link types.                                                                            | `string`                                                                                                                                                                                 | `undefined` |
 | `submenuTriggerFor`  | `submenu-trigger-for` | This references the popover menu instance that the menu item is a trigger for. If this prop is set, then the variant will always be default. | `string`                                                                                                                                                                                 | `undefined` |
 | `target`             | `target`              | The place to display the linked URL, as the name for a browsing context (a tab, window, or iframe).                                          | `string`                                                                                                                                                                                 | `undefined` |
+| `toggleChecked`      | `toggle-checked`      | If `true`, the menu item will be in a checked state. This is only applicable when variant is set to `toggle`.                                | `boolean`                                                                                                                                                                                | `false`     |
 | `variant`            | `variant`             | The variant of the menu item.                                                                                                                | `"default" \| "destructive" \| "toggle"`                                                                                                                                                 | `"default"` |
+
+
+## Events
+
+| Event             | Description                                                                 | Type                                 |
+| ----------------- | --------------------------------------------------------------------------- | ------------------------------------ |
+| `icToggleChecked` | Emitted when the user clicks a menu item that is set to the toggle variant. | `CustomEvent<{ checked: boolean; }>` |
 
 
 ## Slots

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
@@ -487,7 +487,11 @@ export const defaultArgs = {
   >
     {(args) =>
       html`<div>
-        <ic-popover-menu aria-label="popover" open=${args.open}>
+        <ic-popover-menu
+          aria-label="popover"
+          open=${args.open}
+          id="popover-menu-playground"
+        >
           <ic-menu-group label=${args.groupLabel}>
             <ic-menu-item
               description=${args.description}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Change toggleChecked state to a prop and add new icToggleChecked event to ic-menu-item. The need for this became apparent after the work done in https://github.com/mi6/ic-design-system/issues/1184

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 

