### PR TITLE
[disconnectedCallback update]: optional chaining to removeEventListener functions

### DIFF
--- a/packages/web-components/src/components/ic-horizontal-scroll/ic-horizontal-scroll.tsx
+++ b/packages/web-components/src/components/ic-horizontal-scroll/ic-horizontal-scroll.tsx
@@ -94,13 +94,13 @@ export class HorizontalScroll {
       );
     });
 
-    this.items.forEach((item) => {
+    this.items?.forEach((item) => {
       if (item.removeEventListener) {
         item.removeEventListener(this.focusTrigger, this.focusHandler);
       }
     });
 
-    this.itemsContainerEl.removeEventListener("scroll", this.scrollHandler);
+    this.itemsContainerEl?.removeEventListener("scroll", this.scrollHandler);
   }
 
   /**

--- a/packages/web-components/src/components/ic-menu/ic-menu.tsx
+++ b/packages/web-components/src/components/ic-menu/ic-menu.tsx
@@ -214,8 +214,8 @@ export class Menu {
     if (this.popperInstance) {
       this.popperInstance.destroy();
     }
-    this.parentEl.removeEventListener("icClear", this.handleClearListener);
-    this.parentEl.removeEventListener(
+    this.parentEl?.removeEventListener("icClear", this.handleClearListener);
+    this.parentEl?.removeEventListener(
       "icSubmitSearch",
       this.handleSubmitSearch
     );

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -60,12 +60,12 @@ export class NavigationGroup {
 
   disconnectedCallback(): void {
     if (this.navigationType === "side") {
-      this.parentEl.removeEventListener(
+      this.parentEl?.removeEventListener(
         "sideNavExpanded",
         this.sideNavExpandHandler
       );
     } else if (this.navigationType === "top") {
-      this.parentEl.removeEventListener(
+      this.parentEl?.removeEventListener(
         "topNavResized",
         this.topNavResizedHandler
       );

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -164,7 +164,7 @@ export class SideNavigation {
       this.resizeObserver.disconnect();
     }
 
-    this.el.removeEventListener("transitionend", this.transitionEndHandler);
+    this.el?.removeEventListener("transitionend", this.transitionEndHandler);
   }
 
   @Listen("themeChange", { target: "document" })

--- a/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
+++ b/packages/web-components/src/components/ic-tab-context/ic-tab-context.tsx
@@ -98,7 +98,7 @@ export class TabContext {
   }
 
   disconnectedCallback(): void {
-    this.tabGroup.removeEventListener("keydown", this.keydownHandler);
+    this.tabGroup?.removeEventListener("keydown", this.keydownHandler);
   }
 
   @Listen("tabClick")

--- a/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.tsx
+++ b/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.tsx
@@ -153,7 +153,7 @@ export class ToggleButtonGroup {
   }
 
   disconnectedCallback(): void {
-    document.removeEventListener("keydown", this.keyListener);
+    document?.removeEventListener("keydown", this.keyListener);
   }
 
   private keyListener = (ev: KeyboardEvent) => {

--- a/packages/web-components/src/components/ic-toggle-button-group/test/ic-toggle-button-group.spec.ts
+++ b/packages/web-components/src/components/ic-toggle-button-group/test/ic-toggle-button-group.spec.ts
@@ -197,5 +197,7 @@ describe("ic-toggle-button-group component unit tests", () => {
     const mockEvent = new FocusEvent("focus");
 
     expect(page.rootInstance.handleHostFocus(mockEvent)).toBeNull();
+
+    await page.rootInstance.disconnectedCallback();
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added optional chaining on removeEventListener methods within disconnectedCallback to prevent vitest console errors. For example, the Vitest console would output `Cannot read properties of undefined (reading 'removeEventListener')` for `this.tabGroup`. By adding the optional chaining, removeEventListener is not called if there is no `tabGroup`

## Related issue
N/A