### PR TITLE
2629 cherry pick

### DIFF
--- a/packages/canary-web-components/src/components/ic-card-horizontal/ic-card-horizontal.tsx
+++ b/packages/canary-web-components/src/components/ic-card-horizontal/ic-card-horizontal.tsx
@@ -8,6 +8,7 @@ import {
   Method,
   forceUpdate,
   Host,
+  Watch,
 } from "@stencil/core";
 import {
   onComponentRequiredPropUndefined,
@@ -55,6 +56,10 @@ export class Card {
    * If `true`, the horizontal card will be disabled if it is clickable.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The heading for the horizontal card. This is required, unless a slotted heading is used.

--- a/packages/canary-web-components/src/components/ic-card-horizontal/test/basic/__snapshots__/ic-card-horizontal.spec.ts.snap
+++ b/packages/canary-web-components/src/components/ic-card-horizontal/test/basic/__snapshots__/ic-card-horizontal.spec.ts.snap
@@ -81,6 +81,60 @@ exports[`ic-card-horizontal should render as a link 1`] = `
 </ic-card-horizontal>
 `;
 
+exports[`ic-card-horizontal should render disabled 1`] = `
+<ic-card-horizontal clickable="" disabled="" heading="Card" message="This is a static card">
+  <mock:shadow-root>
+    <button aria-disabled="true" class="card disabled medium" disabled="" tabindex="0">
+      <div class="card-content">
+        <div class="card-header">
+          <div class="card-title">
+            <slot name="heading">
+              <ic-typography variant="h4">
+                <p>
+                  Card
+                </p>
+              </ic-typography>
+            </slot>
+          </div>
+        </div>
+        <div class="card-message">
+          <ic-typography variant="body">
+            This is a static card
+          </ic-typography>
+        </div>
+      </div>
+    </button>
+  </mock:shadow-root>
+</ic-card-horizontal>
+`;
+
+exports[`ic-card-horizontal should render disabled: disabled-removed 1`] = `
+<ic-card-horizontal clickable="" heading="Card" message="This is a static card">
+  <mock:shadow-root>
+    <button class="card clickable medium" tabindex="0">
+      <div class="card-content">
+        <div class="card-header">
+          <div class="card-title">
+            <slot name="heading">
+              <ic-typography variant="h4">
+                <p>
+                  Card
+                </p>
+              </ic-typography>
+            </slot>
+          </div>
+        </div>
+        <div class="card-message">
+          <ic-typography variant="body">
+            This is a static card
+          </ic-typography>
+        </div>
+      </div>
+    </button>
+  </mock:shadow-root>
+</ic-card-horizontal>
+`;
+
 exports[`ic-card-horizontal should render extra large 1`] = `
 <ic-card-horizontal heading="Card" message="This is a static card" size="extra large">
   <mock:shadow-root>

--- a/packages/canary-web-components/src/components/ic-card-horizontal/test/basic/ic-card-horizontal.spec.ts
+++ b/packages/canary-web-components/src/components/ic-card-horizontal/test/basic/ic-card-horizontal.spec.ts
@@ -66,6 +66,20 @@ describe("ic-card-horizontal", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should render disabled", async () => {
+    const page = await newSpecPage({
+      components: [Card],
+      html: `<ic-card-horizontal heading="Card" message="This is a static card" disabled clickable></ic-card-horizontal>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
+  });
+
   it("should apply 'focussed' style when parent is focussed", async () => {
     const page = await newSpecPage({
       components: [Card],

--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.tsx
@@ -34,6 +34,7 @@ import {
   isEmptyString,
   isNumeric,
   onComponentRequiredPropUndefined,
+  removeDisabledFalse,
   removeFormResetListener,
   renderHiddenInput,
   stringEnumToArray,
@@ -119,6 +120,10 @@ export class DateInput {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The days of the week to disable.
@@ -332,6 +337,7 @@ export class DateInput {
     this.selectedDateInfoId = `${this.inputId}-selected-date-info`;
 
     addFormResetListener(this.el, this.handleFormReset);
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/canary-web-components/src/components/ic-date-picker/ic-date-picker.tsx
+++ b/packages/canary-web-components/src/components/ic-date-picker/ic-date-picker.tsx
@@ -24,6 +24,7 @@ import {
 import {
   stringEnumToArray,
   onComponentRequiredPropUndefined,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import {
   IcWeekDays,
@@ -138,6 +139,10 @@ export class DatePicker {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The days of the week to disable.
@@ -425,6 +430,7 @@ export class DatePicker {
     this.watchStartOfWeekHandler();
     this.watchMaxHandler();
     this.watchMinHandler();
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentWillRender(): void {

--- a/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
@@ -17,6 +17,7 @@ import {
   isSlotUsed,
   onComponentRequiredPropUndefined,
   checkSlotInChildMutations,
+  removeDisabledFalse,
 } from "../../utils/helpers";
 import arrowDropdown from "../../assets/arrow-dropdown.svg";
 
@@ -48,6 +49,10 @@ export class TreeItem {
    * If `true`, the tree item appears in the disabled state.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * If `true`, the tree item appears in the expanded state.
@@ -133,6 +138,10 @@ export class TreeItem {
 
   disconnectedCallback(): void {
     this.hostMutationObserver?.disconnect();
+  }
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/canary-web-components/src/components/ic-tree-item/test/basic/__snapshots__/ic-tree-item.spec.ts.snap
+++ b/packages/canary-web-components/src/components/ic-tree-item/test/basic/__snapshots__/ic-tree-item.spec.ts.snap
@@ -13,9 +13,21 @@ exports[`ic-tree-item component should render 1`] = `
 `;
 
 exports[`ic-tree-item component should render disabled 1`] = `
-<ic-tree-item aria-disabled="true" class="ic-tree-item-dark ic-tree-item-disabled" disabled="true" id="ic-tree-item-6" label="Item 1">
+<ic-tree-item class="ic-tree-item-dark ic-tree-item-disabled" disabled="true" id="ic-tree-item-0" label="Item 1">
   <mock:shadow-root>
-    <div class="ic-tree-item-single tree-item-content" tabindex="-1">
+    <div aria-disabled="true" aria-live="polite" class="tree-item-content" tabindex="-1">
+      <ic-typography class="tree-item-label">
+        Item 1
+      </ic-typography>
+    </div>
+  </mock:shadow-root>
+</ic-tree-item>
+`;
+
+exports[`ic-tree-item component should render disabled: disabled-removed 1`] = `
+<ic-tree-item class="ic-tree-item-dark" id="ic-tree-item-0" label="Item 1">
+  <mock:shadow-root>
+    <div aria-disabled="false" aria-live="polite" class="tree-item-content" tabindex="0">
       <ic-typography class="tree-item-label">
         Item 1
       </ic-typography>

--- a/packages/canary-web-components/src/components/ic-tree-item/test/basic/ic-tree-item.spec.ts
+++ b/packages/canary-web-components/src/components/ic-tree-item/test/basic/ic-tree-item.spec.ts
@@ -65,6 +65,11 @@ describe("ic-tree-item component", () => {
     });
 
     expect(page.root).toMatchSnapshot();
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render selected", async () => {

--- a/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
+++ b/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
@@ -9,7 +9,7 @@ import {
   Watch,
   Method,
 } from "@stencil/core";
-import { isSlotUsed } from "../../utils/helpers";
+import { isSlotUsed, removeDisabledFalse } from "../../utils/helpers";
 import chevronIcon from "../../assets/chevron-icon.svg";
 import { IcSizes, IcThemeMode } from "../../utils/types";
 
@@ -37,6 +37,10 @@ export class Accordion {
    * If `true`, the accordion will be disabled.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * If `true`, the accordion appears expanded.
@@ -82,6 +86,10 @@ export class Accordion {
     if (this.accordionBtnHeading) {
       this.accordionBtnHeading.focus();
     }
+  }
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   disconnectedCallback(): void {

--- a/packages/web-components/src/components/ic-accordion/test/basic/__snapshots__/ic-accordion.spec.ts.snap
+++ b/packages/web-components/src/components/ic-accordion/test/basic/__snapshots__/ic-accordion.spec.ts.snap
@@ -144,6 +144,29 @@ exports[`ic-accordion snapshots should render in a disabled state: disabled 1`] 
 </ic-accordion>
 `;
 
+exports[`ic-accordion snapshots should render in a disabled state: disabled-removed 1`] = `
+<ic-accordion aria-disabled="false" heading="Accordion 1" id="ic-accordion-7">
+  <mock:shadow-root>
+    <button aria-controls="expanded-content-area" aria-expanded="false" class="medium section-button" id="ic-accordion-7-button" tabindex="0">
+      <ic-typography class="section-header" variant="subtitle-large">
+        Accordion 1
+      </ic-typography>
+      <span aria-hidden="true" class="expand-chevron">
+        svg
+      </span>
+    </button>
+    <div aria-hidden="true" aria-labelledby="ic-accordion-7-button" class="expanded-content" id="expanded-content-area" role="region">
+      <div class="expanded-content-inner">
+        <slot></slot>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <ic-typography variant="body">
+    This is an example of the main body text.
+  </ic-typography>
+</ic-accordion>
+`;
+
 exports[`ic-accordion snapshots should render with a heading slot when supplied: renders with heading slot 1`] = `
 <ic-accordion aria-disabled="false" id="ic-accordion-6">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-accordion/test/basic/ic-accordion.spec.ts
+++ b/packages/web-components/src/components/ic-accordion/test/basic/ic-accordion.spec.ts
@@ -116,6 +116,11 @@ describe("ic-accordion snapshots", () => {
       </ic-accordion>`,
     });
     expect(page.root).toMatchSnapshot("disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   describe("ic-accordion component", () => {

--- a/packages/web-components/src/components/ic-card-vertical/ic-card-vertical.tsx
+++ b/packages/web-components/src/components/ic-card-vertical/ic-card-vertical.tsx
@@ -8,6 +8,7 @@ import {
   Method,
   forceUpdate,
   Host,
+  Watch,
 } from "@stencil/core";
 import {
   onComponentRequiredPropUndefined,
@@ -62,6 +63,10 @@ export class CardVertical {
    * If `true`, the card will be disabled if it is clickable.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    *  If `true`, the card will have an expandable area and expansion toggle button.

--- a/packages/web-components/src/components/ic-card-vertical/test/basic/__snapshots__/ic-card-vertical.spec.ts.snap
+++ b/packages/web-components/src/components/ic-card-vertical/test/basic/__snapshots__/ic-card-vertical.spec.ts.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ic-card-vertical should correctly remove disabled attribute when setting disabled to false: disabled 1`] = `
+<ic-card-vertical clickable="true" disabled="" heading="Card" message="This is a full width card">
+  <mock:shadow-root>
+    <button aria-disabled="true" class="card disabled" disabled="" tabindex="0">
+      <div class="card-header">
+        <div class="card-title">
+          <slot name="heading">
+            <ic-typography variant="h4">
+              <p>
+                Card
+              </p>
+            </ic-typography>
+          </slot>
+        </div>
+      </div>
+      <div class="card-message">
+        <ic-typography variant="body">
+          This is a full width card
+        </ic-typography>
+      </div>
+    </button>
+  </mock:shadow-root>
+</ic-card-vertical>
+`;
+
+exports[`ic-card-vertical should correctly remove disabled attribute when setting disabled to false: disabled-removed 1`] = `
+<ic-card-vertical clickable="true" heading="Card" message="This is a full width card">
+  <mock:shadow-root>
+    <button class="card clickable" tabindex="0">
+      <div class="card-header">
+        <div class="card-title">
+          <slot name="heading">
+            <ic-typography variant="h4">
+              <p>
+                Card
+              </p>
+            </ic-typography>
+          </slot>
+        </div>
+      </div>
+      <div class="card-message">
+        <ic-typography variant="body">
+          This is a full width card
+        </ic-typography>
+      </div>
+    </button>
+  </mock:shadow-root>
+</ic-card-vertical>
+`;
+
 exports[`ic-card-vertical should render 1`] = `
 <ic-card-vertical heading="Card" message="This is a static card">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-card-vertical/test/basic/ic-card-vertical.spec.ts
+++ b/packages/web-components/src/components/ic-card-vertical/test/basic/ic-card-vertical.spec.ts
@@ -47,6 +47,20 @@ describe("ic-card-vertical", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should correctly remove disabled attribute when setting disabled to false", async () => {
+    const page = await newSpecPage({
+      components: [CardVertical],
+      html: `<ic-card-vertical heading="Card" disabled message="This is a full width card" clickable=true></ic-card-vertical>`,
+    });
+
+    expect(page.root).toMatchSnapshot("disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
+  });
+
   it("should apply 'focussed' style when parent is focussed", async () => {
     const page = await newSpecPage({
       components: [CardVertical],

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.tsx
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.tsx
@@ -36,6 +36,10 @@ export class CheckboxGroup {
    * If `true`, the checkbox group will be set to the disabled state.
    */
   @Prop() disabled: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The helper text that will be displayed for additional field guidance.

--- a/packages/web-components/src/components/ic-checkbox-group/test/basic/__snapshots__/ic-checkbox-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-checkbox-group/test/basic/__snapshots__/ic-checkbox-group.spec.ts.snap
@@ -271,6 +271,33 @@ exports[`ic-checkbox-group should render checked: renders-checked 1`] = `
 </ic-checkbox-group>
 `;
 
+exports[`ic-checkbox-group should render in a disabled state: disabled-removed 1`] = `
+<ic-checkbox-group class="ic-checkbox-group-medium" label="test label" name="test">
+  <mock:shadow-root>
+    <fieldset aria-labelledby="" id="test">
+      <legend>
+        <ic-input-label helpertext="" label="test label"></ic-input-label>
+      </legend>
+      <div class="checkboxes-container">
+        <slot></slot>
+      </div>
+    </fieldset>
+  </mock:shadow-root>
+  <ic-checkbox additional-field-display="static" class="ic-checkbox-medium" label="test label" value="test">
+    <mock:shadow-root>
+      <div class="container">
+        <input class="checkbox" id="ic-checkbox-test-label-test-label" name="test" role="checkbox" type="checkbox" value="test">
+        <ic-typography class="checkbox-label" variant="body">
+          <label htmlfor="ic-checkbox-test-label-test-label">
+            test label
+          </label>
+        </ic-typography>
+      </div>
+    </mock:shadow-root>
+  </ic-checkbox>
+</ic-checkbox-group>
+`;
+
 exports[`ic-checkbox-group should render in a disabled state: renders-disabled 1`] = `
 <ic-checkbox-group class="ic-checkbox-group-medium" label="test label" name="test">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-checkbox-group/test/basic/ic-checkbox-group.spec.ts
+++ b/packages/web-components/src/components/ic-checkbox-group/test/basic/ic-checkbox-group.spec.ts
@@ -99,6 +99,11 @@ describe("ic-checkbox-group", () => {
     });
 
     expect(page.root).toMatchSnapshot("renders-disabled");
+
+    document.querySelector("ic-checkbox").disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render with validation status", async () => {

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -58,6 +58,10 @@ export class Checkbox {
    * If `true`, the checkbox will be set to the disabled state.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The text to be displayed when dynamic.

--- a/packages/web-components/src/components/ic-chip/ic-chip.tsx
+++ b/packages/web-components/src/components/ic-chip/ic-chip.tsx
@@ -56,6 +56,10 @@ export class Chip {
    * If `true`, the chip will appear disabled.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * If `true`, the chip will have a close button at the end to dismiss it.

--- a/packages/web-components/src/components/ic-chip/test/basic/__snapshots__/ic-chip.spec.ts.snap
+++ b/packages/web-components/src/components/ic-chip/test/basic/__snapshots__/ic-chip.spec.ts.snap
@@ -25,6 +25,31 @@ exports[`ic-chip component renders label should render disabled 1`] = `
 </ic-chip>
 `;
 
+exports[`ic-chip component renders label should render disabled: disabled-removed 1`] = `
+<ic-chip dismissible="true" label="Label">
+  <mock:shadow-root>
+    <div class="chip dismissible filled medium">
+      <div class="icon">
+        <slot name="icon"></slot>
+      </div>
+      <ic-typography class="label" variant="label">
+        <span>
+          Label
+        </span>
+      </ic-typography>
+      <ic-tooltip label="Dismiss" target="dismiss-icon">
+        <button aria-label="Dismiss Label chip" class="dismiss-icon" id="dismiss-icon" tabindex="0">
+          svg
+        </button>
+      </ic-tooltip>
+    </div>
+  </mock:shadow-root>
+  <svg fill="none" height="20" slot="icon" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM10 3C11.66 3 13 4.34 13 6C13 7.66 11.66 9 10 9C8.34 9 7 7.66 7 6C7 4.34 8.34 3 10 3ZM10 17.2C7.5 17.2 5.29 15.92 4 13.98C4.03 11.99 8 10.9 10 10.9C11.99 10.9 15.97 11.99 16 13.98C14.71 15.92 12.5 17.2 10 17.2Z" fill="currentColor"></path>
+  </svg>
+</ic-chip>
+`;
+
 exports[`ic-chip component renders label should render dismissible 1`] = `
 <ic-chip dismissible="true" label="Label">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-chip/test/basic/ic-chip.spec.ts
+++ b/packages/web-components/src/components/ic-chip/test/basic/ic-chip.spec.ts
@@ -40,6 +40,11 @@ describe("ic-chip component renders label", () => {
     });
 
     expect(page.root).toMatchSnapshot();
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render small", async () => {

--- a/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.tsx
+++ b/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.tsx
@@ -1,4 +1,12 @@
-import { Component, Element, Host, Prop, forceUpdate, h } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Host,
+  Prop,
+  Watch,
+  forceUpdate,
+  h,
+} from "@stencil/core";
 
 import {
   IcInformationStatus,
@@ -6,7 +14,11 @@ import {
   IcSizes,
 } from "../../utils/types";
 import successIcon from "../../assets/success-icon.svg";
-import { checkSlotInChildMutations, slotHasContent } from "../../utils/helpers";
+import {
+  checkSlotInChildMutations,
+  removeDisabledFalse,
+  slotHasContent,
+} from "../../utils/helpers";
 
 /**
  * @slot left-icon - Content will be placed to the left of the input.
@@ -23,6 +35,10 @@ export class InputComponentContainer {
    *  If `true`, the disabled state will be set.
    */
   @Prop() disabled: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    *  If `true`, the input component container will fill the width of the container it is in.
@@ -53,6 +69,10 @@ export class InputComponentContainer {
    * The validation status of the input component container - e.g. 'error' | 'warning' | 'success'.
    */
   @Prop() validationStatus: IcInformationStatusOrEmpty = "";
+
+  componentWillLoad(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   componentDidLoad(): void {
     this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
@@ -93,7 +113,7 @@ export class InputComponentContainer {
           "ic-input-component-container-multiline": multiLine,
           "ic-input-component-container-full-width": fullWidth,
         }}
-        aria-disabled={disabled && `${disabled}`}
+        aria-disabled={disabled ? "true" : null}
       >
         <div class="focus-indicator">
           {slotHasContent(this.el, "left-icon") && (

--- a/packages/web-components/src/components/ic-input-component-container/test/basic/ic-input-component-container.spec.tsx
+++ b/packages/web-components/src/components/ic-input-component-container/test/basic/ic-input-component-container.spec.tsx
@@ -108,6 +108,17 @@ describe("ic-input-component-container", () => {
       </div>
     </ic-input-component-container>
     `);
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <ic-input-component-container class="ic-input-component-container-medium ic-input-component-container-success" validation-status="success">
+        <div class="focus-indicator">
+          content
+        </div>
+      </ic-input-component-container>
+      `);
   });
 
   it("should render readonly", async () => {

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -7,6 +7,7 @@ import {
   Event,
   EventEmitter,
   Listen,
+  Watch,
 } from "@stencil/core";
 import {
   isSlotUsed,
@@ -46,6 +47,10 @@ export class MenuItem {
    * If `true`, the menu item will be in disabled state.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The URL that the link points to. This will render the menu item as an "a" tag.

--- a/packages/web-components/src/components/ic-menu-item/test/basic/__snapshots__/ic-menu-item.spec.ts.snap
+++ b/packages/web-components/src/components/ic-menu-item/test/basic/__snapshots__/ic-menu-item.spec.ts.snap
@@ -63,6 +63,46 @@ exports[`menu item variants should render the destructive variant 1`] = `
 </ic-menu-item>
 `;
 
+exports[`menu item variants should render the disabled variant 1`] = `
+<ic-menu-item class="ic-menu-item-disabled" disabled="" label="Default variant" variant="default">
+  <mock:shadow-root>
+    <li aria-disabled="true" role="menuitem">
+      <ic-button aria-disabled="true" aria-label="Default variant" fullwidth="" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Default variant
+              </ic-typography>
+            </div>
+          </div>
+        </div>
+      </ic-button>
+    </li>
+  </mock:shadow-root>
+</ic-menu-item>
+`;
+
+exports[`menu item variants should render the disabled variant: disabled-removed 1`] = `
+<ic-menu-item label="Default variant" variant="default">
+  <mock:shadow-root>
+    <li aria-disabled="false" role="menuitem">
+      <ic-button aria-disabled="false" aria-label="Default variant" fullwidth="" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Default variant
+              </ic-typography>
+            </div>
+          </div>
+        </div>
+      </ic-button>
+    </li>
+  </mock:shadow-root>
+</ic-menu-item>
+`;
+
 exports[`menu item variants should render the toggle variant 1`] = `
 <ic-menu-item id="test-menu-item" label="Toggle variant" variant="toggle">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-menu-item/test/basic/ic-menu-item.spec.ts
+++ b/packages/web-components/src/components/ic-menu-item/test/basic/ic-menu-item.spec.ts
@@ -14,6 +14,23 @@ describe("menu item variants", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should render the disabled variant", async () => {
+    const page = await newSpecPage({
+      components: [MenuItem],
+      html: `<ic-menu-item
+            label="Default variant"
+            disabled
+          />`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
+  });
+
   it("should render a menu item with a description", async () => {
     const page = await newSpecPage({
       components: [MenuItem],

--- a/packages/web-components/src/components/ic-pagination-item/ic-pagination-item.tsx
+++ b/packages/web-components/src/components/ic-pagination-item/ic-pagination-item.tsx
@@ -26,6 +26,10 @@ export class PaginationItem {
    * If `true`, the pagination item will be disabled.
    */
   @Prop() disabled: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The label for the pagination item (applicable when simple pagination is being used).

--- a/packages/web-components/src/components/ic-pagination-item/test/basic/__snapshots__/ic-pagination-item.spec.ts.snap
+++ b/packages/web-components/src/components/ic-pagination-item/test/basic/__snapshots__/ic-pagination-item.spec.ts.snap
@@ -54,6 +54,20 @@ exports[`ic-pagination-item should render disabled ellipsis type: render disable
 </ic-pagination-item>
 `;
 
+exports[`ic-pagination-item should render disabled: disabled-removed 1`] = `
+<ic-pagination-item page="1" type="page">
+  <mock:shadow-root>
+    <a>
+      <button aria-label="Go to Page 1" class="item-container page" role="button" tabindex="0">
+        <ic-typography variant="label">
+          1
+        </ic-typography>
+      </button>
+    </a>
+  </mock:shadow-root>
+</ic-pagination-item>
+`;
+
 exports[`ic-pagination-item should render disabled: render disabled 1`] = `
 <ic-pagination-item disabled="" page="1" type="page">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-pagination-item/test/basic/ic-pagination-item.spec.ts
+++ b/packages/web-components/src/components/ic-pagination-item/test/basic/ic-pagination-item.spec.ts
@@ -54,6 +54,11 @@ describe("ic-pagination-item", () => {
     });
 
     expect(page.root).toMatchSnapshot("render disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render as ellipsis type", async () => {

--- a/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
@@ -67,6 +67,10 @@ export class Pagination {
    * If `true`, the pagination will not allow interaction.
    */
   @Prop() disabled: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * If `true`, the current page of the simple pagination will not be displayed.

--- a/packages/web-components/src/components/ic-pagination/test/basic/__snapshots__/ic-pagination.spec.ts.snap
+++ b/packages/web-components/src/components/ic-pagination/test/basic/__snapshots__/ic-pagination.spec.ts.snap
@@ -569,6 +569,50 @@ exports[`ic-pagination simple appearance component should render all pages when 
 </ic-pagination>
 `;
 
+exports[`ic-pagination simple appearance component should render disabled 1`] = `
+<ic-pagination disabled="" pages="10">
+  <mock:shadow-root>
+    <nav aria-label="Pagination Navigation" class="disabled" role="navigation">
+      <ic-button aria-label="Go to first page" class="first-last page-button" disabled="" id="first-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+      <ic-button aria-label="Go to previous page" class="flip next-previous page-button" disabled="" id="previous-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+      <ic-pagination-item disabled="" label="Page" page="1" theme="inherit" type="simple-current"></ic-pagination-item>
+      <ic-button aria-label="Go to next page" class="next-previous page-button" disabled="" id="next-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+      <ic-button aria-label="Go to last page" class="first-last flip page-button" disabled="" id="last-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+    </nav>
+  </mock:shadow-root>
+</ic-pagination>
+`;
+
+exports[`ic-pagination simple appearance component should render disabled: disabled-removed 1`] = `
+<ic-pagination pages="10">
+  <mock:shadow-root>
+    <nav aria-label="Pagination Navigation" role="navigation">
+      <ic-button aria-label="Go to first page" class="first-last page-button" disabled="" id="first-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+      <ic-button aria-label="Go to previous page" class="flip next-previous page-button" disabled="" id="previous-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+      <ic-pagination-item label="Page" page="1" theme="inherit" type="simple-current"></ic-pagination-item>
+      <ic-button aria-label="Go to next page" class="next-previous page-button" id="next-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+      <ic-button aria-label="Go to last page" class="first-last flip page-button" id="last-page-button" theme="inherit" variant="icon-tertiary">
+        svg
+      </ic-button>
+    </nav>
+  </mock:shadow-root>
+</ic-pagination>
+`;
+
 exports[`ic-pagination simple appearance component should render on the last page: render on the last page 1`] = `
 <ic-pagination default-page="15" pages="15">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-pagination/test/basic/ic-pagination.spec.ts
+++ b/packages/web-components/src/components/ic-pagination/test/basic/ic-pagination.spec.ts
@@ -146,6 +146,19 @@ describe("ic-pagination simple appearance component", () => {
 
     expect(pageEl.page).toBe(1);
   });
+  it("should render disabled", async () => {
+    const page = await newSpecPage({
+      components: [Pagination],
+      html: `<ic-pagination pages=10 disabled></ic-pagination>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
+  });
 });
 describe("ic-pagination complex type", () => {
   it("should render as complex type", async () => {

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -56,6 +56,7 @@ export class RadioGroup {
     this.radioOptions.forEach(
       (radioOption) => (radioOption.disabled = newValue)
     );
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   /**

--- a/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
@@ -50,6 +50,33 @@ exports[`ic-radio-group should render as required: renders-required 1`] = `
 </ic-radio-group>
 `;
 
+exports[`ic-radio-group should render radio group disabled: disabled-removed 1`] = `
+<ic-radio-group label="test label" name="test">
+  <mock:shadow-root>
+    <div aria-label="test label" role="radiogroup">
+      <ic-input-label label="test label"></ic-input-label>
+      <div class="radio-buttons-container">
+        <slot></slot>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <ic-radio-option additional-field-display="static" group-label="test group" label="test label" value="test">
+    <!---->
+    <div class="container">
+      <div>
+        <input id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
+      </div>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test label-test label">
+          test label
+        </label>
+      </ic-typography>
+    </div>
+  </ic-radio-option>
+</ic-radio-group>
+`;
+
 exports[`ic-radio-group should render radio group disabled: renders-disabled 1`] = `
 <ic-radio-group disabled="" label="test label" name="test">
   <mock:shadow-root>
@@ -65,6 +92,33 @@ exports[`ic-radio-group should render radio group disabled: renders-disabled 1`]
     <div class="container disabled">
       <div>
         <input disabled="" id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
+        <span class="checkmark"></span>
+      </div>
+      <ic-typography class="radio-label" variant="body">
+        <label htmlfor="ic-radio-option-test label-test label">
+          test label
+        </label>
+      </ic-typography>
+    </div>
+  </ic-radio-option>
+</ic-radio-group>
+`;
+
+exports[`ic-radio-group should render radio option disabled: disabled-removed 1`] = `
+<ic-radio-group label="test label" name="test">
+  <mock:shadow-root>
+    <div aria-label="test label" role="radiogroup">
+      <ic-input-label label="test label"></ic-input-label>
+      <div class="radio-buttons-container">
+        <slot></slot>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <ic-radio-option additional-field-display="static" group-label="test group" label="test label" value="test">
+    <!---->
+    <div class="container">
+      <div>
+        <input id="ic-radio-option-test label-test label" name="test" tabindex="0" type="radio" value="test">
         <span class="checkmark"></span>
       </div>
       <ic-typography class="radio-label" variant="body">

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
@@ -81,6 +81,11 @@ describe("ic-radio-group", () => {
     });
 
     expect(page.root).toMatchSnapshot("renders-disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render radio option disabled", async () => {
@@ -92,6 +97,11 @@ describe("ic-radio-group", () => {
     });
 
     expect(page.root).toMatchSnapshot("renders-option-disabled");
+
+    document.querySelector("ic-radio-option").disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render with unselected static additional field", async () => {

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
@@ -53,6 +53,10 @@ export class RadioOption {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The text to be displayed when dynamic.

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -109,6 +109,10 @@ export class SearchBar {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * Specify whether to disable the built in filtering. For example, if options will already be filtered from external source.

--- a/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
@@ -48,6 +48,55 @@ exports[`ic-search-bar search should render aria-label when hideLabel is set: re
 </ic-search-bar>
 `;
 
+exports[`ic-search-bar search should render disabled variant: disabled-removed 1`] = `
+<ic-search-bar class="ic-search-bar-search" label="Test label" value="">
+  <mock:shadow-root>
+    <ic-text-field value="">
+      <mock:shadow-root>
+        <ic-input-container>
+          <ic-input-label for="ic-search-bar-input-4" helpertext="" label="Test label"></ic-input-label>
+          <ic-input-component-container size="medium" validationstatus="">
+            <input aria-describedby="" aria-invalid="false" aria-label="" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-4" inputmode="search" name="ic-search-bar-input-4" placeholder="Search" type="text" value="">
+            <slot name="clear-button"></slot>
+            <slot name="search-submit-button"></slot>
+          </ic-input-component-container>
+          <slot name="menu"></slot>
+        </ic-input-container>
+      </mock:shadow-root>
+      <div class="clear-button-container" slot="clear-button">
+        <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
+          <mock:shadow-root>
+            <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
+              <button aria-label="Clear" class="button" part="button" type="submit">
+                <slot></slot>
+              </button>
+            </ic-tooltip>
+          </mock:shadow-root>
+          svg
+        </ic-button>
+        <div class="divider"></div>
+      </div>
+      <div class="search-submit-button-container search-submit-button-disabled" slot="search-submit-button">
+        <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
+          <mock:shadow-root>
+            <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
+              <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <slot></slot>
+              </button>
+            </ic-tooltip>
+          </mock:shadow-root>
+          svg
+        </ic-button>
+      </div>
+      <div class="menu-container" slot="menu"></div>
+      <input class="ic-input" name="ic-search-bar-input-4" type="hidden" value="">
+    </ic-text-field>
+    <div aria-live="polite" class="search-results-status" role="status"></div>
+  </mock:shadow-root>
+  <input class="ic-input" name="ic-search-bar-input-4" type="hidden" value="">
+</ic-search-bar>
+`;
+
 exports[`ic-search-bar search should render disabled variant: renders-disabled 1`] = `
 <ic-search-bar class="ic-search-bar-disabled ic-search-bar-search" disabled="true" label="Test label" value="">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-search-bar/test/basic/ic-search-bar.spec.ts
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/ic-search-bar.spec.ts
@@ -75,6 +75,11 @@ describe("ic-search-bar search", () => {
     });
 
     expect(page.root).toMatchSnapshot("renders-disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render readonly variant", async () => {

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -91,6 +91,10 @@ export class Select {
    * If `true`, the disabled state will be set.
    */
   @Prop({ reflect: true }) disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * If `true`, the built in filtering will be disabled for a searchable variant. For example, if options will already be filtered from external source.

--- a/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
@@ -4,12 +4,12 @@ exports[`ic-select multi should not render a native select on a mobile / tablet 
 <ic-select label="IC Select Test" multiple="true">
   <mock:shadow-root>
     <ic-input-container>
-      <ic-input-label for="ic-select-input-70" helpertext="" label="IC Select Test"></ic-input-label>
+      <ic-input-label for="ic-select-input-71" helpertext="" label="IC Select Test"></ic-input-label>
       <ic-input-component-container class="ic-input-component-container-medium">
         <!---->
         <div class="focus-indicator">
           <div class="select-container">
-            <button aria-controls="ic-select-input-70-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-70-menu" class="select-input" id="ic-select-input-70">
+            <button aria-controls="ic-select-input-71-menu" aria-describedby="" aria-expanded="false" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, Select an option" aria-owns="ic-select-input-71-menu" class="select-input" id="ic-select-input-71">
               <ic-typography class="placeholder value-text" variant="body">
                 Select an option
               </ic-typography>
@@ -23,8 +23,8 @@ exports[`ic-select multi should not render a native select on a mobile / tablet 
         </div>
       </ic-input-component-container>
       <ic-menu class="ic-menu-medium ic-menu-multiple no-results">
-        <ul aria-label="IC Select Test pop-up" aria-multiselectable="true" class="menu" id="ic-select-input-70-menu" role="listbox" tabindex="-1">
-          <li aria-disabled="false" aria-label="Test label 1" aria-selected="false" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-70-menu-Test value 1" role="option" tabindex="-1">
+        <ul aria-label="IC Select Test pop-up" aria-multiselectable="true" class="menu" id="ic-select-input-71-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 1" aria-selected="false" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-71-menu-Test value 1" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -33,7 +33,7 @@ exports[`ic-select multi should not render a native select on a mobile / tablet 
               </div>
             </div>
           </li>
-          <li aria-disabled="false" aria-label="Test label 2" aria-selected="false" class="option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-70-menu-Test value 2" role="option" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 2" aria-selected="false" class="option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-71-menu-Test value 2" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -42,7 +42,7 @@ exports[`ic-select multi should not render a native select on a mobile / tablet 
               </div>
             </div>
           </li>
-          <li aria-disabled="false" aria-label="Test label 3" aria-selected="false" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-70-menu-Test value 3" role="option" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 3" aria-selected="false" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-71-menu-Test value 3" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -56,7 +56,7 @@ exports[`ic-select multi should not render a native select on a mobile / tablet 
       <div aria-live="polite" class="multi-select-selected-count" role="status"></div>
     </ic-input-container>
   </mock:shadow-root>
-  <input class="ic-input" name="ic-select-input-70" type="hidden" value="">
+  <input class="ic-input" name="ic-select-input-71" type="hidden" value="">
 </ic-select>
 `;
 
@@ -64,12 +64,12 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
 <ic-select label="IC Select Test" multiple="true">
   <mock:shadow-root>
     <ic-input-container>
-      <ic-input-label for="ic-select-input-73" helpertext="" label="IC Select Test"></ic-input-label>
+      <ic-input-label for="ic-select-input-74" helpertext="" label="IC Select Test"></ic-input-label>
       <ic-input-component-container class="ic-input-component-container-medium menu-open">
         <!---->
         <div class="focus-indicator">
           <div class="select-container">
-            <button aria-controls="ic-select-input-73-menu" aria-describedby="" aria-expanded="true" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, 1 of 3 selected, Test label 1" aria-owns="ic-select-input-73-menu" class="select-input" id="ic-select-input-73">
+            <button aria-controls="ic-select-input-74-menu" aria-describedby="" aria-expanded="true" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, 1 of 3 selected, Test label 1" aria-owns="ic-select-input-74-menu" class="select-input" id="ic-select-input-74">
               <ic-typography class="value-text" variant="body">
                 Test label 1
               </ic-typography>
@@ -83,8 +83,8 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
         </div>
       </ic-input-component-container>
       <ic-menu class="ic-menu-medium ic-menu-multiple ic-menu-open no-results" data-popper-placement="bottom-start" data-popper-reference-hidden open="" style="position: absolute; left: 0; top: 0; margin: 0; right: auto; bottom: auto; transform: translate(0px, 7px);">
-        <ul aria-activedescendant="ic-select-input-73-menu-Test value 1" aria-label="IC Select Test pop-up" aria-multiselectable="true" class="menu" id="ic-select-input-73-menu" role="listbox" tabindex="-1">
-          <li aria-disabled="false" aria-label="Test label 1" aria-selected="true" class="focused-option option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-73-menu-Test value 1" role="option" tabindex="0">
+        <ul aria-activedescendant="ic-select-input-74-menu-Test value 1" aria-label="IC Select Test pop-up" aria-multiselectable="true" class="menu" id="ic-select-input-74-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 1" aria-selected="true" class="focused-option option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-74-menu-Test value 1" role="option" tabindex="0">
             <div class="option-text-container show-check-icon">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -96,7 +96,7 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
               svg
             </span>
           </li>
-          <li aria-disabled="false" aria-label="Test label 2" aria-selected="false" class="option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-73-menu-Test value 2" role="option" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 2" aria-selected="false" class="option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-74-menu-Test value 2" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -105,7 +105,7 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
               </div>
             </div>
           </li>
-          <li aria-disabled="false" aria-label="Test label 3" aria-selected="false" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-73-menu-Test value 3" role="option" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 3" aria-selected="false" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-74-menu-Test value 3" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -121,7 +121,7 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
       </div>
     </ic-input-container>
   </mock:shadow-root>
-  <input class="ic-input" name="ic-select-input-73" type="hidden" value="Test value 1">
+  <input class="ic-input" name="ic-select-input-74" type="hidden" value="Test value 1">
 </ic-select>
 `;
 
@@ -129,12 +129,12 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
 <ic-select label="IC Select Test" multiple="true">
   <mock:shadow-root>
     <ic-input-container>
-      <ic-input-label for="ic-select-input-73" helpertext="" label="IC Select Test"></ic-input-label>
+      <ic-input-label for="ic-select-input-74" helpertext="" label="IC Select Test"></ic-input-label>
       <ic-input-component-container class="ic-input-component-container-medium menu-open">
         <!---->
         <div class="focus-indicator">
           <div class="select-container">
-            <button aria-controls="ic-select-input-73-menu" aria-describedby="" aria-expanded="true" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, 2 of 3 selected, Test label 1, Test label 2" aria-owns="ic-select-input-73-menu" class="select-input" id="ic-select-input-73">
+            <button aria-controls="ic-select-input-74-menu" aria-describedby="" aria-expanded="true" aria-haspopup="listbox" aria-invalid="false" aria-label="IC Select Test, 2 of 3 selected, Test label 1, Test label 2" aria-owns="ic-select-input-74-menu" class="select-input" id="ic-select-input-74">
               <ic-typography class="value-text" variant="body">
                 Test label 1, Test label 2
               </ic-typography>
@@ -148,8 +148,8 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
         </div>
       </ic-input-component-container>
       <ic-menu class="ic-menu-medium ic-menu-multiple ic-menu-open no-results" data-popper-placement="bottom-start" data-popper-reference-hidden open="" style="position: absolute; left: 0; top: 0; margin: 0; right: auto; bottom: auto; transform: translate(0px, 7px);">
-        <ul aria-activedescendant="ic-select-input-73-menu-Test value 2" aria-label="IC Select Test pop-up" aria-multiselectable="true" class="menu" id="ic-select-input-73-menu" role="listbox" tabindex="-1">
-          <li aria-disabled="false" aria-label="Test label 1" aria-selected="true" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-73-menu-Test value 1" role="option" tabindex="0">
+        <ul aria-activedescendant="ic-select-input-74-menu-Test value 2" aria-label="IC Select Test pop-up" aria-multiselectable="true" class="menu" id="ic-select-input-74-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 1" aria-selected="true" class="option" data-label="Test label 1" data-value="Test value 1" id="ic-select-input-74-menu-Test value 1" role="option" tabindex="0">
             <div class="option-text-container show-check-icon">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -161,7 +161,7 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
               svg
             </span>
           </li>
-          <li aria-disabled="false" aria-label="Test label 2" aria-selected="true" class="focused-option option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-73-menu-Test value 2" role="option" tabindex="0">
+          <li aria-disabled="false" aria-label="Test label 2" aria-selected="true" class="focused-option option" data-label="Test label 2" data-value="Test value 2" id="ic-select-input-74-menu-Test value 2" role="option" tabindex="0">
             <div class="option-text-container show-check-icon">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -173,7 +173,7 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
               svg
             </span>
           </li>
-          <li aria-disabled="false" aria-label="Test label 3" aria-selected="false" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-73-menu-Test value 3" role="option" tabindex="-1">
+          <li aria-disabled="false" aria-label="Test label 3" aria-selected="false" class="option" data-label="Test label 3" data-value="Test value 3" id="ic-select-input-74-menu-Test value 3" role="option" tabindex="-1">
             <div class="option-text-container">
               <div class="option-label">
                 <ic-typography aria-hidden="true" variant="body">
@@ -189,7 +189,7 @@ exports[`ic-select multi should test keydown on menu - arrow down, up, and enter
       </div>
     </ic-input-container>
   </mock:shadow-root>
-  <input class="ic-input" name="ic-select-input-73" type="hidden" value="Test value 1,Test value 2">
+  <input class="ic-input" name="ic-select-input-74" type="hidden" value="Test value 1,Test value 2">
 </ic-select>
 `;
 
@@ -287,6 +287,78 @@ exports[`ic-select searchable should render as required: required-searchable 1`]
     </ic-input-container>
   </mock:shadow-root>
   <input class="ic-input" name="ic-select-input-29" type="hidden" value="">
+</ic-select>
+`;
+
+exports[`ic-select searchable should render disabled: disabled-removed 1`] = `
+<ic-select class="ic-select-searchable" label="IC Select Test" searchable="true">
+  <mock:shadow-root>
+    <ic-input-container>
+      <ic-input-label for="ic-select-input-70" helpertext="" label="IC Select Test"></ic-input-label>
+      <ic-input-component-container class="ic-input-component-container-medium">
+        <!---->
+        <div class="focus-indicator">
+          <div class="searchable-select-container">
+            <input aria-autocomplete="list" aria-controls="ic-select-input-70-menu" aria-describedby="" aria-expanded="false" aria-invalid="false" aria-label="IC Select Test" aria-required="false" autocomplete="off" class="select-input" id="ic-select-input-70" placeholder="Select an option" role="combobox">
+            <span aria-hidden="true" class="expand-icon">
+              svg
+            </span>
+            <div aria-live="polite" class="searchable-select-results-status" role="status"></div>
+          </div>
+        </div>
+      </ic-input-component-container>
+      <ic-menu class="ic-menu-medium ic-menu-no-focus no-results">
+        <ul aria-label="IC Select Test pop-up" aria-multiselectable="false" class="menu" id="ic-select-input-70-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" aria-selected="false" class="option" data-label="No results found" data-value id="ic-select-input-70-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  No results found
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
+    </ic-input-container>
+  </mock:shadow-root>
+  <input class="ic-input" name="ic-select-input-70" type="hidden" value="">
+</ic-select>
+`;
+
+exports[`ic-select searchable should render disabled: renders-disabled 1`] = `
+<ic-select class="ic-select-disabled ic-select-searchable" disabled="" label="IC Select Test" searchable="true">
+  <mock:shadow-root>
+    <ic-input-container>
+      <ic-input-label disabled="" for="ic-select-input-70" helpertext="" label="IC Select Test"></ic-input-label>
+      <ic-input-component-container aria-disabled="true" class="ic-input-component-container-disabled ic-input-component-container-medium">
+        <!---->
+        <div class="focus-indicator">
+          <div class="searchable-select-container">
+            <input aria-autocomplete="list" aria-controls="ic-select-input-70-menu" aria-describedby="" aria-expanded="false" aria-invalid="false" aria-label="IC Select Test" aria-required="false" autocomplete="off" class="select-input" disabled="" id="ic-select-input-70" placeholder="Select an option" role="combobox">
+            <span aria-hidden="true" class="expand-icon">
+              svg
+            </span>
+            <div aria-live="polite" class="searchable-select-results-status" role="status"></div>
+          </div>
+        </div>
+      </ic-input-component-container>
+      <ic-menu class="ic-menu-medium no-results">
+        <ul aria-label="IC Select Test pop-up" aria-multiselectable="false" class="menu" id="ic-select-input-70-menu" role="listbox" tabindex="-1">
+          <li aria-disabled="false" aria-label="No results found" aria-selected="false" class="option" data-label="No results found" data-value id="ic-select-input-70-menu-" role="option" tabindex="-1">
+            <div class="option-text-container">
+              <div class="option-label">
+                <ic-typography aria-hidden="true" variant="body">
+                  No results found
+                </ic-typography>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </ic-menu>
+    </ic-input-container>
+  </mock:shadow-root>
+  <input class="ic-input" disabled="" name="ic-select-input-70" type="hidden" value="">
 </ic-select>
 `;
 

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
@@ -1885,6 +1885,20 @@ describe("ic-select searchable", () => {
     await page.waitForChanges();
     expect(page.rootInstance.searchableSelectInputValue).toBeUndefined;
   });
+
+  it("should render disabled", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      html: `<ic-select label="IC Select Test" searchable="true" disabled="true"></ic-select>`,
+    });
+
+    expect(page.root).toMatchSnapshot("renders-disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
+  });
 });
 
 describe("ic-select multi", () => {

--- a/packages/web-components/src/components/ic-switch/ic-switch.tsx
+++ b/packages/web-components/src/components/ic-switch/ic-switch.tsx
@@ -55,6 +55,10 @@ export class Switch {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * The helper text that will be displayed for additional field guidance.

--- a/packages/web-components/src/components/ic-switch/test/basic/__snapshots__/ic-switch.spec.ts.snap
+++ b/packages/web-components/src/components/ic-switch/test/basic/__snapshots__/ic-switch.spec.ts.snap
@@ -44,6 +44,28 @@ exports[`ic-switch component should render checked: renders-checked 1`] = `
 </ic-switch>
 `;
 
+exports[`ic-switch component should render disabled: disabled-removed 1`] = `
+<ic-switch label="Custom title">
+  <mock:shadow-root>
+    <label class="ic-switch-container" htmlfor="ic-switch-input-1">
+      <ic-input-label class="ic-switch-label" for="ic-switch-input-1" helpertext="" label="Custom title" readonly=""></ic-input-label>
+      <span class="ic-switch-line-break"></span>
+      <input aria-checked="false" aria-describedby="" aria-label="Custom title" class="ic-switch-input" id="ic-switch-input-1" name="toggle" role="switch" type="checkbox">
+      <span class="ic-switch-toggle">
+        <svg aria-hidden="true" class="ic-switch-icon" focusable="false" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+          <line class="ic-switch-icon-line" x1="9" x2="9" y1="1" y2="9"></line>
+        </svg>
+        <svg aria-hidden="true" class="ic-switch-icon" focusable="false" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+          <circle class="ic-switch-icon-circle" cx="5" cy="5" fill="none" r="4.445"></circle>
+        </svg>
+      </span>
+      <slot name="right-adornment"></slot>
+    </label>
+  </mock:shadow-root>
+  <input class="ic-input" name="ic-switch-input-1" type="hidden" value="">
+</ic-switch>
+`;
+
 exports[`ic-switch component should render disabled: renders-disabled 1`] = `
 <ic-switch disabled="true" label="Custom title">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-switch/test/basic/ic-switch.spec.ts
+++ b/packages/web-components/src/components/ic-switch/test/basic/ic-switch.spec.ts
@@ -18,6 +18,11 @@ describe("ic-switch component", () => {
     });
 
     expect(page.root).toMatchSnapshot("renders-disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render checked", async () => {

--- a/packages/web-components/src/components/ic-tab/ic-tab.tsx
+++ b/packages/web-components/src/components/ic-tab/ic-tab.tsx
@@ -37,6 +37,10 @@ export class Tab {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /** @internal Determines whether black variant of the tabs should be displayed. */
   @Prop() monochrome?: boolean = false;

--- a/packages/web-components/src/components/ic-tab/test/basic/ic-tab.spec.ts
+++ b/packages/web-components/src/components/ic-tab/test/basic/ic-tab.spec.ts
@@ -70,6 +70,24 @@ describe("ic-tab component", () => {
     </mock:shadow-root>
     IC Tab Test
   </ic-tab>`);
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root)
+      .toEqualHtml(`<ic-tab aria-disabled="false" aria-selected="false" context-id="default" role="tab" tabindex="-1" tab-position="1">
+<mock:shadow-root>
+  <ic-typography class="ic-tab-label ic-typography-label">
+    <mock:shadow-root>
+      <slot></slot>
+    </mock:shadow-root>
+    <span>
+      <slot></slot>
+    </span>
+  </ic-typography>
+</mock:shadow-root>
+IC Tab Test
+</ic-tab>`);
   });
 
   it("should display an icon", async () => {

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -117,6 +117,10 @@ export class TextField {
    * If `true`, the disabled state will be set.
    */
   @Prop() disabled: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * Specify whether the text field fills the full width of the container.

--- a/packages/web-components/src/components/ic-text-field/test/basic/__snapshots__/ic-text-field.input.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-text-field/test/basic/__snapshots__/ic-text-field.input.spec.tsx.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ic-text-field should render disabled: disabled-removed 1`] = `
+<ic-text-field label="Test label" value="test value">
+  <mock:shadow-root>
+    <ic-input-container>
+      <ic-input-label for="ic-text-field-input-7" helpertext="" label="Test label"></ic-input-label>
+      <ic-input-component-container size="medium" validationstatus="">
+        <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-7" inputmode="text" name="ic-text-field-input-7" placeholder="" type="text" value="test value">
+      </ic-input-component-container>
+    </ic-input-container>
+  </mock:shadow-root>
+  <input class="ic-input" name="ic-text-field-input-7" type="hidden" value="test value">
+</ic-text-field>
+`;
+
 exports[`ic-text-field should render disabled: renders-disabled 1`] = `
 <ic-text-field class="ic-text-field-disabled" disabled="true" label="Test label" value="test value">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.input.spec.tsx
+++ b/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.input.spec.tsx
@@ -87,6 +87,11 @@ describe("ic-text-field", () => {
     });
 
     expect(page.root).toMatchSnapshot("renders-disabled");
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
   });
 
   it("should render readonly", async () => {

--- a/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.tsx
+++ b/packages/web-components/src/components/ic-toggle-button-group/ic-toggle-button-group.tsx
@@ -17,6 +17,7 @@ import {
   IcThemeMode,
 } from "../../utils/types";
 import { IcChangeEventDetail } from "./ic-toggle-button-group.types";
+import { removeDisabledFalse } from "../../utils/helpers";
 
 interface lastKey {
   key: string | null;
@@ -52,6 +53,7 @@ export class ToggleButtonGroup {
     this.getAllToggleButtons().forEach((el) => {
       el.disabled = this.disabled;
     });
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   /**
@@ -155,6 +157,7 @@ export class ToggleButtonGroup {
     this.selectType === "multi" && (this.selectMethod = "manual");
     this.selectMethod === "auto" && this.selectType === "single";
     document.addEventListener("keydown", this.keyListener);
+    removeDisabledFalse(this.disabled, this.el);
   }
 
   componentDidLoad(): void {

--- a/packages/web-components/src/components/ic-toggle-button-group/test/ic-toggle-button-group.spec.ts
+++ b/packages/web-components/src/components/ic-toggle-button-group/test/ic-toggle-button-group.spec.ts
@@ -7,6 +7,114 @@ const keyboard = (key: string): KeyboardEvent => {
   return new KeyboardEvent("keydown", { key: key });
 };
 
+describe("ic-toggle-button-group component snapshot tests", () => {
+  it("should render and update disabled", async () => {
+    const page = await newSpecPage({
+      components: [ToggleButtonGroup, ToggleButton, Button],
+      html: `<ic-toggle-button-group select-type="single" disabled>
+              <ic-toggle-button label="Toggle"></ic-toggle-button>
+              <ic-toggle-button label="Toggle"></ic-toggle-button>
+              <ic-toggle-button label="Toggle"></ic-toggle-button>
+            </ic-toggle-button-group>`,
+    });
+
+    expect(page.root)
+      .toEqualHtml(`<ic-toggle-button-group aria-disabled="true" aria-label="Toggle button group" class="ic-toggle-button-group-disabled" disabled="" role="group" select-type="single" tabindex="0" variant="default">
+      <mock:shadow-root>
+        <slot></slot>
+      </mock:shadow-root>
+      <ic-toggle-button class="expand-toggle-group-child ic-toggle-button-disabled ic-toggle-button-medium" id="0" label="Toggle" tabindex="-1" variant="default">
+        <mock:shadow-root>
+          <ic-button aria-disabled="true" aria-pressed="false" class="ic-button-disabled ic-button-size-medium ic-button-variant-secondary" exportparts="button">
+            <mock:shadow-root>
+              <button aria-disabled="false" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" type="button">
+                <slot></slot>
+              </button>
+            </mock:shadow-root>
+            Toggle
+            <slot></slot>
+          </ic-button>
+        </mock:shadow-root>
+      </ic-toggle-button>
+      <ic-toggle-button class="expand-toggle-group-child ic-toggle-button-disabled ic-toggle-button-medium" id="1" label="Toggle" tabindex="-1" variant="default">
+        <mock:shadow-root>
+          <ic-button aria-disabled="true" aria-pressed="false" class="ic-button-disabled ic-button-size-medium ic-button-variant-secondary" exportparts="button">
+            <mock:shadow-root>
+              <button aria-disabled="false" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" type="button">
+                <slot></slot>
+              </button>
+            </mock:shadow-root>
+            Toggle
+            <slot></slot>
+          </ic-button>
+        </mock:shadow-root>
+      </ic-toggle-button>
+      <ic-toggle-button class="expand-toggle-group-child ic-toggle-button-disabled ic-toggle-button-medium" id="2" label="Toggle" tabindex="-1" variant="default">
+        <mock:shadow-root>
+          <ic-button aria-disabled="true" aria-pressed="false" class="ic-button-disabled ic-button-size-medium ic-button-variant-secondary" exportparts="button">
+            <mock:shadow-root>
+              <button aria-disabled="false" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" type="button">
+                <slot></slot>
+              </button>
+            </mock:shadow-root>
+            Toggle
+            <slot></slot>
+          </ic-button>
+        </mock:shadow-root>
+      </ic-toggle-button>
+    </ic-toggle-button-group>`);
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root)
+      .toEqualHtml(`<ic-toggle-button-group aria-disabled="false" aria-label="Toggle button group" role="group" select-type="single" tabindex="0" variant="default">
+      <mock:shadow-root>
+        <slot></slot>
+      </mock:shadow-root>
+      <ic-toggle-button class="expand-toggle-group-child ic-toggle-button-medium" id="0" label="Toggle" tabindex="-1" variant="default">
+        <mock:shadow-root>
+          <ic-button aria-disabled="false" aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
+            <mock:shadow-root>
+              <button aria-disabled="false" aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+                <slot></slot>
+              </button>
+            </mock:shadow-root>
+            Toggle
+            <slot></slot>
+          </ic-button>
+        </mock:shadow-root>
+      </ic-toggle-button>
+      <ic-toggle-button class="expand-toggle-group-child ic-toggle-button-medium" id="1" label="Toggle" tabindex="-1" variant="default">
+        <mock:shadow-root>
+          <ic-button aria-disabled="false" aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
+            <mock:shadow-root>
+              <button aria-disabled="false" aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+                <slot></slot>
+              </button>
+            </mock:shadow-root>
+            Toggle
+            <slot></slot>
+          </ic-button>
+        </mock:shadow-root>
+      </ic-toggle-button>
+      <ic-toggle-button class="expand-toggle-group-child ic-toggle-button-medium" id="2" label="Toggle" tabindex="-1" variant="default">
+        <mock:shadow-root>
+          <ic-button aria-disabled="false" aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
+            <mock:shadow-root>
+              <button aria-disabled="false" aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+                <slot></slot>
+              </button>
+            </mock:shadow-root>
+            Toggle
+            <slot></slot>
+          </ic-button>
+        </mock:shadow-root>
+      </ic-toggle-button>
+    </ic-toggle-button-group>`);
+  });
+});
+
 describe("ic-toggle-button-group component unit tests", () => {
   it("should getAllToggleButtons and return an array of slotted ic-toggle-buttons", async () => {
     const page = await newSpecPage({

--- a/packages/web-components/src/components/ic-toggle-button/ic-toggle-button.tsx
+++ b/packages/web-components/src/components/ic-toggle-button/ic-toggle-button.tsx
@@ -7,6 +7,7 @@ import {
   EventEmitter,
   Listen,
   h,
+  Watch,
 } from "@stencil/core";
 import {
   isSlotUsed,
@@ -46,6 +47,10 @@ export class ToggleButton {
    * If `true`, the toggle button will be in disabled state.
    */
   @Prop() disabled?: boolean = false;
+  @Watch("disabled")
+  watchDisabledHandler(): void {
+    removeDisabledFalse(this.disabled, this.el);
+  }
 
   /**
    * If `true`, the toggle button will fill the width of the container.

--- a/packages/web-components/src/components/ic-toggle-button/test/basic/__snapshots__/ic-toggle-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-toggle-button/test/basic/__snapshots__/ic-toggle-button.spec.ts.snap
@@ -11,6 +11,28 @@ exports[`ic-toggle-button component should render 1`] = `
 </ic-toggle-button>
 `;
 
+exports[`ic-toggle-button component should render disabled 1`] = `
+<ic-toggle-button class="ic-toggle-button-disabled ic-toggle-button-medium" disabled="" label="Toggle" variant="default">
+  <mock:shadow-root>
+    <ic-button aria-disabled="true" aria-label="Toggle, unticked" aria-pressed="false" disabled="" size="medium" variant="secondary">
+      Toggle
+      <slot></slot>
+    </ic-button>
+  </mock:shadow-root>
+</ic-toggle-button>
+`;
+
+exports[`ic-toggle-button component should render disabled: disabled-removed 1`] = `
+<ic-toggle-button class="ic-toggle-button-medium" label="Toggle" variant="default">
+  <mock:shadow-root>
+    <ic-button aria-disabled="false" aria-label="Toggle, unticked" aria-pressed="false" size="medium" variant="secondary">
+      Toggle
+      <slot></slot>
+    </ic-button>
+  </mock:shadow-root>
+</ic-toggle-button>
+`;
+
 exports[`ic-toggle-button component should render icon variant 1`] = `
 <ic-toggle-button accessible-label="Refresh the page" class="ic-toggle-button-icon ic-toggle-button-medium" variant="icon">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-toggle-button/test/basic/ic-toggle-button.spec.ts
+++ b/packages/web-components/src/components/ic-toggle-button/test/basic/ic-toggle-button.spec.ts
@@ -90,6 +90,20 @@ describe("ic-toggle-button component", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should render disabled", async () => {
+    const page = await newSpecPage({
+      components: [ToggleButton],
+      html: `<ic-toggle-button label="Toggle" disabled></ic-toggle-button>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+
+    page.rootInstance.disabled = false;
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot("disabled-removed");
+  });
+
   it("should update checked value on click", async () => {
     const page = await newSpecPage({
       components: [ToggleButton],

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -630,6 +630,10 @@ export const removeFormResetListener = (
 export const pxToRem = (px: string, base = 16): string =>
   `${(1 / base) * parseInt(px)}rem`;
 
+/**
+ * Removes the disabled attribute from the provided element when its value is set to false.
+ * This effectively makes it null, to not confuse screen readers that cannot interpret the false value
+ */
 export const removeDisabledFalse = (
   disabled: boolean,
   element: HTMLElement


### PR DESCRIPTION
## Summary of the changes
Cherry-pick for #2930 

## Related issue
#2629 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.