### PR TITLE
Add on click to action element

### DIFF
--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
@@ -40,6 +40,7 @@ import {
   textWrapColumns,
   textWrapRow,
   ACTION_DATA_ELEMENTS,
+  DATA_WITH_EMPTY_VALUES,
 } from "@ukic/canary-web-components/src/components/ic-data-table/story-data";
 
 import {
@@ -86,6 +87,7 @@ const PAGINATION_GO_TO_PAGE_TEXT_FIELD_SELECTOR =
   ".go-to-page-holder ic-text-field";
 const PAGINATION_GO_TO_PAGE_BUTTON_SELECTOR = ".go-to-page-holder ic-button";
 const ITEMS_PER_PAGE_SELECTOR = ".items-per-page-input";
+const ACTION_ELEMENT = "action-element";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const BasicDataTable = (dataTableProps?: any): ReactElement => (
@@ -131,6 +133,7 @@ describe("IcDataTables", () => {
   afterEach(() => {
     cy.task("generateReport");
   });
+
   it("should render", () => {
     mount(<BasicDataTable />);
 
@@ -566,7 +569,7 @@ describe("IcDataTables", () => {
     cy.checkHydrated(DATA_TABLE_SELECTOR);
     cy.wait(350).compareSnapshot({
       name: "loading-options",
-      testThreshold: setThresholdBasedOnEnv(0.026),
+      testThreshold: setThresholdBasedOnEnv(0.029),
       cypressScreenshotOptions: {
         capture: "viewport",
       },
@@ -1071,69 +1074,122 @@ describe("IcDataTables", () => {
       sorted: "descending",
     });
   });
-});
 
-it("should render an element in the table cell if the data prop contains the actionElement key", () => {
-  mount(
-    <IcDataTable
-      columns={COLS}
-      data={ACTION_DATA_ELEMENTS}
-      caption="Data tables"
-    ></IcDataTable>
-  );
-  cy.viewport(1024, 768);
+  it("should run an event when clicked if the data prop contains actionOnClick key", () => {
+    mount(
+      <IcDataTable
+        columns={COLS}
+        data={ACTION_DATA_ELEMENTS}
+        caption="Data tables"
+      ></IcDataTable>
+    );
 
-  cy.checkHydrated(DATA_TABLE_SELECTOR);
+    cy.spy(window.console, "log").as("spyWinConsoleLog");
 
-  cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-    .eq(0)
-    .find("span")
-    .should(HAVE_CLASS, "action-element")
-    .find("ic-button")
-    .should("be.visible");
-});
+    cy.viewport(1024, 768);
 
-it("should not render an element in the table cell if the data prop does not contain the actionElement key", () => {
-  mount(
-    <IcDataTable
-      columns={COLS}
-      data={ACTION_DATA_ELEMENTS}
-      caption="Data tables"
-    ></IcDataTable>
-  );
-  cy.viewport(1024, 768);
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
 
-  cy.checkHydrated(DATA_TABLE_SELECTOR);
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+      .eq(0)
+      .find("span")
+      .should(HAVE_CLASS, ACTION_ELEMENT)
+      .click();
 
-  cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-    .eq(1)
-    .find("span")
-    .should("not.exist");
-});
+    cy.get("@spyWinConsoleLog").should("have.callCount", 1);
+    cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, "hello");
+  });
 
-it("should apply styling to the cell container if an action element is present in the cell", () => {
-  mount(
-    <IcDataTable
-      columns={COLS}
-      data={ACTION_DATA_ELEMENTS}
-      caption="Data tables"
-    ></IcDataTable>
-  );
+  it("should render an element in the table cell if the data prop contains the actionElement key", () => {
+    mount(
+      <IcDataTable
+        columns={COLS}
+        data={ACTION_DATA_ELEMENTS}
+        caption="Data tables"
+      ></IcDataTable>
+    );
+    cy.viewport(1024, 768);
 
-  cy.viewport(1024, 768);
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
 
-  cy.checkHydrated(DATA_TABLE_SELECTOR);
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+      .eq(0)
+      .find("span")
+      .should(HAVE_CLASS, ACTION_ELEMENT)
+      .find("ic-button")
+      .should("be.visible");
 
-  cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-    .eq(0)
-    .find("div")
-    .eq(0)
-    .should(HAVE_CLASS, "cell-grid-wrapper")
-    .should(HAVE_CSS, "grid-template-columns", "156.797px 32px");
+    cy.checkA11yWithWait(undefined, 300);
 
-  cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
-    .should(HAVE_CLASS, "action-element")
-    .should(HAVE_CSS, "justify-content", "right");
+    cy.compareSnapshot({
+      name: "action-elements",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.038),
+      cypressScreenshotOptions: {
+        capture: "viewport",
+      },
+    });
+  });
+
+  it("should not render an element in the table cell if the data prop does not contain the actionElement key", () => {
+    mount(
+      <IcDataTable
+        columns={COLS}
+        data={ACTION_DATA_ELEMENTS}
+        caption="Data tables"
+      ></IcDataTable>
+    );
+
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+      .eq(1)
+      .find("span")
+      .should("not.exist");
+  });
+
+  it("should apply styling to the cell container if an action element is present in the cell", () => {
+    mount(
+      <IcDataTable
+        columns={COLS}
+        data={ACTION_DATA_ELEMENTS}
+        caption="Data tables"
+      ></IcDataTable>
+    );
+
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+      .eq(0)
+      .find("div")
+      .eq(0)
+      .should(HAVE_CLASS, "cell-grid-wrapper")
+      .should(HAVE_CSS, "grid-template-columns", "156.797px 32px");
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
+      .should(HAVE_CLASS, "action-element")
+      .should(HAVE_CSS, "justify-content", "right");
+  });
+
+  it("should render empty data values", () => {
+    mount(
+      <IcDataTable
+        columns={COLS}
+        data={DATA_WITH_EMPTY_VALUES}
+        caption="Data Table with empty data"
+      />
+    );
+
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+    cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "empty-data-values",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.043),
+      cypressScreenshotOptions: {
+        capture: "viewport",
+      },
+    });
+  });
 });
 
 describe("IcDataTables with IcPaginationBar", () => {
@@ -3879,7 +3935,7 @@ describe("IcDataTable table sizing and column width", () => {
     });
   });
 
-  it("should set first name column to 300px and age t0 100px with table layout set to auto", () => {
+  it("should set first name column to 300px and age to 100px with table layout set to auto", () => {
     mount(
       <IcDataTable
         caption="Basic Table"
@@ -3908,8 +3964,6 @@ describe("IcDataTable table sizing and column width", () => {
   });
 });
 
-// This test needs to be last as it seems to affect other tests.
-// For example, it will remove the last column for the remaining tests if placed higher.
 describe("IcDataTable row deletion", () => {
   beforeEach(() => {
     cy.injectAxe();
@@ -3921,7 +3975,8 @@ describe("IcDataTable row deletion", () => {
   });
 
   it('should delete a row when the "Delete" button is clicked', () => {
-    const nextData = [...DATA_REACT_ELEMENTS];
+    const clonedData = JSON.parse(JSON.stringify(DATA_REACT_ELEMENTS));
+    const nextData = [...clonedData];
     mount(
       <IcDataTable
         columns={COLS_ELEMENTS}
@@ -3976,7 +4031,8 @@ describe("IcDataTable row deletion", () => {
   });
 
   it("should have tooltip visible when it would overlap bottom of table", () => {
-    const nextData = [...DATA_REACT_ELEMENTS];
+    const clonedData = JSON.parse(JSON.stringify(DATA_REACT_ELEMENTS));
+    const nextData = [...clonedData];
     mount(
       <IcDataTable
         columns={COLS_ELEMENTS}
@@ -4025,7 +4081,10 @@ describe("IcDataTable row deletion", () => {
   });
 
   it("should render table correctly when only some rows have an icon in the column", () => {
-    const data = [...DATA_REACT_ELEMENTS_WITH_ICONS];
+    const clonedData = JSON.parse(
+      JSON.stringify(DATA_REACT_ELEMENTS_WITH_ICONS)
+    );
+    const data = [...clonedData];
     mount(
       <IcDataTable columns={COLS_ELEMENTS} data={data} caption="Data tables">
         {data.map((_, index) => (
@@ -4338,7 +4397,9 @@ describe("IcDataTable visual regression tests in high contrast mode", () => {
   });
 
   it("should render slotted custom elements in cell in high contrast mode", () => {
-    const nextData = [...DATA_REACT_ELEMENTS];
+    const clonedData = JSON.parse(JSON.stringify(DATA_REACT_ELEMENTS));
+    const nextData = [...clonedData];
+
     mount(
       <IcDataTable
         columns={COLS_ELEMENTS}

--- a/packages/canary-react/src/stories/ic-data-table.stories.mdx
+++ b/packages/canary-react/src/stories/ic-data-table.stories.mdx
@@ -28,7 +28,8 @@ import {
   COLUMNS_TEXT_WRAP,
   TEXT_WRAP_LONG_DATA,
   COLS_WIDTH,
-  ACTION_DATA_ELEMENTS
+  ACTION_DATA_ELEMENTS,
+  DATA_WITH_EMPTY_VALUES
 } from "../../../canary-web-components/src/components/ic-data-table/story-data";
 
 import { mdiAccountGroup, mdiImage, mdiDelete } from "@mdi/js";
@@ -1147,10 +1148,10 @@ const data = [
   {
     firstName: {
       data: "Joe",
-      cellAlignment: { horizontal: "center", vertical: "middle" },
-      emphasis: "high",
+      href: "https://www.example.com",
+      target: "_blank",
+      rel: "noopener noreferrer",
     },
-    lastName: "Bloggs",
     age: 30,
     jobTitle: "Developer",
     address: "1 Main Street, Town, County, Postcode",
@@ -2080,7 +2081,7 @@ const DataTable = () => {
 
 ### Action Element
 
-An example with action elements passed in via the data
+Action Element and Action OnClick can be passed via the `data` prop to display in certain cells, this is beneficial when dealing with large sets of data.
 
 <Canvas withSource="none">
   <Story name="Action Element">
@@ -2114,6 +2115,7 @@ const DATA = [
     firstName: {
       data: "Joe",
       actionElement: `<ic-button variant="icon" size="small  aria-label="you can disable tooltips on icon buttons">  <svg  aria-label="refresh button"  xmlns="http://www.w3.org/2000/svg"    width="24"    height="24"    viewBox="0 0 24 24"    fill="#000000"  >    <path d="M0 0h24v24H0V0z" fill="none"></path>    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>  </svg></ic-button>`,
+      actionOnClick: () => console.log('hello')
     },
     lastName: "Bloggs",
     age: 30,
@@ -2125,6 +2127,64 @@ const DATA = [
 
 const DataTable = () => (
   <IcDataTable caption="Action Element" columns={COLS} data={DATA} />
+);
+
+export default DataTable;
+```
+
+### Missing cell data
+
+An example showing the table being able to handle empty cell values (null, undefined or empty string).
+
+<Canvas withSource="none">
+  <Story name="Missing cell data">
+    <IcDataTable caption="Missing cell data" columns={COLS} data={DATA_WITH_EMPTY_VALUES} />
+  </Story>
+</Canvas>
+
+#### Missing cell data code example
+
+```jsx
+import * as React from "react";
+import { IcDataTable } from "@ukic/canary-react";
+import { IcDataTableColumnObject } from "@ukic/canary-web-components";
+
+// Copy columns array for 'basic' example
+const COLUMNS: IcDataTableColumnObject[] = [
+  {
+    key: "firstName",
+    title: "First name",
+    dataType: "string",
+  },
+  ...
+];
+
+const DATA = [
+  {
+    firstName: "Nigel",
+    lastName: null,
+    age: 62,
+    jobTitle: "Developer",
+    address: "1 Main Street, Town, County, Postcode",
+  },
+  {
+    firstName: "Sarah",
+    lastName: "Smith",
+    age: 28,
+    jobTitle: undefined,
+    address: "2 Main Street, Town, County, Postcode",
+  },
+  {
+    firstName: "Mark",
+    lastName: "Owens",
+    age: 45,
+    jobTitle: "Team Lead",
+    address: "",
+  },
+];
+
+const DataTable = () => (
+  <IcDataTable caption="Missing cell data" columns={COLUMNS} data={DATA} />
 );
 
 export default DataTable;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
In the data table on the data prop, where the action element is added, i have added an on click to the actionElement, with a ternary to only use click when a prop is passed.

## Related issue
2943


## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.