### PR TITLE
[ic-footer]: Slot updates after initial render

### DIFF
--- a/packages/canary-web-components/src/components/ic-card-horizontal/ic-card-horizontal.tsx
+++ b/packages/canary-web-components/src/components/ic-card-horizontal/ic-card-horizontal.tsx
@@ -6,7 +6,6 @@ import {
   State,
   h,
   Method,
-  forceUpdate,
   Watch,
 } from "@stencil/core";
 import {
@@ -14,7 +13,7 @@ import {
   isSlotUsed,
   getThemeFromContext,
   removeDisabledFalse,
-  checkSlotInChildMutations,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 import {
   IcTheme,
@@ -128,7 +127,9 @@ export class Card {
       );
     this.updateTheme();
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, "image", this)
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
@@ -158,18 +159,6 @@ export class Card {
       this.el.shadowRoot.querySelector("button").focus();
     }
   }
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, "image")
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
-  };
 
   private parentFocussed = (): void => {
     this.isFocussed = true;

--- a/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
@@ -9,15 +9,14 @@ import {
   Watch,
   State,
   Listen,
-  forceUpdate,
   Method,
 } from "@stencil/core";
 import { IcSizes, IcThemeForegroundNoDefault } from "../../utils/types";
 import {
   isSlotUsed,
   onComponentRequiredPropUndefined,
-  checkSlotInChildMutations,
   removeDisabledFalse,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 import arrowDropdown from "../../assets/arrow-dropdown.svg";
 
@@ -162,7 +161,9 @@ export class TreeItem {
         "Tree item"
       );
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, "icon", this)
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
@@ -338,18 +339,6 @@ export class TreeItem {
     this.routerSlot = this.el.querySelector('[slot="router-item"]');
     return !!this.routerSlot;
   }
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, "icon")
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
-  };
 
   private handleDisplayTooltip = (display: boolean) => {
     const typographyEl: HTMLIcTypographyElement =

--- a/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.tsx
@@ -7,13 +7,12 @@ import {
   Watch,
   State,
   Listen,
-  forceUpdate,
 } from "@stencil/core";
 import { IcSizes, IcThemeForegroundNoDefault } from "../../utils/types";
 import {
   isPropDefined,
   isSlotUsed,
-  checkSlotInChildMutations,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 
 let treeViewIds = 0;
@@ -100,7 +99,9 @@ export class TreeView {
 
     this.addSlotChangeListener();
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, "icon", this)
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
@@ -265,18 +266,6 @@ export class TreeView {
         headingContainer.appendChild(tooltipEl);
         tooltipEl.appendChild(typographyEl);
       }
-    }
-  };
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, "icon")
-          : false
-      )
-    ) {
-      forceUpdate(this);
     }
   };
 

--- a/packages/web-components/src/components/ic-alert/ic-alert.tsx
+++ b/packages/web-components/src/components/ic-alert/ic-alert.tsx
@@ -8,10 +8,9 @@ import {
   Listen,
   Prop,
   h,
-  forceUpdate,
 } from "@stencil/core";
 import closeIcon from "../../assets/close-icon.svg";
-import { isSlotUsed, checkSlotInChildMutations } from "../../utils/helpers";
+import { isSlotUsed, renderDynamicChildSlots } from "../../utils/helpers";
 import { IcThemeForegroundEnum, IcStatusVariants } from "../../utils/types";
 import { VARIANT_ICONS } from "../../utils/constants";
 
@@ -85,7 +84,9 @@ export class Alert {
   componentDidLoad(): void {
     this.alertTitleShouldWrap();
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, "action", this)
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
@@ -106,18 +107,6 @@ export class Alert {
       this.el.shadowRoot.querySelector(".alert-title")?.clientHeight;
     if (titleHeight > 24) this.alertTitleWrap = true;
   }
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, "action")
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
-  };
 
   render() {
     const {

--- a/packages/web-components/src/components/ic-alert/test/basic/__snapshots__/ic-alert.spec.ts.snap
+++ b/packages/web-components/src/components/ic-alert/test/basic/__snapshots__/ic-alert.spec.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ic-alert component should test rendering an action after initial render 1`] = `
+<ic-alert class="dark" heading="Test heading" role="alert">
+  <mock:shadow-root>
+    <div class="container container-neutral">
+      <div class="alert-icon-container">
+        <div class="divider divider-neutral"></div>
+        <span class="alert-icon icon-neutral svg-container">
+          svg
+        </span>
+      </div>
+      <div class="alert-content">
+        <div class="alert-message">
+          <ic-typography class="alert-title" variant="subtitle-large">
+            <p>
+              Test heading
+            </p>
+          </ic-typography>
+          <slot name="message">
+            <ic-typography variant="body"></ic-typography>
+          </slot>
+        </div>
+        <div class="alert-action-container">
+          <slot name="action"></slot>
+        </div>
+      </div>
+      <div class="dismiss-icon-container"></div>
+    </div>
+  </mock:shadow-root>
+  <button slot="action"></button>
+</ic-alert>
+`;

--- a/packages/web-components/src/components/ic-card/ic-card.tsx
+++ b/packages/web-components/src/components/ic-card/ic-card.tsx
@@ -6,7 +6,6 @@ import {
   State,
   h,
   Method,
-  forceUpdate,
   Watch,
 } from "@stencil/core";
 import {
@@ -14,7 +13,7 @@ import {
   isSlotUsed,
   getThemeFromContext,
   removeDisabledFalse,
-  checkSlotInChildMutations,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 import {
   IcTheme,
@@ -146,7 +145,23 @@ export class Card {
       );
     this.updateTheme();
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(
+        mutationList,
+        [
+          "message",
+          "adornment",
+          "expanded-content",
+          "image-top",
+          "image-mid",
+          "icon",
+          "interaction-button",
+          "badge",
+          "interaction-controls",
+        ],
+        this
+      )
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
@@ -195,28 +210,6 @@ export class Card {
 
   private toggleExpanded = (): void => {
     this.areaExpanded = !this.areaExpanded;
-  };
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, [
-              "message",
-              "adornment",
-              "expanded-content",
-              "image-top",
-              "image-mid",
-              "icon",
-              "interaction-button",
-              "badge",
-              "interaction-controls",
-            ])
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
   };
 
   render() {

--- a/packages/web-components/src/components/ic-card/test/basic/__snapshots__/ic-card.spec.ts.snap
+++ b/packages/web-components/src/components/ic-card/test/basic/__snapshots__/ic-card.spec.ts.snap
@@ -451,6 +451,47 @@ exports[`ic-card should render with interaction controls 1`] = `
 </ic-card>
 `;
 
+exports[`ic-card should test rendering slotted after initial render 1`] = `
+<ic-card heading="Card" message="This is a static card">
+  <mock:shadow-root>
+    <div class="card">
+      <div class="image-top">
+        <slot name="image-top"></slot>
+      </div>
+      <div class="card-header">
+        <div class="icon">
+          <slot name="icon"></slot>
+        </div>
+        <div class="card-title">
+          <slot name="heading">
+            <ic-typography variant="h4">
+              <p>
+                Card
+              </p>
+            </ic-typography>
+          </slot>
+        </div>
+        <div class="interaction-button">
+          <slot name="interaction-button"></slot>
+        </div>
+      </div>
+      <div class="image-mid">
+        <slot name="image-mid"></slot>
+      </div>
+      <div class="card-message">
+        <ic-typography variant="body">
+          This is a static card
+        </ic-typography>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <svg slot="icon"></svg>
+  <svg slot="image-mid"></svg>
+  <svg slot="image-top"></svg>
+  <button slot="interaction-button"></button>
+</ic-card>
+`;
+
 exports[`ic-card should toggle expanded content when expansion toggle is clicked 1`] = `
 <ic-card expandable="" heading="Card" id="test-card" message="This is a clickable card">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-empty-state/ic-empty-state.tsx
+++ b/packages/web-components/src/components/ic-empty-state/ic-empty-state.tsx
@@ -1,10 +1,10 @@
-import { h, Component, Host, Prop, Element, forceUpdate } from "@stencil/core";
+import { h, Component, Host, Prop, Element } from "@stencil/core";
 
 import { IcEmptyStateAlignment } from "./ic-empty-state.types";
 import {
   isSlotUsed,
   onComponentRequiredPropUndefined,
-  checkSlotInChildMutations,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 import { IcSizes } from "../../utils/types";
 
@@ -66,26 +66,13 @@ export class EmptyState {
         "Empty State"
       );
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, ["image", "actions"], this)
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
   }
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, [
-              "image",
-              "actions",
-            ])
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
-  };
 
   render() {
     const { aligned, body, bodyMaxLines, heading, imageSize, subheading } =

--- a/packages/web-components/src/components/ic-footer/ic-footer.tsx
+++ b/packages/web-components/src/components/ic-footer/ic-footer.tsx
@@ -16,6 +16,7 @@ import {
   checkResizeObserver,
   hasClassificationBanner,
   isSlotUsed,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 import {
   IcAlignment,
@@ -40,6 +41,7 @@ import { IcFooterBreakpoints } from "./ic-footer.types";
 export class Footer {
   private footerEl: HTMLElement;
   private resizeObserver: ResizeObserver = null;
+  private hostMutationObserver: MutationObserver = null;
 
   @Element() el: HTMLIcFooterElement;
 
@@ -85,6 +87,8 @@ export class Footer {
     if (this.resizeObserver !== null) {
       this.resizeObserver.disconnect();
     }
+
+    this.hostMutationObserver?.disconnect();
   }
 
   componentWillLoad(): void {
@@ -93,6 +97,14 @@ export class Footer {
 
   componentDidLoad(): void {
     checkResizeObserver(this.runResizeObserver);
+
+    this.hostMutationObserver = new MutationObserver((mutationList) => {
+      return renderDynamicChildSlots(mutationList, "link", this);
+    });
+
+    this.hostMutationObserver.observe(this.el, {
+      childList: true,
+    });
   }
 
   @Listen("themeChange", { target: "document" })

--- a/packages/web-components/src/components/ic-footer/test/basic/__snapshots__/ic-footer.spec.ts.snap
+++ b/packages/web-components/src/components/ic-footer/test/basic/__snapshots__/ic-footer.spec.ts.snap
@@ -430,3 +430,33 @@ exports[`ic-footer should render without the copyright text when the copyright p
   </ic-typography>
 </ic-footer>
 `;
+
+exports[`ic-footer should test rendering slotted after initial render 1`] = `
+<ic-footer class="footer footer-light footer-sparse footer-ungrouped light">
+  <mock:shadow-root>
+    <footer>
+      <div class="footer-links">
+        <ic-section-container aligned="left" fullheight="">
+          <div class="footer-links-inner" role="list">
+            <slot name="link"></slot>
+          </div>
+        </ic-section-container>
+      </div>
+      <div class="footer-compliance">
+        <ic-section-container aligned="left" fullheight="">
+          <div class="footer-compliance-inner">
+            <div class="footer-copyright">
+              <ic-typography variant="label-uppercase">
+                © Crown Copyright
+              </ic-typography>
+            </div>
+          </div>
+        </ic-section-container>
+      </div>
+    </footer>
+  </mock:shadow-root>
+  <ic-footer-link slot="link">
+    foo
+  </ic-footer-link>
+</ic-footer>
+`;

--- a/packages/web-components/src/components/ic-footer/test/basic/ic-footer.spec.ts
+++ b/packages/web-components/src/components/ic-footer/test/basic/ic-footer.spec.ts
@@ -2,8 +2,22 @@ import { newSpecPage } from "@stencil/core/testing";
 import { Typography } from "../../../ic-typography/ic-typography";
 import { Footer } from "../../ic-footer";
 import { DEVICE_SIZES } from "../../../../utils/helpers";
+import {
+  mockHasDynamicChildSlots,
+  mockMutationObserverImplementation,
+  MockMutationRecord,
+  mockRenderDynamicChildSlots,
+} from "../../../../testspec.setup";
 
 describe("ic-footer", () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should render", async () => {
     const page = await newSpecPage({
       components: [Footer],
@@ -180,5 +194,49 @@ describe("ic-footer", () => {
     expect(page.root).not.toBeNull;
 
     expect(page.root).toMatchSnapshot("footer-xl-breakpoint");
+  });
+
+  it("should test rendering slotted after initial render", async () => {
+    const page = await newSpecPage({
+      components: [Footer],
+      html: `<ic-footer></ic-footer>`,
+    });
+
+    const component = page.rootInstance;
+    const host = page.root;
+
+    const observerInstance =
+      mockMutationObserverImplementation.mock.results[0].value;
+
+    const footerLink = page.doc.createElement("ic-footer-link");
+    footerLink.textContent = "foo";
+    footerLink.setAttribute("slot", "link");
+
+    observerInstance.observe(host, { childList: true });
+
+    host.appendChild(footerLink);
+
+    const mockMutationRecord: MockMutationRecord[] = [
+      {
+        addedNodes: [footerLink],
+        removedNodes: [],
+        target: host,
+      },
+    ];
+
+    observerInstance.trigger(mockMutationRecord);
+
+    await page.waitForChanges();
+
+    expect(mockRenderDynamicChildSlots).toHaveBeenCalledTimes(1);
+    expect(mockRenderDynamicChildSlots).toHaveBeenCalledWith(
+      mockMutationRecord,
+      "link",
+      component
+    );
+
+    expect(mockHasDynamicChildSlots).toHaveBeenCalledTimes(1);
+
+    expect(page.root).toMatchSnapshot();
   });
 });

--- a/packages/web-components/src/components/ic-hero/ic-hero.tsx
+++ b/packages/web-components/src/components/ic-hero/ic-hero.tsx
@@ -6,7 +6,6 @@ import {
   h,
   State,
   Listen,
-  forceUpdate,
 } from "@stencil/core";
 import {
   IcAlignment,
@@ -21,7 +20,7 @@ import {
   onComponentRequiredPropUndefined,
   isPropDefined,
   isSlotUsed,
-  checkSlotInChildMutations,
+  renderDynamicChildSlots,
 } from "../../utils/helpers";
 import { IcHeroContentAlignments } from "./ic-hero.types";
 
@@ -114,7 +113,9 @@ export class Hero {
         "Hero"
       );
 
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, "secondary", this)
+    );
     this.hostMutationObserver.observe(this.el, {
       childList: true,
     });
@@ -141,18 +142,6 @@ export class Hero {
     const y = -100 + scrolltotop * factor;
     this.scrollFactor = "right " + y + "px";
   }
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, "secondary")
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
-  };
 
   render() {
     const {

--- a/packages/web-components/src/components/ic-hero/test/basic/__snapshots__/ic-hero.spec.ts.snap
+++ b/packages/web-components/src/components/ic-hero/test/basic/__snapshots__/ic-hero.spec.ts.snap
@@ -195,6 +195,38 @@ exports[`ic-hero component should render: renders 1`] = `
 </ic-hero>
 `;
 
+exports[`ic-hero component should test rendering secondary slot after initial render 1`] = `
+<ic-hero heading="Test title" subheading="Test text">
+  <mock:shadow-root>
+    <ic-section-container aligned="left" class="section-container" fullheight="">
+      <div class="left-container left-container-full-width">
+        <div class="heading">
+          <slot name="heading">
+            <ic-typography class="heading-bottom-spacing" variant="h1">
+              Test title
+            </ic-typography>
+          </slot>
+        </div>
+        <div class="subheading">
+          <slot name="subheading">
+            <ic-typography variant="body">
+              Test text
+            </ic-typography>
+          </slot>
+        </div>
+        <div class="interaction-container">
+          <slot name="interaction"></slot>
+        </div>
+      </div>
+      <div class="right-container">
+        <slot name="secondary"></slot>
+      </div>
+    </ic-section-container>
+  </mock:shadow-root>
+  <svg slot="secondary"></svg>
+</ic-hero>
+`;
+
 exports[`ic-hero component should use not parallax on scroll when a background image is given, but parallax disabled: renders-with-parallax-on-scroll-disabled 1`] = `
 <ic-hero background-image="test.png" class="has-background-image" disable-background-parallax="" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -100px;">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.tsx
+++ b/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.tsx
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Element,
-  Host,
-  Prop,
-  Watch,
-  forceUpdate,
-  h,
-} from "@stencil/core";
+import { Component, Element, Host, Prop, Watch, h } from "@stencil/core";
 
 import {
   IcInformationStatus,
@@ -15,8 +7,8 @@ import {
 } from "../../utils/types";
 import successIcon from "../../assets/success-icon.svg";
 import {
-  checkSlotInChildMutations,
   removeDisabledFalse,
+  renderDynamicChildSlots,
   slotHasContent,
 } from "../../utils/helpers";
 
@@ -90,21 +82,11 @@ export class InputComponentContainer {
   }
 
   componentDidLoad(): void {
-    this.hostMutationObserver = new MutationObserver(this.hostMutationCallback);
+    this.hostMutationObserver = new MutationObserver((mutationList) =>
+      renderDynamicChildSlots(mutationList, "left-icon", this)
+    );
     this.hostMutationObserver.observe(this.el, { childList: true });
   }
-
-  private hostMutationCallback = (mutationList: MutationRecord[]): void => {
-    if (
-      mutationList.some(({ type, addedNodes, removedNodes }) =>
-        type === "childList"
-          ? checkSlotInChildMutations(addedNodes, removedNodes, "left-icon")
-          : false
-      )
-    ) {
-      forceUpdate(this);
-    }
-  };
 
   render() {
     const {

--- a/packages/web-components/src/components/ic-input-component-container/test/basic/__snapshots__/ic-input-component-container.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-input-component-container/test/basic/__snapshots__/ic-input-component-container.spec.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ic-input-component-container should test rendering icon after initial render 1`] = `
+<ic-input-component-container class="default">
+  <!---->
+  <div class="focus-indicator">
+    <div class="icon-container">
+      <svg slot="left-icon"></svg>
+    </div>
+    content
+  </div>
+</ic-input-component-container>
+`;

--- a/packages/web-components/src/testspec.setup.ts
+++ b/packages/web-components/src/testspec.setup.ts
@@ -39,6 +39,31 @@ Object.defineProperty(global, "MutationObserver", {
   value: mockMutationObserver,
 });
 
+export const mockMutationObserverImplementation = jest
+  .spyOn(global, "MutationObserver")
+  .mockImplementation((callback) => ({
+    observe: jest.fn(),
+    disconnect: jest.fn(),
+    takeRecords: jest.fn(),
+    trigger: (mutations: MutationRecord[]) => {
+      callback(mutations, this);
+    },
+  }));
+
+export type MockMutationRecord = {
+  addedNodes?: Node[];
+  removedNodes?: Node[];
+  target?: Node;
+};
+
+export const mockRenderDynamicChildSlots = jest.spyOn(
+  helpers,
+  "renderDynamicChildSlots"
+);
+export const mockHasDynamicChildSlots = jest
+  .spyOn(helpers, "hasDynamicChildSlots")
+  .mockImplementation(() => true);
+
 export const waitForTimeout = async (ms: number): Promise<void> => {
   await new Promise((r) => setTimeout(r, ms));
 };

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "@stencil/core";
+import { EventEmitter, forceUpdate } from "@stencil/core";
 import {
   IcCallbackFunctionNoReturn,
   IcInformationStatusOrEmpty,
@@ -664,3 +664,24 @@ export const checkSlotInChildMutations = (
 
 export const isElInAGGrid = (el: HTMLElement): boolean =>
   !!el.closest(".ag-cell") && !!el.closest(".ag-root");
+
+export const hasDynamicChildSlots = (
+  mutationList: MutationRecord[],
+  slotNames: string | string[]
+) => {
+  return mutationList.some(({ type, addedNodes, removedNodes }) =>
+    type === "childList"
+      ? checkSlotInChildMutations(addedNodes, removedNodes, slotNames)
+      : false
+  );
+};
+
+export const renderDynamicChildSlots = (
+  mutationList: MutationRecord[],
+  slotNames: string | string[],
+  ref: any
+): void => {
+  if (hasDynamicChildSlots(mutationList, slotNames)) {
+    forceUpdate(ref);
+  }
+};


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
- Updated `ic-footer` to forceUpdate if `link` slot rendered after initial load.
- Refactored mutationObserver function to use in other components where relevant
- Created unit tests

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 

### System modes
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] Props/slots can be updated after initial render.