### PR TITLE
fix(canary-web-components): skip adding slotted column placeholders when the slotted column already has data

### DIFF
--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -1505,7 +1505,12 @@ export class DataTable {
           ({ key }, index) =>
             isSlotUsed(this.el, `${key}-${rowIndex}`) && { key, index }
         )
-        .filter((col) => !!col);
+        .filter(
+          (col) =>
+            !!col &&
+            // skip the column if its already in the row
+            !Object.prototype.hasOwnProperty.call(row, col.key)
+        );
       return slottedColumns.length > 0
         ? addDataToPosition(row, slottedColumns, "")
         : row;

--- a/packages/canary-web-components/src/utils/helpers.ts
+++ b/packages/canary-web-components/src/utils/helpers.ts
@@ -664,15 +664,18 @@ export const addDataToPosition = (
 ): IcDataTableDataType => {
   const newData: IcDataTableDataType = {};
   const newIndexes = newKeys.map((key) => key.index);
-  let controlledIndex = 0; // When a new key is added to the data, need to increment the index to account for this new object value
 
-  Object.keys(dataObject).forEach((dataKey) => {
-    if (newIndexes.includes(controlledIndex)) {
-      newData[newKeys[newIndexes.indexOf(controlledIndex)].key] = newValue;
-      controlledIndex++;
+  const keys = Object.keys(dataObject);
+  const values = Object.values(dataObject);
+  const numberOfKeys = keys.length + newIndexes.length;
+
+  for (let i = 0, j = 0; i < numberOfKeys; i++) {
+    if (newIndexes.includes(i)) {
+      newData[newKeys[newIndexes.indexOf(i)].key] = newValue;
+      continue;
     }
-    newData[dataKey] = dataObject[dataKey];
-    controlledIndex++;
-  });
+    newData[keys[j]] = values[j];
+    j++;
+  }
   return newData;
 };


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

There were a number of issues with how columns were laid out before with slotting this corrects them

~To take out of draft I want to take a look at:~
- [x] I think this may still be broken if data is not provided in the cells - fixed

I have tried to create a unit test for the helper but jest is only configured for a11y on this project and looks to be a pain to setup, I can try if deemed needed


## Related issue
fixes #2743

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added.
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues.
- [x] Manual screen reader testing performed using NVDA and VoiceOver.
- [x] Manual keyboard testing for keyboard controls and logical focus order.
- [x] Correct roles used and ARIA attributes used correctly where required.
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure.

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content.
- [x] Screen magnifier used with no issues.
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow.
- [x] All prop combinations work without issue.
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.