### PR TITLE
feat(web-components): ensure screen-reader-only text is hidden for RTL languages

### DIFF
--- a/packages/web-components/src/components/ic-badge/ic-badge.css
+++ b/packages/web-components/src/components/ic-badge/ic-badge.css
@@ -158,6 +158,10 @@
   left: -9999px;
 }
 
+.sr-only:dir(rtl) {
+  right: -9999px;
+}
+
 @keyframes expand {
   from {
     opacity: 0;

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.css
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.css
@@ -39,3 +39,7 @@ ic-input-validation {
   color: #000;
   text-transform: none;
 }
+
+.screen-reader-only-text:dir(rtl) {
+  right: -9999px;
+}

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.css
@@ -56,6 +56,10 @@
   text-transform: none;
 }
 
+.offscreen:dir(rtl) {
+  right: -9999px;
+}
+
 @media (forced-colors: active) {
   .classification-banner {
     border: var(--ic-hc-border);

--- a/packages/web-components/src/components/ic-pagination/ic-pagination.css
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.css
@@ -46,3 +46,7 @@ ic-button.first-last {
   position: absolute;
   left: -9999px;
 }
+
+.sr-only:dir(rtl) {
+  right: -9999px;
+}

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.css
@@ -209,6 +209,10 @@ slot[name="app-title"]::slotted(a) {
     transition: opacity var(--ic-easing-transition-slow);
   }
 
+  :host(.sm-collapsed) slot[name="app-title"]:dir(rtl)::slotted(a) {
+    right: -9999px;
+  }
+
   :host(.sm-expanded) slot[name="app-title"]::slotted(a) {
     font: var(--ic-font-h3) !important;
     font-weight: var(--ic-font-weight-semibold) !important;
@@ -471,6 +475,10 @@ slot[name="app-title"]::slotted(a) {
   left: -9999px;
   opacity: 0;
   transition: opacity var(--ic-easing-transition-slow);
+}
+
+:host(.sm-collapsed.side-display) .app-title-wrapper ic-typography:dir(rtl) {
+  right: -9999px;
 }
 
 :host(.sm-expanded.side-display) ic-typography {

--- a/packages/web-components/src/components/ic-step/ic-step.css
+++ b/packages/web-components/src/components/ic-step/ic-step.css
@@ -23,11 +23,15 @@
 
 .visually-hidden {
   position: absolute;
-  left: -625rem;
+  left: -9999px;
   top: auto;
   width: 1px;
   height: 1px;
   overflow: hidden;
+}
+
+.visually-hidden:dir(rtl) {
+  right: -9999px;
 }
 
 /* COMPACT STEP STYLING */

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -155,11 +155,15 @@ slot[name="toggle-icon"] svg {
 
 .menu-button-container .navigation-landmark-button-text {
   position: absolute;
-  left: -10000px;
+  left: -9999px;
   top: auto;
   width: 1px;
   height: 1px;
   overflow: hidden;
+}
+
+.menu-button-container .navigation-landmark-button-text:dir(rtl) {
+  right: -9999px;
 }
 
 .search-actions-container {


### PR DESCRIPTION
## Summary of the changes

When using RTL languages, elements using `left: -9999px` and roughly equivalent styles will cause a large scrollable but blank region to appear on the left of the screen. By using the `:dir` pseudo-class it is possible to instead shift these elements to be `right: -9999px` which the browser will hide when `<html dir="rtl">` in the same way as it does for elements to the left when `<html dir="ltr">`.

This change also standardises on using -9999px from the start of the page as the offscreen position to make it easier to locate occurrences of this pattern with search. I also found -10000px and -625rem but these are roughly or exactly equivalent.

There is a question as to whether this is the correct change, or if the correct change is to have just one class that can be applied to these elements. Seeing multiple classes defined as:

* .sr-only
* .screen-reader-only-text
* .offscreen
* .visually-hidden

feels redundant to me. The technique is also applied directly to component-specific classes instead of defining the styles just once for the technique and re-using that class where it is needed.

## Related issue

Closes: #2906

## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [ ] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [ ] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] All prop combinations work without issue. 
- [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [ ] Controlled and uncontrolled input components tested.
- [ ] Props/slots can be updated after initial render.