### PR TITLE
1785 changing text field hidden input has no effect

### DIFF
--- a/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextField.cy.tsx
@@ -41,6 +41,7 @@ import {
   Controlled,
   Uncontrolled,
   TextFieldWithMaxLengthMessage,
+  HiddenInput,
 } from "./IcTextFieldTestData";
 import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
 
@@ -341,6 +342,18 @@ describe("IcTextField end-to-end tests", () => {
     cy.get(IC_TEXTFIELD).invoke("attr", "title", "new-input-title");
 
     input.should(HAVE_ATTR, "title", "new-input-title");
+  });
+
+  it("should remove the hidden input when hiddenInput prop is toggled", () => {
+    mount(<HiddenInput />);
+
+    cy.get(IC_TEXTFIELD).invoke("prop", "hiddenInput", true);
+
+    cy.get(IC_TEXTFIELD).find('input[type="hidden"]').should("exist");
+
+    cy.get(IC_TEXTFIELD).invoke("prop", "hiddenInput", false);
+
+    cy.get(IC_TEXTFIELD).find('input[type="hidden"]').should("not.exist");
   });
 });
 

--- a/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
+++ b/packages/react/src/component-tests/IcTextField/IcTextFieldTestData.tsx
@@ -343,3 +343,9 @@ export const CustomSizeTextField = (): ReactElement => (
     ></IcTextField>
   </div>
 );
+
+export const HiddenInput = (): ReactElement => (
+  <div style={style}>
+    <IcTextField label="my label" />
+  </div>
+);

--- a/packages/react/src/stories/ic-text-field.stories.mdx
+++ b/packages/react/src/stories/ic-text-field.stories.mdx
@@ -6,7 +6,7 @@ import {
   ArgsTable,
   Description,
 } from "@storybook/addon-docs";
-import { IcTextField } from "../components";
+import { IcTextField, IcButton } from "../components";
 import {SlottedSVG} from "../react-component-lib/slottedSVG";
 import readme from "../../../web-components/src/components/ic-text-field/readme.md";
 
@@ -558,6 +558,27 @@ export const Uncontrolled = () => {
       label="What is your favourite coffee?"
       helper-text="Long answer please."
     ></IcTextField>
+  </Story>
+</Canvas>
+
+### Hidden input
+
+export const HiddenInput = () => {
+  const [renderHidden, setRenderHidden] = useState(true);
+  const handleChange = () => {
+    setRenderHidden(!renderHidden);
+  };
+  return (
+    <>
+      <IcTextField label="my label" hiddenInput={renderHidden} />
+      <IcButton onClick={() => handleChange()}>Toggle hidden input</IcButton>
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Hidden input">
+    <HiddenInput />
   </Story>
 </Canvas>
 

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -32,6 +32,7 @@ import {
   isSlotUsed,
   removeDisabledFalse,
   checkSlotInChildMutations,
+  removeHiddenInput,
 } from "../../utils/helpers";
 import { IC_INHERITED_ARIA } from "../../utils/constants";
 import {
@@ -575,9 +576,10 @@ export class TextField {
 
     const invalid = `${currentStatus === IcInformationStatus.Error}`;
 
-    if (hiddenInput) {
-      renderHiddenInput(true, this.el, name, value, disabledMode);
-    }
+    hiddenInput
+      ? renderHiddenInput(true, this.el, name, value, disabledMode)
+      : removeHiddenInput(this.el);
+
     return (
       <Host class={{ ["fullwidth"]: fullWidth }}>
         <ic-input-container readonly={readonly} disabled={disabledMode}>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Adds in removeHiddenInput for text field so hidden input prop can be toggled

## Related issue
#1785 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.