### PR TITLE
2140 text field renders ic input validation element in the html when validationstatus is set to an empty string

### DIFF
--- a/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
@@ -36,6 +36,7 @@ import {
   TextFieldWithMinMaxCharacters,
   TextFieldWithMinMaxValue,
   TextFieldWithValidation,
+  TextFieldWithEmptyValidation,
   TextFieldWithinForm,
   Controlled,
   Uncontrolled,
@@ -46,6 +47,7 @@ import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
 const IC_TEXTFIELD = "ic-text-field";
 const TEXTFIELD_INPUT = 'input[type="text"]';
 const DEFAULT_TEST_THRESHOLD = 0.03;
+const IC_VALIDATION = "ic-input-validation";
 
 describe("IcTextField end-to-end tests", () => {
   beforeEach(() => {
@@ -251,6 +253,12 @@ describe("IcTextField end-to-end tests", () => {
       .find('[id$="validation-text"]')
       .should(CONTAIN_TEXT, "Minimum value of 1 not met");
     cy.findShadowEl(IC_TEXTFIELD, ".icon-error").should(BE_VISIBLE);
+  });
+
+  it("should not render validation", () => {
+    mount(<TextFieldWithEmptyValidation />);
+
+    cy.findShadowEl(IC_TEXTFIELD, IC_VALIDATION).should(NOT_EXIST);
   });
 
   it("should not be able to input text string when input type is set as number", () => {

--- a/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
@@ -305,6 +305,16 @@ export const TextFieldWithInlineValidation = (): ReactElement => (
   </div>
 );
 
+export const TextFieldWithEmptyValidation = (): ReactElement => (
+  <div style={style}>
+    <IcTextField
+      label="What is your favourite coffee?"
+      validationStatus=""
+      validationText=""
+    ></IcTextField>
+  </div>
+);
+
 export const ReadonlyTextField = (): ReactElement => (
   <div style={style}>
     <IcTextField

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.stories.mdx
@@ -1016,3 +1016,130 @@ import readme from "./readme.md";
     }
   </Story>
 </Canvas>
+
+### Playground
+
+export const defaultArgs = {
+  disabled: false,
+  fullWidth: false,
+  helperText: "",
+  hideLabel: false,
+  inputId: "ic-text-field-input-0",
+  inputmode: "text",
+  label: "Text Field",
+  maxCharacters: 0,
+  maxLength: 0,
+  maxLengthMessage: "Too many characters",
+  minCharacters: 0,
+  name: "0",
+  placeholder: "",
+  readonly: false,
+  required: false,
+  resize: false,
+  rows: 1,
+  size: "default",
+  spellcheck: false,
+  type: "text",
+  validationInline: false,
+  validationStatus: "none",
+  validationText: "",
+  debounce: 0,
+};
+
+<Canvas>
+  <Story
+    name="Playground"
+    parameters={{ loki: { skip: true } }}
+    args={defaultArgs}
+    argTypes={{
+      inputmode: {
+        options: [
+          "none",
+          "text",
+          "tel",
+          "url",
+          "email",
+          "numeric",
+          "decimal",
+          "search",
+        ],
+        control: { type: "select" },
+      },
+      size: {
+        options: ["default", "small"],
+        control: { type: "inline-radio" },
+      },
+      type: {
+        options: [
+          "email",
+          "password",
+          "tel",
+          "text",
+          "url",
+          "number",
+          "search",
+        ],
+        control: { type: "select" },
+      },
+      validationStatus: {
+        options: ["warning", "error", "success", "none"],
+        mapping: {
+          warning: "warning",
+          error: "error",
+          success: "success",
+          none: "",
+        },
+        control: { type: "select" },
+      },
+      showIconSlot: {
+        control: { type: "boolean" },
+      },
+    }}
+  >
+    {(args) =>
+      html`<ic-text-field
+        label=${args.label}
+        disabled=${args.disabled}
+        full-width=${args.fullWidth}
+        helper-text=${args.helperText}
+        hide-label=${args.hideLabel}
+        input-id=${args.inputId}
+        inputmode=${args.inputmode}
+        max=${args.max}
+        max-characters=${args.maxCharacters}
+        max-length=${args.maxLength}
+        max-length-message=${args.maxLengthMessage}
+        min=${args.min}
+        min-characters=${args.minCharacters}
+        name=${args.name}
+        placeholder=${args.placeholder}
+        readonly=${args.readonly}
+        required=${args.required}
+        resize=${args.resize}
+        rows=${args.rows}
+        size=${args.size}
+        spellcheck=${args.spellcheck}
+        type=${args.type}
+        validation-status=${args.validationStatus}
+        validation-text=${args.validationText}
+        validation-inline=${args.validationInline}
+        debounce=${args.debounce}
+      >
+        {${args.showIconSlot} && (
+        <SlottedSVG
+          slot="icon"
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0z" fill="none" />
+          <path
+            d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+          />
+        </SlottedSVG>
+      </ic-text-field> `
+    }
+  </Story>
+</Canvas>

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -456,6 +456,22 @@ export class TextField {
     }
   };
 
+  private showValidation = (): boolean => {
+    const maxNumChars = this.readonly ? 0 : this.maxLength;
+    const emptyString =
+      isEmptyString(this.validationStatus) ||
+      isEmptyString(this.validationText);
+    const valueOutsideRange = this.minValueUnattained || this.maxValueExceeded;
+    const charOutsideRange =
+      maxNumChars > 0 ||
+      this.maxCharactersError ||
+      this.minCharactersUnattained;
+    return (
+      (!emptyString || valueOutsideRange || charOutsideRange) &&
+      !this.validationInlineInternal
+    );
+  };
+
   render() {
     const {
       inputId,
@@ -492,6 +508,7 @@ export class TextField {
       fullWidth,
       truncateValue,
       hiddenInput,
+      showValidation,
     } = this;
 
     const disabledMode = readonly || disabled;
@@ -664,53 +681,46 @@ export class TextField {
             )}
           </ic-input-component-container>
           {isSlotUsed(this.el, "menu") && <slot name="menu"></slot>}
-          {(!isEmptyString(validationStatus) ||
-            !isEmptyString(validationText) ||
-            maxNumChars > 0 ||
-            maxValueExceeded ||
-            maxCharactersError ||
-            minCharactersUnattained ||
-            minValueUnattained) &&
-            !validationInlineInternal && (
-              <ic-input-validation
-                status={
-                  this.hasStatus(currentStatus) === false ||
-                  (currentStatus === IcInformationStatus.Success &&
-                    validationInline) ||
-                  validationInlineInternal
-                    ? ""
-                    : currentStatus
-                }
-                message={showStatusText ? currentValidationText : ""}
-                ariaLiveMode={messageAriaLive}
-                for={inputId}
-                fullWidth={fullWidth}
-              >
-                {!readonly && maxNumChars > 0 && (
-                  <div slot="validation-message-adornment">
-                    <ic-typography
-                      variant="caption"
-                      class={{
-                        ["maxlengthtext"]: true,
-                        ["error"]: maxLengthExceeded,
-                        ["disabled"]: disabledText,
-                      }}
+          {showValidation() && (
+            <ic-input-validation
+              status={
+                this.hasStatus(currentStatus) === false ||
+                (currentStatus === IcInformationStatus.Success &&
+                  validationInline) ||
+                validationInlineInternal
+                  ? ""
+                  : currentStatus
+              }
+              message={showStatusText ? currentValidationText : ""}
+              ariaLiveMode={messageAriaLive}
+              for={inputId}
+              fullWidth={fullWidth}
+            >
+              {!readonly && maxNumChars > 0 && (
+                <div slot="validation-message-adornment">
+                  <ic-typography
+                    variant="caption"
+                    class={{
+                      ["maxlengthtext"]: true,
+                      ["error"]: maxLengthExceeded,
+                      ["disabled"]: disabledText,
+                    }}
+                  >
+                    <span
+                      aria-live="polite"
+                      id={`${inputId}-charcount`}
+                      class="charcount"
                     >
-                      <span
-                        aria-live="polite"
-                        id={`${inputId}-charcount`}
-                        class="charcount"
-                      >
-                        {numChars}/{maxNumChars}
-                      </span>
-                      <span hidden={true} id={hiddenCharCountDescId}>
-                        Field can contain a maximum of {maxNumChars} characters.
-                      </span>
-                    </ic-typography>
-                  </div>
-                )}
-              </ic-input-validation>
-            )}
+                      {numChars}/{maxNumChars}
+                    </span>
+                    <span hidden={true} id={hiddenCharCountDescId}>
+                      Field can contain a maximum of {maxNumChars} characters.
+                    </span>
+                  </ic-typography>
+                </div>
+              )}
+            </ic-input-validation>
+          )}
         </ic-input-container>
       </Host>
     );


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
When validation status is set to an empty string,  ic-input-validation no longer renders

## Related issue
#2140 
## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.