### PR TITLE
2140 text field renders ic input validation element in the html when validationstatus is set to an empty string

### DIFF
--- a/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
@@ -36,6 +36,7 @@ import {
   TextFieldWithMinMaxCharacters,
   TextFieldWithMinMaxValue,
   TextFieldWithValidation,
+  TextFieldWithEmptyValidation,
   TextFieldWithinForm,
   Controlled,
   Uncontrolled,
@@ -46,6 +47,7 @@ import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
 const IC_TEXTFIELD = "ic-text-field";
 const TEXTFIELD_INPUT = 'input[type="text"]';
 const DEFAULT_TEST_THRESHOLD = 0.03;
+const IC_VALIDATION = "ic-input-validation";
 
 describe("IcTextField end-to-end tests", () => {
   beforeEach(() => {
@@ -251,6 +253,12 @@ describe("IcTextField end-to-end tests", () => {
       .find('[id$="validation-text"]')
       .should(CONTAIN_TEXT, "Minimum value of 1 not met");
     cy.findShadowEl(IC_TEXTFIELD, ".icon-error").should(BE_VISIBLE);
+  });
+
+  it("should not render validation", () => {
+    mount(<TextFieldWithEmptyValidation />);
+
+    cy.get(IC_VALIDATION).should(NOT_EXIST);
   });
 
   it("should not be able to input text string when input type is set as number", () => {

--- a/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
@@ -305,6 +305,22 @@ export const TextFieldWithInlineValidation = (): ReactElement => (
   </div>
 );
 
+export const TextFieldWithEmptyValidation = (): ReactElement => (
+  <div style={style}>
+    <IcTextField
+      maxLength={25}
+      value="Arabica"
+      label="What is your favourite coffee?"
+      required
+      placeholder="Please enter…"
+      helperText="Such as Arabica, Robusta or Liberica"
+      validationStatus=""
+      validationText=""
+      validationInline
+    ></IcTextField>
+  </div>
+);
+
 export const ReadonlyTextField = (): ReactElement => (
   <div style={style}>
     <IcTextField

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
@@ -1027,7 +1027,7 @@ export const defaultArgs = {
 
 <Canvas>
   <Story
-    name="playground"
+    name="Playground"
     parameters={{ loki: { skip: true } }}
     args={defaultArgs}
     argTypes={{

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
@@ -1016,3 +1016,36 @@ import readme from "./readme.md";
     }
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  validationStatus: "error",
+  validationText: "Text",
+  validationInline: false,
+};
+
+<Canvas>
+  <Story
+    name="playground"
+    parameters={{ loki: { skip: true } }}
+    args={defaultArgs}
+    argTypes={{
+      validationInline: { control: { type: "boolean" } },
+    }}
+  >
+    {(args) =>
+      html`<ic-text-field
+        label="What is your favourite coffee?"
+        helper-text="Short answers only."
+        validation-status=${args.validationStatus}
+        validation-text=${args.validationText}
+        validation-inline=${args.validationInline}
+        value="Arabica"
+        required
+        placeholder="Placeholder"
+      >
+      </ic-text-field> `
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -466,12 +466,6 @@ export class TextField {
       maxNumChars > 0 ||
       this.maxCharactersError ||
       this.minCharactersUnattained;
-    console.log(
-      emptyString,
-      valueOutsideRange,
-      charOutsideRange,
-      this.validationInline
-    );
     return (
       (!emptyString || valueOutsideRange || charOutsideRange) &&
       !(this.validationInline && this.validationStatus === "success")

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -456,6 +456,28 @@ export class TextField {
     }
   };
 
+  private showValidation = (): boolean => {
+    const maxNumChars = this.readonly ? 0 : this.maxLength;
+    const emptyString =
+      isEmptyString(this.validationStatus) ||
+      isEmptyString(this.validationText);
+    const valueOutsideRange = this.minValueUnattained || this.maxValueExceeded;
+    const charOutsideRange =
+      maxNumChars > 0 ||
+      this.maxCharactersError ||
+      this.minCharactersUnattained;
+    console.log(
+      emptyString,
+      valueOutsideRange,
+      charOutsideRange,
+      this.validationInline
+    );
+    return (
+      (!emptyString || valueOutsideRange || charOutsideRange) &&
+      !(this.validationInline && this.validationStatus === "success")
+    );
+  };
+
   render() {
     const {
       inputId,
@@ -492,6 +514,7 @@ export class TextField {
       fullWidth,
       truncateValue,
       hiddenInput,
+      showValidation,
     } = this;
 
     const disabledMode = readonly || disabled;
@@ -664,53 +687,46 @@ export class TextField {
             )}
           </ic-input-component-container>
           {isSlotUsed(this.el, "menu") && <slot name="menu"></slot>}
-          {(!isEmptyString(validationStatus) ||
-            !isEmptyString(validationText) ||
-            maxNumChars > 0 ||
-            maxValueExceeded ||
-            maxCharactersError ||
-            minCharactersUnattained ||
-            minValueUnattained) &&
-            !validationInlineInternal && (
-              <ic-input-validation
-                status={
-                  this.hasStatus(currentStatus) === false ||
-                  (currentStatus === IcInformationStatus.Success &&
-                    validationInline) ||
-                  validationInlineInternal
-                    ? ""
-                    : currentStatus
-                }
-                message={showStatusText ? currentValidationText : ""}
-                ariaLiveMode={messageAriaLive}
-                for={inputId}
-                fullWidth={fullWidth}
-              >
-                {!readonly && maxNumChars > 0 && (
-                  <div slot="validation-message-adornment">
-                    <ic-typography
-                      variant="caption"
-                      class={{
-                        ["maxlengthtext"]: true,
-                        ["error"]: maxLengthExceeded,
-                        ["disabled"]: disabledText,
-                      }}
+          {showValidation() && (
+            <ic-input-validation
+              status={
+                this.hasStatus(currentStatus) === false ||
+                (currentStatus === IcInformationStatus.Success &&
+                  validationInline) ||
+                validationInlineInternal
+                  ? ""
+                  : currentStatus
+              }
+              message={showStatusText ? currentValidationText : ""}
+              ariaLiveMode={messageAriaLive}
+              for={inputId}
+              fullWidth={fullWidth}
+            >
+              {!readonly && maxNumChars > 0 && (
+                <div slot="validation-message-adornment">
+                  <ic-typography
+                    variant="caption"
+                    class={{
+                      ["maxlengthtext"]: true,
+                      ["error"]: maxLengthExceeded,
+                      ["disabled"]: disabledText,
+                    }}
+                  >
+                    <span
+                      aria-live="polite"
+                      id={`${inputId}-charcount`}
+                      class="charcount"
                     >
-                      <span
-                        aria-live="polite"
-                        id={`${inputId}-charcount`}
-                        class="charcount"
-                      >
-                        {numChars}/{maxNumChars}
-                      </span>
-                      <span hidden={true} id={hiddenCharCountDescId}>
-                        Field can contain a maximum of {maxNumChars} characters.
-                      </span>
-                    </ic-typography>
-                  </div>
-                )}
-              </ic-input-validation>
-            )}
+                      {numChars}/{maxNumChars}
+                    </span>
+                    <span hidden={true} id={hiddenCharCountDescId}>
+                      Field can contain a maximum of {maxNumChars} characters.
+                    </span>
+                  </ic-typography>
+                </div>
+              )}
+            </ic-input-validation>
+          )}
         </ic-input-container>
       </Host>
     );


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
When ic-validation status is empty, ic-validation does not render anymore

## Related issue
fix #2140 
## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [ ] All acceptance criteria reviewed and met. 

### Testing

- [ ] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [ ] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] All prop combinations work without issue. 
- [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [ ] Controlled and uncontrolled input components tested.
- [ ] Props/slots can be updated after initial render.