### PR TITLE
2934 add elements to end of cells in icdatatable

### DIFF
--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
@@ -39,6 +39,7 @@ import {
   textWrapCell,
   textWrapColumns,
   textWrapRow,
+  ACTION_DATA_ELEMENTS,
 } from "@ukic/canary-web-components/src/components/ic-data-table/story-data";
 
 import {
@@ -1070,6 +1071,69 @@ describe("IcDataTables", () => {
       sorted: "descending",
     });
   });
+});
+
+it("should render an element in the table cell if the data prop contains the actionElement key", () => {
+  mount(
+    <IcDataTable
+      columns={COLS}
+      data={ACTION_DATA_ELEMENTS}
+      caption="Data tables"
+    ></IcDataTable>
+  );
+  cy.viewport(1024, 768);
+
+  cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+  cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+    .eq(0)
+    .find("span")
+    .should(HAVE_CLASS, "action-element")
+    .find("ic-button")
+    .should("be.visible");
+});
+
+it("should not render an element in the table cell if the data prop does not contain the actionElement key", () => {
+  mount(
+    <IcDataTable
+      columns={COLS}
+      data={ACTION_DATA_ELEMENTS}
+      caption="Data tables"
+    ></IcDataTable>
+  );
+  cy.viewport(1024, 768);
+
+  cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+  cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+    .eq(1)
+    .find("span")
+    .should("not.exist");
+});
+
+it("should apply styling to the cell container if an action element is present in the cell", () => {
+  mount(
+    <IcDataTable
+      columns={COLS}
+      data={ACTION_DATA_ELEMENTS}
+      caption="Data tables"
+    ></IcDataTable>
+  );
+
+  cy.viewport(1024, 768);
+
+  cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+  cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+    .eq(0)
+    .find("div")
+    .eq(0)
+    .should(HAVE_CLASS, "cell-grid-wrapper")
+    .should(HAVE_CSS, "grid-template-columns", "156.797px 32px");
+
+  cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
+    .should(HAVE_CLASS, "action-element")
+    .should(HAVE_CSS, "justify-content", "right");
 });
 
 describe("IcDataTables with IcPaginationBar", () => {

--- a/packages/canary-react/src/stories/ic-data-table.stories.mdx
+++ b/packages/canary-react/src/stories/ic-data-table.stories.mdx
@@ -27,7 +27,8 @@ import {
   ICON_COLS,
   COLUMNS_TEXT_WRAP,
   TEXT_WRAP_LONG_DATA,
-  COLS_WIDTH
+  COLS_WIDTH,
+  ACTION_DATA_ELEMENTS
 } from "../../../canary-web-components/src/components/ic-data-table/story-data";
 
 import { mdiAccountGroup, mdiImage, mdiDelete } from "@mdi/js";
@@ -2075,6 +2076,58 @@ const DataTable = () => {
     />
   );
 };
+```
+
+### Action Element
+
+An example with action elements passed in via the data
+
+<Canvas withSource="none">
+  <Story name="Action Element">
+    <IcDataTable caption="Action Element" columns={COLS} data={ACTION_DATA_ELEMENTS} />
+  </Story>
+</Canvas>
+
+#### Action Element code example
+
+```jsx
+import * as React from "react";
+import { IcDataTable } from "@ukic/canary-react";
+import { IcDataTableColumnObject } from "@ukic/canary-web-components";
+
+const COLS: IcDataTableColumnObject[] = [
+  { key: "firstName", title: "First name", dataType: "string", columnWidth: "15%" },
+  { key: "lastName", title: "Last name", dataType: "string", columnWidth: "300px" },
+  { 
+    key: "age", 
+    title: "Age", 
+    dataType: "number",
+    columnWidth: {
+      maxWidth: "100px",
+    },
+  },
+  ...
+];
+
+const DATA = [
+  {
+    firstName: {
+      data: "Joe",
+      actionElement: `<ic-button variant="icon" size="small  aria-label="you can disable tooltips on icon buttons">  <svg  aria-label="refresh button"  xmlns="http://www.w3.org/2000/svg"    width="24"    height="24"    viewBox="0 0 24 24"    fill="#000000"  >    <path d="M0 0h24v24H0V0z" fill="none"></path>    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>  </svg></ic-button>`,
+    },
+    lastName: "Bloggs",
+    age: 30,
+    jobTitle: "Developer",
+    address: "1 Main Street, Town, County, Postcode",
+  },
+  ...
+];
+
+const DataTable = () => (
+  <IcDataTable caption="Action Element" columns={COLS} data={DATA} />
+);
+
+export default DataTable;
 ```
 
 ### Playground example

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.css
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.css
@@ -374,6 +374,16 @@ td.table-density-spacious {
   width: 100%;
 }
 
+.action-element {
+  display: flex;
+  justify-content: right;
+}
+
+.cell-grid-wrapper {
+  display: grid;
+  grid-template-columns: auto auto;
+}
+
 @media screen and (min-width: 577px) {
   .column-header-inner-container {
     display: flex;

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.mdx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.mdx
@@ -36,6 +36,7 @@ import {
   UpdatingData,
   SlottedPagination,
   LargeDataSet,
+  ActionElement,
   DevArea,
 } from "./story-data";
 import readme from "./readme.md";
@@ -1643,6 +1644,16 @@ To set the min and max width of a table cell, set the `table-layout` attribute t
   dataTable.data = data;
 </script>
 ```
+
+### Action Element
+
+The example below demonstrates action elements appearing in table cells after being passed in via the data.
+
+<Canvas withSource="none">
+  <Story name="Action Element" parameters={{ loki: { skip: true } }}>
+    {ActionElement()}
+  </Story>
+</Canvas>
 
 #### Development Area
 

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -393,6 +393,7 @@ export class DataTable {
 
   componentDidRender(): void {
     this.fixCellTooltips();
+    this.adjustWidthForActionElement();
   }
 
   private runHeaderResizeObserver = () => {
@@ -1228,6 +1229,126 @@ export class DataTable {
     return {};
   };
 
+  private adjustWidthForActionElement = () => {
+    const elements = this.el.shadowRoot.querySelectorAll(".action-element");
+    elements.forEach((element) => {
+      const width = (element.firstChild as HTMLElement).getBoundingClientRect()
+        .width;
+      const gridWrapper: HTMLElement = element.closest(".cell-grid-wrapper");
+      gridWrapper.style.gridTemplateColumns = `auto calc(${width}px + var(--ic-space-xs))`;
+    });
+  };
+
+  private createCellContent = (
+    columnProps: IcDataTableColumnObject,
+    cell: any,
+    cellSlotName: string,
+    rowOptions: any,
+    rowAlignment: string,
+    hasIcon: boolean,
+    currentRowHeight: number,
+    cellValue: (key: string) => any,
+    rowEmphasis: string
+  ) => (
+    <div
+      innerHTML={
+        columnProps?.dataType === "element" &&
+        !isSlotUsed(this.el, cellSlotName)
+          ? (cell as string)
+          : null
+      }
+      class={{
+        "cell-container": columnProps?.dataType !== "element",
+        [`cell-alignment-${
+          columnProps?.columnAlignment?.vertical ||
+          rowOptions?.rowAlignment?.vertical ||
+          rowAlignment ||
+          this.getCellAlignment(cell, "vertical")
+        }`]:
+          !!columnProps?.columnAlignment?.vertical ||
+          !!rowOptions?.rowAlignment?.vertical ||
+          !!rowAlignment ||
+          !!this.getCellAlignment(cell, "vertical"),
+        [`cell-alignment-${
+          columnProps?.columnAlignment?.horizontal ||
+          rowOptions?.rowAlignment?.horizontal ||
+          this.getCellAlignment(cell, "horizontal")
+        }`]:
+          !!columnProps?.columnAlignment?.horizontal ||
+          !!rowOptions?.rowAlignment?.horizontal ||
+          !!this.getCellAlignment(cell, "horizontal"),
+        [`data-type-${columnProps?.dataType}`]: true,
+        [this.TEXT_WRAP_STRING]:
+          columnProps?.textWrap ||
+          rowOptions?.textWrap ||
+          !!this.getCellOptions(cell, "textWrap"),
+        ["cell-icon"]: hasIcon || !!columnProps?.icon?.icon,
+        ...this.setTruncationClass(),
+      }}
+      style={{
+        ...this.getRowHeight(
+          currentRowHeight,
+          columnProps,
+          rowOptions?.textWrap,
+          cell
+        ),
+        ...this.getColumnWidth(columnProps?.columnWidth),
+      }}
+      data-row-height={
+        this.truncationPattern || currentRowHeight
+          ? this.setRowHeight(currentRowHeight)
+          : null
+      }
+    >
+      {isSlotUsed(this.el, cellSlotName) ? (
+        <slot name={cellSlotName} />
+      ) : (
+        <Fragment>
+          {isSlotUsed(this.el, `${cellSlotName}-icon`) ? (
+            <slot name={`${cellSlotName}-icon`} />
+          ) : (
+            (hasIcon || columnProps?.icon?.onAllCells) &&
+            (cellValue("icon") || columnProps?.icon?.icon) && (
+              <span
+                class="icon"
+                innerHTML={cellValue("icon") || columnProps?.icon?.icon}
+              ></span>
+            )
+          )}
+          {columnProps?.dataType !== "element" &&
+            !isSlotUsed(this.el, cellSlotName) && (
+              <ic-typography
+                variant="body"
+                class={{
+                  [`cell-emphasis-${
+                    (this.isObject(cell) && cellValue("emphasis")) ||
+                    columnProps?.emphasis ||
+                    rowEmphasis
+                  }`]:
+                    (this.isObject(cell) && !!cellValue("emphasis")) ||
+                    !!columnProps?.emphasis ||
+                    !!rowEmphasis,
+                  [`text-${this.density}`]: this.notDefaultDensity(),
+                }}
+              >
+                {this.isObject(cell) && columnProps?.dataType !== "date" ? (
+                  Object.keys(cell).includes("href") ? (
+                    <ic-link href={cellValue("href")}>
+                      {cellValue("data")}
+                    </ic-link>
+                  ) : (
+                    cellValue("data")
+                  )
+                ) : (
+                  this.getCellContent(cell, columnProps?.dataType)
+                )}
+              </ic-typography>
+            )}
+        </Fragment>
+      )}
+    </div>
+  );
+
   private createCells = (row: IcDataTableDataType, rowIndex: number) => {
     const rowValues = Object.values(row);
     const rowKeys = Object.keys(row);
@@ -1286,104 +1407,37 @@ export class DataTable {
             }}
             style={{ ...this.getColumnWidth(columnProps.columnWidth) }}
           >
-            <div
-              innerHTML={
-                columnProps?.dataType === "element" &&
-                !isSlotUsed(this.el, cellSlotName)
-                  ? (cell as string)
-                  : null
-              }
-              class={{
-                "cell-container": columnProps?.dataType !== "element",
-                [`cell-alignment-${
-                  columnProps?.columnAlignment?.vertical ||
-                  rowOptions?.rowAlignment?.vertical ||
-                  rowAlignment ||
-                  this.getCellAlignment(cell, "vertical")
-                }`]:
-                  !!columnProps?.columnAlignment?.vertical ||
-                  !!rowOptions?.rowAlignment?.vertical ||
-                  !!rowAlignment ||
-                  !!this.getCellAlignment(cell, "vertical"),
-                [`cell-alignment-${
-                  columnProps?.columnAlignment?.horizontal ||
-                  rowOptions?.rowAlignment?.horizontal ||
-                  this.getCellAlignment(cell, "horizontal")
-                }`]:
-                  !!columnProps?.columnAlignment?.horizontal ||
-                  !!rowOptions?.rowAlignment?.horizontal ||
-                  !!this.getCellAlignment(cell, "horizontal"),
-                [`data-type-${columnProps?.dataType}`]: true,
-                [this.TEXT_WRAP_STRING]:
-                  columnProps?.textWrap ||
-                  rowOptions?.textWrap ||
-                  !!this.getCellOptions(cell, "textWrap"),
-                ["cell-icon"]: hasIcon || !!columnProps?.icon?.icon,
-                ...this.setTruncationClass(),
-              }}
-              style={{
-                ...this.getRowHeight(
-                  currentRowHeight,
+            {Object.keys(cell).includes("actionElement") ? (
+              <div class="cell-grid-wrapper">
+                {this.createCellContent(
                   columnProps,
-                  rowOptions?.textWrap,
-                  cell
-                ),
-                ...this.getColumnWidth(columnProps?.columnWidth),
-              }}
-              data-row-height={
-                this.truncationPattern || currentRowHeight
-                  ? this.setRowHeight(currentRowHeight)
-                  : null
-              }
-            >
-              {isSlotUsed(this.el, cellSlotName) ? (
-                <slot name={cellSlotName} />
-              ) : (
-                <Fragment>
-                  {isSlotUsed(this.el, `${cellSlotName}-icon`) ? (
-                    <slot name={`${cellSlotName}-icon`} />
-                  ) : (
-                    (hasIcon || columnProps?.icon?.onAllCells) &&
-                    (cellValue("icon") || columnProps?.icon?.icon) && (
-                      <span
-                        class="icon"
-                        innerHTML={cellValue("icon") || columnProps?.icon?.icon}
-                      ></span>
-                    )
-                  )}
-                  {columnProps?.dataType !== "element" &&
-                    !isSlotUsed(this.el, cellSlotName) && (
-                      <ic-typography
-                        variant="body"
-                        class={{
-                          [`cell-emphasis-${
-                            (this.isObject(cell) && cellValue("emphasis")) ||
-                            columnProps?.emphasis ||
-                            rowEmphasis
-                          }`]:
-                            (this.isObject(cell) && !!cellValue("emphasis")) ||
-                            !!columnProps?.emphasis ||
-                            !!rowEmphasis,
-                          [`text-${this.density}`]: this.notDefaultDensity(),
-                        }}
-                      >
-                        {this.isObject(cell) &&
-                        columnProps?.dataType !== "date" ? (
-                          Object.keys(cell).includes("href") ? (
-                            <ic-link href={cellValue("href")}>
-                              {cellValue("data")}
-                            </ic-link>
-                          ) : (
-                            cellValue("data")
-                          )
-                        ) : (
-                          this.getCellContent(cell, columnProps?.dataType)
-                        )}
-                      </ic-typography>
-                    )}
-                </Fragment>
-              )}
-            </div>
+                  cell,
+                  cellSlotName,
+                  rowOptions,
+                  rowAlignment,
+                  hasIcon,
+                  currentRowHeight,
+                  cellValue,
+                  rowEmphasis
+                )}
+                <span
+                  class="action-element"
+                  innerHTML={cellValue("actionElement")}
+                ></span>
+              </div>
+            ) : (
+              this.createCellContent(
+                columnProps,
+                cell,
+                cellSlotName,
+                rowOptions,
+                rowAlignment,
+                hasIcon,
+                currentRowHeight,
+                cellValue,
+                rowEmphasis
+              )
+            )}
           </td>
         );
       }

--- a/packages/canary-web-components/src/components/ic-data-table/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/story-data.ts
@@ -960,6 +960,56 @@ export const DATA_REACT_ELEMENTS_WITH_ICONS = [
   },
 ];
 
+export const ACTION_DATA_ELEMENTS = [
+  {
+    firstName: {
+      data: "Joe",
+      actionElement: `<ic-button variant="icon" size="small  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="refresh button" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#000000"> <path d="M0 0h24v24H0V0z" fill="none"></path> <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path> </svg></ic-button>`,
+    },
+    lastName: "Bloggs",
+    age: 31,
+    jobTitle: "Developer",
+    address: "1 Main Street, Town, County, Postcode",
+  },
+  {
+    firstName: "Sarah",
+    lastName: "Jane",
+    age: 28,
+    jobTitle: {
+      data: "Senior Software Developer, Site Reliability Engineering",
+      actionElement: `<ic-status-tag role="status" label="Success" status="success"></ic-status-tag>`,
+    },
+    address: "2 Main Street, Town, Country, Postcode",
+  },
+  {
+    firstName: "Mark",
+    lastName: "Smith",
+    age: {
+      data: 45,
+      actionElement: `<ic-button variant="icon" id="small-button" size="small aria-label="you can disable tooltips on icon buttons"> <svg aria-label="refresh button" xmlns="http://www.w3.org/2000/svg"    width="24"    height="24"    viewBox="0 0 24 24"    fill="#000000"  >    <path d="M0 0h24v24H0V0z" fill="none"></path>    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>  </svg></ic-button>`,
+    },
+    jobTitle: "Team Lead",
+    address: "12 Key Street, Town, Country, Postcode",
+  },
+  {
+    firstName: "Naomi",
+    lastName: "Kens",
+    age: 32,
+    jobTitle: "Analyst",
+    address: "8 Side Street, Town, Country, Postcode",
+  },
+  {
+    firstName: "Luke",
+    lastName: "Sky",
+    age: 18,
+    jobTitle: "Junior Developer",
+    address: {
+      data: "5 New Street, Town, Country, Postcode",
+      actionElement: `<ic-status-tag role="status" label="Error" status="danger"></ic-status-tag>`,
+    },
+  },
+];
+
 export const createDataTableElement = (
   caption: string,
   columns: IcDataTableColumnObject[] = COLS,
@@ -1416,6 +1466,9 @@ export const SlottedPagination = (): HTMLIcDataTableElement => {
   dataTable.appendChild(paginationBar);
   return dataTable;
 };
+
+export const ActionElement = (): HTMLElement =>
+  createDataTableElement("Action Element", COLS, ACTION_DATA_ELEMENTS);
 
 export const DevArea = (): HTMLElement => {
   const dataTable = createDataTableElement(

--- a/packages/canary-web-components/src/components/ic-data-table/test/basic/__snapshots__/ic-data-table.spec.tsx.snap
+++ b/packages/canary-web-components/src/components/ic-data-table/test/basic/__snapshots__/ic-data-table.spec.tsx.snap
@@ -2747,6 +2747,222 @@ exports[`ic-data-table should render a slotted icon instead of an icon defined i
 </ic-data-table>
 `;
 
+exports[`ic-data-table should render an action element if present in the data set 1`] = `
+<ic-data-table>
+  <mock:shadow-root>
+    <div class="table-container">
+      <div class="table-row-container">
+        <table style="--table-layout: fixed;">
+          <caption class="table-caption">
+            test table
+          </caption>
+          <thead>
+            <tr>
+              <th class="column-header" scope="col">
+                <div class="column-header-inner-container">
+                  <ic-typography class="column-header-text" variant="body">
+                    Name
+                  </ic-typography>
+                </div>
+              </th>
+              <th class="column-header" scope="col">
+                <div class="column-header-inner-container">
+                  <ic-typography class="column-header-text" variant="body">
+                    Age
+                  </ic-typography>
+                </div>
+              </th>
+              <th class="column-header" scope="col">
+                <div class="column-header-inner-container">
+                  <ic-typography class="column-header-text" variant="body">
+                    Department
+                  </ic-typography>
+                </div>
+              </th>
+              <th class="column-header" scope="col">
+                <div class="column-header-inner-container">
+                  <ic-typography class="column-header-text" variant="body">
+                    Employee number
+                  </ic-typography>
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="table-row">
+              <th class="row-header" scope="row">
+                1
+              </th>
+              <td class="table-cell">
+                <div class="cell-grid-wrapper" style="grid-template-columns: auto calc(0px + var(--ic-space-xs));">
+                  <div class="cell-container data-type-number">
+                    <ic-typography variant="body">
+                      John Smith
+                    </ic-typography>
+                  </div>
+                  <span class="action-element">
+                    <ic-button aria-label="you can disable tooltips on icon buttons" disable-tooltip="true" size="small" variant="icon">
+                      <svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M0 0h24v24H0V0z" fill="none"></path>
+                        <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
+                      </svg>
+                    </ic-button>
+                  </span>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-string">
+                  <ic-typography variant="body">
+                    36
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Accounts
+                  </ic-typography>
+                </div>
+              </td>
+            </tr>
+            <tr class="table-row">
+              <th class="row-header" scope="row">
+                2
+              </th>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Sally Jones
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-string">
+                  <ic-typography variant="body">
+                    32
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Engineering
+                  </ic-typography>
+                </div>
+              </td>
+            </tr>
+            <tr class="table-row">
+              <th class="row-header" scope="row">
+                3
+              </th>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Tim Rayes
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-string">
+                  <ic-typography variant="body">
+                    41
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Sales
+                  </ic-typography>
+                </div>
+              </td>
+            </tr>
+            <tr class="table-row">
+              <th class="row-header" scope="row">
+                4
+              </th>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Luke Fisher
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-string">
+                  <ic-typography variant="body">
+                    23
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Engineering
+                  </ic-typography>
+                </div>
+              </td>
+            </tr>
+            <tr class="table-row">
+              <th class="row-header" scope="row">
+                5
+              </th>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Jane Lock
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-string">
+                  <ic-typography variant="body">
+                    34
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Engineering
+                  </ic-typography>
+                </div>
+              </td>
+            </tr>
+            <tr class="table-row">
+              <th class="row-header" scope="row">
+                6
+              </th>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    Margaret Hale
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-string">
+                  <ic-typography variant="body">
+                    45
+                  </ic-typography>
+                </div>
+              </td>
+              <td class="table-cell">
+                <div class="cell-container data-type-number">
+                  <ic-typography variant="body">
+                    HR
+                  </ic-typography>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </mock:shadow-root>
+</ic-data-table>
+`;
+
 exports[`ic-data-table should render column icon on all column cells if onAllCells is true, except ones that already have a custom icon 1`] = `
 <ic-data-table>
   <mock:shadow-root>

--- a/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
@@ -369,6 +369,38 @@ const dataWithIcons = [
   { name: name5, age: 45, department: "HR", employeeNumber: 6 },
 ];
 
+const dataWithActionElement = [
+  {
+    header: { title: 1 },
+    name: {
+      data: name1,
+      actionElement: `<ic-button size="small" variant="icon"  aria-label="you can disable tooltips on icon buttons"  disable-tooltip="true">  <svg    xmlns="http://www.w3.org/2000/svg"    width="24"    height="24"    viewBox="0 0 24 24"    fill="#000000"  >    <path d="M0 0h24v24H0V0z" fill="none"></path>    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>  </svg></ic-button>`,
+    },
+    age: 36,
+    department: "Accounts",
+  },
+  {
+    header: { title: 2 },
+    name: name2,
+    age: 32,
+    department: "Engineering",
+  },
+  { header: { title: 3 }, name: "Tim Rayes", age: 41, department: "Sales" },
+  {
+    header: { title: 4 },
+    name: name3,
+    age: "23",
+    department: "Engineering",
+  },
+  {
+    header: { title: 5 },
+    name: name4,
+    age: 34,
+    department: "Engineering",
+  },
+  { header: { title: 6 }, name: name5, age: 45, department: "HR" },
+];
+
 describe(icDataTable, () => {
   it("should render", async () => {
     const page = await newSpecPage({
@@ -1318,6 +1350,21 @@ describe(icDataTable, () => {
             </ic-button>
           ))}
         </ic-data-table>
+      ),
+    });
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it("should render an action element if present in the data set", async () => {
+    const page = await newSpecPage({
+      components: [DataTable],
+      template: () => (
+        <ic-data-table
+          caption="test table"
+          columns={columns}
+          data={dataWithActionElement}
+        ></ic-data-table>
       ),
     });
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added action-element to ICDataTable cells that can be passed in through the data.

The action-element can be any HTMLElement, so a lot of the checklist would seem to not be applicable. Happy to help with any issues that arise and listen to any comments.

Storybook:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/663fe918-cdac-40f4-a3e9-2856d6cb96ff" />

## Related issue
#2847
2934

## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.