### PR TITLE
2853 popover menu opening parent when submenu open

### DIFF
--- a/packages/react/src/component-tests/IcPopoverMenu/IcPopoverMenu.cy.tsx
+++ b/packages/react/src/component-tests/IcPopoverMenu/IcPopoverMenu.cy.tsx
@@ -309,6 +309,21 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
 
     cy.get("@icToggleChecked").should(HAVE_BEEN_CALLED_ONCE);
   });
+
+  it("should close submenu popover if open/close button is clicked", () => {
+    mount(<PopoverDropdown />);
+
+    cy.checkHydrated(POPOVER_SELECTOR);
+
+    cy.get(BUTTON_SELECTOR).click();
+    cy.get("#submenu-trigger-actions").click().wait(250);
+
+    cy.get(POPOVER_SELECTOR + '[submenu-id="actions"]').should(BE_VISIBLE);
+
+    cy.get(BUTTON_SELECTOR).click().click();
+
+    cy.get(POPOVER_SELECTOR + '[submenu-id="actions"]').should(NOT_BE_VISIBLE);
+  });
 });
 
 describe("IcPopoverMenu visual regression tests in high contrast mode", () => {

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
@@ -74,6 +74,8 @@ export class PopoverMenu {
         this.popoverMenuEls.unshift(this.backButton);
       }
 
+      this.closeAllPopovers();
+
       this.currentFocus = 0;
       // Needed so that anchorEl isn't always focused
       setTimeout(this.setButtonFocus, 50);
@@ -338,6 +340,22 @@ export class PopoverMenu {
         },
       ],
     });
+  };
+
+  private closeAllPopovers = () => {
+    const allPopovers = Array.from(
+      document.querySelectorAll("ic-popover-menu")
+    );
+
+    const openPopovers = allPopovers.filter((popover) => popover.open);
+
+    if (openPopovers.length > 1) {
+      for (let i = 0; i < openPopovers.length; i++) {
+        if (openPopovers[i].anchor === openPopovers[i + 1]?.anchor) {
+          allPopovers.forEach((popover) => (popover.open = false));
+        }
+      }
+    }
   };
 
   render() {

--- a/packages/web-components/src/components/ic-popover-menu/test/basic/ic-popover-menu.spec.ts
+++ b/packages/web-components/src/components/ic-popover-menu/test/basic/ic-popover-menu.spec.ts
@@ -4,6 +4,7 @@ import { PopoverMenu } from "../../ic-popover-menu";
 import { waitForTimeout } from "../../../../testspec.setup";
 import { MenuGroup } from "../../../ic-menu-group/ic-menu-group";
 import { Dialog } from "../../../ic-dialog/ic-dialog";
+import { Button } from "../../../ic-button/ic-button";
 
 describe("ic-popover-menu", () => {
   it("should render with anchor", async () => {
@@ -497,5 +498,40 @@ describe("ic-popover-menu", () => {
     page.rootInstance.closeMenu();
     await page.waitForChanges();
     expect(page.root.open).toBeFalsy();
+  });
+
+  it("should set open to false for root popover when submenu is open and button is clicked", async () => {
+    const page = await newSpecPage({
+      components: [PopoverMenu, MenuItem, Button],
+      html: `<ic-button id="anchorEl" onclick="buttonClick()"
+          >Show/Hide popover</ic-button
+        >
+        <script>
+          var icPopover = document.querySelector("ic-popover-menu");
+          function buttonClick() {
+            icPopover.open = !icPopover.open;
+          }
+        </script>
+      <ic-popover-menu anchor="#anchorEl" aria-label="popover-menu">
+      <ic-menu-item label="Button 1" submenu-trigger-for="submenu" id="trigger-button"></ic-menu-item>
+      <ic-menu-item label="Button 2"></ic-menu-item>
+      </ic-popover-menu>
+      <ic-popover-menu submenu-id="submenu">
+      <ic-menu-item label="Button 1"></ic-menu-item>
+      <ic-menu-item label="Button 2"></ic-menu-item>
+      </ic-popover-menu>`,
+    });
+
+    const anchor = document.getElementById("anchorEl");
+
+    anchor.click();
+
+    const trigger = document.getElementById("trigger-button");
+
+    trigger.click();
+
+    await page.rootInstance.closeAllPopovers;
+
+    expect(page.root.open).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updates popover so that a submenu can't be open at the same time as parent

## Related issue
#2853 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [ ] Relevant unit tests and visual regression tests added. 
- x ] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.