### PR TITLE
Fix/2194 breadcrumb slotted link focus issues

### DIFF
--- a/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumb.cy.tsx
+++ b/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumb.cy.tsx
@@ -11,6 +11,7 @@ import {
   Appearance,
   ToggleCollapsed,
   ToggleBackBreadcrumb,
+  SlottedLinks,
 } from "./IcBreadcrumbTestData";
 import {
   BE_VISIBLE,
@@ -84,7 +85,7 @@ describe("IcBreadcrumb end-to-end tests", () => {
     cy.get('[page-title="Home"]').should(BE_VISIBLE);
   });
 
-  it("should add 'aria-current' when current prop is true", () => {
+  it("should add 'aria-current' when current prop is true and remove it when changed to false", () => {
     mount(<WithCurrentPage />);
 
     cy.checkHydrated(IC_BREADCRUMB_LABEL);
@@ -92,6 +93,9 @@ describe("IcBreadcrumb end-to-end tests", () => {
     cy.get('[page-title="Coffee"]').should(HAVE_ATTR, "aria-current", "page");
     cy.get('[page-title="Home"]').should(NOT_HAVE_ATTR, "current", "true");
     cy.get('[page-title="Beverages"]').should(NOT_HAVE_ATTR, "current", "true");
+
+    cy.get('[page-title="Coffee"]').invoke("prop", "current", false);
+    cy.get('[page-title="Coffee"]').should(NOT_HAVE_ATTR, "aria-current");
   });
 
   it("should call 'setFocus' when breadcrumb is focused", () => {
@@ -107,6 +111,22 @@ describe("IcBreadcrumb end-to-end tests", () => {
       .each(($el) => {
         cy.wrap($el).focus().should(HAVE_FOCUS);
       });
+  });
+
+  it("should only allow focus on slotted links when not within current page breadcrumbs", () => {
+    mount(<SlottedLinks />);
+
+    cy.checkHydrated(IC_BREADCRUMB_LABEL);
+    cy.get("ic-button").eq(0).shadow().find("button").focus();
+    cy.realPress("Tab");
+    cy.get("ic-button").eq(1).shadow().find("button").should(HAVE_FOCUS);
+
+    cy.get(IC_BREADCRUMB_LABEL).eq(0).invoke("prop", "current", false);
+
+    cy.get("ic-button").eq(0).shadow().find("button").focus();
+    cy.realPress("Tab");
+    cy.realPress("Tab");
+    cy.get("ic-button").eq(1).shadow().find("button").should(HAVE_FOCUS);
   });
 
   it("should render collapsed breadcrumb", () => {

--- a/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumbTestData.tsx
+++ b/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumbTestData.tsx
@@ -1,5 +1,10 @@
 import React, { ReactElement } from "react";
-import { IcBreadcrumb, IcBreadcrumbGroup, IcButton } from "../../components";
+import {
+  IcBreadcrumb,
+  IcBreadcrumbGroup,
+  IcButton,
+  IcLink,
+} from "../../components";
 import { SlottedSVG } from "../../react-component-lib/slottedSVG";
 
 const ReusableSlottedIcon = (): ReactElement => (
@@ -218,6 +223,30 @@ export const Appearance = (): ReactElement => {
           ></IcBreadcrumb>
         </IcBreadcrumbGroup>
       </div>
+    </div>
+  );
+};
+
+export const SlottedLinks = (): ReactElement => {
+  return (
+    <div>
+      <IcButton>Button</IcButton>
+      <IcBreadcrumbGroup>
+        <IcBreadcrumb pageTitle="Breadcrumb 1" current>
+          <IcLink href="#">Breadcrumb 1</IcLink>
+        </IcBreadcrumb>
+        <IcBreadcrumb pageTitle="Breadcrumb 2" current>
+          <a href="#">Breadcrumb 2</a>
+        </IcBreadcrumb>
+        <IcBreadcrumb pageTitle="Breadcrumb 3" current>
+          <IcLink>
+            <a slot="router-item" href="#">
+              Breadcrumb 3
+            </a>
+          </IcLink>
+        </IcBreadcrumb>
+      </IcBreadcrumbGroup>
+      <IcButton>Button</IcButton>
     </div>
   );
 };

--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.stories.mdx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.stories.mdx
@@ -63,44 +63,40 @@ import BreadcrumbReadme from "../ic-breadcrumb/readme.md";
       <ic-breadcrumb-group>
         <ic-breadcrumb page-title="breadcrumb-1">
           <ic-link>
-            <a slot="router-item" href="/breadcrumb-1"> Breadcrumb 1 </a>
+            <a slot="router-item" href="/breadcrumb-1">Breadcrumb 1</a>
           </ic-link>
         </ic-breadcrumb>
       </ic-breadcrumb-group>
       <ic-breadcrumb-group>
-        <ic-breadcrumb current="page" page-title="breadcrumb 1">
-          Breadcrumb 1
+        <ic-breadcrumb current="true" page-title="breadcrumb 1">
+          <ic-link href="/breadcrumb-1">Breadcrumb 1</ic-link>
         </ic-breadcrumb>
       </ic-breadcrumb-group>
       <ic-breadcrumb-group>
         <ic-breadcrumb page-title="breadcrumb-1">
-          <ic-link
-            ><a slot="router-item" href="/breadcrumb-1"
-              >Breadcrumb 1</a
-            ></ic-link
-          >
+          <ic-link>
+            <a slot="router-item" href="/breadcrumb-1">Breadcrumb 1</a>
+          </ic-link>
         </ic-breadcrumb>
-        <ic-breadcrumb current="page" page-title="breadcrumb 2">
-          Breadcrumb 2
+        <ic-breadcrumb current="true" page-title="breadcrumb 2">
+          <a href="/breadcrumb-2">Breadcrumb 2</a>
         </ic-breadcrumb>
       </ic-breadcrumb-group>
       <ic-breadcrumb-group>
-        <ic-breadcrumb page-title="breadcrumb 1">
-          <ic-link
-            ><a slot="router-item" href="/breadcrumb-1"
-              >Breadcrumb 1</a
-            ></ic-link
-          >
+        <ic-breadcrumb page title="breadcrumb 1">
+          <ic-link>
+            <a slot="router-item" href="/breadcrumb-1">Breadcrumb 1</a>
+          </ic-link>
         </ic-breadcrumb>
         <ic-breadcrumb page-title="breadcrumb 2">
-          <ic-link
-            ><a slot="router-item" href="/breadcrumb-2"
-              >Breadcrumb 2</a
-            ></ic-link
-          >
+          <ic-link>
+            <a slot="router-item" href="/breadcrumb-2">Breadcrumb 2</a>
+          </ic-link>
         </ic-breadcrumb>
-        <ic-breadcrumb current="page" page-title="breadcrumb 3">
-          Breadcrumb 3
+        <ic-breadcrumb current="true" page-title="breadcrumb 3">
+          <ic-link>
+            <a href="/breadcrumb-3">Breadcrumb 3</a>
+          </ic-link>
         </ic-breadcrumb>
       </ic-breadcrumb-group>
     `}

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
@@ -197,7 +197,9 @@ exports[`ic-breadcrumb-group should render with collapse button: should render w
         <span aria-hidden="true" class="chevron">
           svg
         </span>
-        <slot></slot>
+        <span class="link-wrapper" tabindex="0">
+          <slot></slot>
+        </span>
       </div>
     </mock:shadow-root>
     <span class="hide" id="collapsed-button-described">
@@ -252,7 +254,9 @@ exports[`ic-breadcrumb-group should render with ic-breadcrumb: should render wit
         <span aria-hidden="true" class="chevron">
           svg
         </span>
-        <slot></slot>
+        <span class="link-wrapper" tabindex="0">
+          <slot></slot>
+        </span>
       </div>
     </mock:shadow-root>
   </ic-breadcrumb>
@@ -298,7 +302,9 @@ exports[`ic-breadcrumb-group should test collapsed behaviour on resize to small 
         <span aria-hidden="true" class="chevron">
           svg
         </span>
-        <slot></slot>
+        <span class="link-wrapper" tabindex="0">
+          <slot></slot>
+        </span>
       </div>
     </mock:shadow-root>
     <span class="hide" id="collapsed-button-described">

--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.css
@@ -48,6 +48,10 @@ ic-link {
   --breadcrumb-link-gap: var(--ic-space-xs);
 }
 
+:host([aria-current="page"]) {
+  cursor: text;
+}
+
 :host([aria-current="page"]) .current-page-container {
   display: flex;
   align-items: center;
@@ -57,6 +61,10 @@ ic-link {
 
 :host([aria-current="page"].ic-breadcrumb-monochrome) .current-page-container {
   color: var(--ic-breadcrumb-text-monochrome);
+}
+
+:host([aria-current="page"]) slot {
+  pointer-events: none;
 }
 
 :host(.collapsed-breadcrumb-wrapper) {

--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
@@ -1,9 +1,21 @@
-import { Component, Host, Prop, h, Element, Method } from "@stencil/core";
+import {
+  Component,
+  Host,
+  Prop,
+  h,
+  Element,
+  Method,
+  Watch,
+} from "@stencil/core";
 import { IcBreadcrumbDefault } from "./ic-breadcrumb.types";
 
 import chevronIcon from "../../assets/chevron-icon.svg";
 import backIcon from "../../assets/back-icon.svg";
-import { isPropDefined, isSlotUsed } from "../../utils/helpers";
+import {
+  getSlotElements,
+  isPropDefined,
+  isSlotUsed,
+} from "../../utils/helpers";
 import { IcThemeMode } from "../../utils/types";
 
 /**
@@ -17,12 +29,22 @@ import { IcThemeMode } from "../../utils/types";
   },
 })
 export class Breadcrumb {
+  private HREF_ATTR = "href";
+  private linkSlotContent: HTMLElement;
+  private slottedLinkEl: HTMLElement | null;
+  private slottedLinkHref: string;
+
   @Element() el: HTMLIcBreadcrumbElement;
 
   /**
    * If `true`, aria-current will be set on the breadcrumb.
    */
   @Prop() current?: boolean = false;
+  @Watch("current")
+  watchCurrentHandler(): void {
+    this.updatedSlottedLinkFocus();
+    this.el.ariaCurrent = this.current ? "page" : null;
+  }
 
   /**
    * The URL that the breadcrumb link points to.
@@ -48,6 +70,48 @@ export class Breadcrumb {
    * @internal Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.
    */
   @Prop() theme?: IcThemeMode = "inherit";
+
+  // Prevent focus on breadcrumb if current page and contains slotted link
+  private updatedSlottedLinkFocus = (): void => {
+    // Sets tabindex on wrong element in unit test snapshots
+    // - related to known Jest issue: https://github.com/ionic-team/stencil/issues/2830
+    if (this.linkSlotContent) {
+      this.linkSlotContent.tabIndex = this.current ? -1 : 0; // Prevent focus
+    }
+
+    if (this.slottedLinkEl) {
+      if (this.current) {
+        this.slottedLinkEl.removeAttribute(this.HREF_ATTR); // Prevent screen reader announcing breadcrumb as a link
+      } else {
+        this.slottedLinkEl.setAttribute(this.HREF_ATTR, this.slottedLinkHref);
+      }
+    }
+  };
+
+  private getSlottedLinkEl = (): HTMLElement | null => {
+    const link = this.linkSlotContent;
+    if (link) {
+      const elWithHref = link.hasAttribute(this.HREF_ATTR)
+        ? link
+        : link.querySelector("[href]");
+      return elWithHref as HTMLElement;
+    }
+    return null;
+  };
+
+  componentDidLoad(): void {
+    const slottedLinkWrapper =
+      this.el.shadowRoot.querySelector(".link-wrapper");
+
+    if (slottedLinkWrapper) {
+      this.linkSlotContent = getSlotElements(
+        slottedLinkWrapper
+      )[0] as HTMLElement;
+      this.slottedLinkEl = this.getSlottedLinkEl();
+      this.slottedLinkHref = this.slottedLinkEl?.getAttribute("href");
+      this.updatedSlottedLinkFocus();
+    }
+  }
 
   componentWillRender(): void {
     this.setSlottedCurrentPageClass();
@@ -152,7 +216,9 @@ export class Breadcrumb {
               href
             )
           ) : (
-            <slot />
+            <span class="link-wrapper">
+              <slot />
+            </span>
           )}
         </div>
       </Host>


### PR DESCRIPTION
## Summary of the changes
Updated breadcrumb component to prevent focus on current page breadcrumb when it has a slotted link. Added slotted links to current page breadcrumbs in web components Slotted Links story to help with testing.

Go to the Slotted Links story (either web components or React) to test this.

-------

I have added functionality which checks for and removes hrefs from any slotted element in the default slot i.e. the link slot. I originally just added a -1 tabindex but the VO virtual cursor still read out the current page as a 'link'. Removing the hrefs stops this happening. 

However, I'm a bit concerned that this might not work for all types of slotted links e.g. links from some routing libraries may be structured / work differently. The tabindex will prevent focus at least, but I have also opened a [PR to add guidance](https://github.com/mi6/ic-design-system/pull/1322) recommending to not slot a link in the current page breadcrumb. But hopefully these changes prevent most issues if someone does use a slotted link.

## Related issue
#2194 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.