### PR TITLE
fix(web-components): select bugfix

### DIFF
--- a/packages/react/src/component-tests/IcSelect/IcSelect.cy.tsx
+++ b/packages/react/src/component-tests/IcSelect/IcSelect.cy.tsx
@@ -1573,6 +1573,19 @@ describe("IcSelect end-to-end, visual regression and a11y tests", () => {
       .should(HAVE_LENGTH, "12");
   });
 
+  it("should bring focus back to the input when 'no results' is selected", () => {
+    mount(<IcSelect label="What is your favourite coffee?" options={[]} />);
+
+    cy.checkHydrated(IC_SELECT);
+    cy.get(IC_SELECT).should(HAVE_CLASS, "hydrated");
+    cy.clickOnShadowEl(IC_SELECT, IC_INPUT_CONTAINER);
+    cy.findShadowEl(IC_SELECT, IC_MENU_LI).should(BE_VISIBLE);
+    cy.realPress("{enter}");
+    cy.findShadowEl(IC_SELECT, IC_MENU_LI).should(NOT_BE_VISIBLE);
+    cy.get(IC_SELECT).should(HAVE_FOCUS);
+    cy.get(".ic-input").should(HAVE_VALUE, "");
+  });
+
   it("should render as an uncontrolled component", () => {
     mount(<UncontrolledSelect />);
 

--- a/packages/react/src/stories/ic-select_(single).stories.mdx
+++ b/packages/react/src/stories/ic-select_(single).stories.mdx
@@ -629,11 +629,15 @@ export const Uncontrolled = () => {
         options: ["inherit", "light", "dark"],
         control: { type: "inline-radio" },
       },
+      options: {
+        defaultValue: true,
+        control: { type: "boolean" },
+      }
     }}
   >
     {(args) => (
       <IcSelect
-        options={playgroundOptions}
+        options={args.options ? playgroundOptions : []}
         disabled={args.disabled}
         fullWidth={args.fullWidth}
         helperText={args.helperText}

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -625,8 +625,10 @@ export class Select {
   private handleCustomSelectChange = (event: CustomEvent): void => {
     const value = event.detail.value;
 
-    if (this.searchable && event.detail.label === this.emptyOptionListText) {
-      this.searchableSelectElement.focus();
+    if (event.detail.label === this.emptyOptionListText) {
+      if (this.searchable) {
+        this.searchableSelectElement.focus();
+      }
       return;
     }
 


### PR DESCRIPTION
when no options available the 'no options found' item cannot be selected

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Can't have `cursor event` and `pointer` CSS changes on the same element, so I created a `<span>` to wrap the li option on a different layer, only when options not available, not when 'retry' is available.

## Related issue
#2390 