### PR TITLE
fix(canary-web-components): added check to prevent duplicate tooltip being added

### DIFF
--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
@@ -1581,11 +1581,23 @@ describe("IcDataTable with truncation", () => {
 
       cy.checkHydrated(DATA_TABLE_SELECTOR);
 
+      cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR).eq(4).click();
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, TABLE_ROW_SELECTOR)
+        .last()
+        .find(`${LAST_CELL_SELECTOR} ic-tooltip`)
+        .should(HAVE_LENGTH, 1);
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR)
+        .eq(4)
+        .click()
+        .click();
       cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR).eq(2).click();
 
       cy.findShadowEl(DATA_TABLE_SELECTOR, TABLE_ROW_SELECTOR)
         .last()
         .find(`${LAST_CELL_SELECTOR} ic-tooltip`)
+        .should(HAVE_LENGTH, 1)
         .should(HAVE_ATTR, "label", LONG_DATA_VALUES[2].jobTitle);
 
       cy.compareSnapshot({

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -1969,7 +1969,8 @@ export class DataTable {
       ) {
         this.addLineClampCSS(typographyEl, cellContainer);
       }
-      this.createTruncationTooltip(typographyEl, cellContainer);
+      if (!cellContainer.querySelector(this.IC_TOOLTIP_STRING))
+        this.createTruncationTooltip(typographyEl, cellContainer);
     }
   }
   private setTableDimensions = () => {

--- a/packages/canary-web-components/src/components/ic-data-table/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/story-data.ts
@@ -1502,6 +1502,7 @@ export const TruncationTooltip = (): HTMLElement => {
   dataTable.globalRowHeight = 40;
   dataTable.variableRowHeight = null;
   dataTable.setAttribute("truncation-pattern", "tooltip");
+  dataTable.setAttribute("sortable", "true");
 
   const resetButton = document.createElement("ic-button");
   resetButton.addEventListener("click", () => dataTable.resetRowHeights(40));


### PR DESCRIPTION
## Summary of the changes
Added check to stop duplicate tooltips being created in cells when it is already truncated, preventing content being forced right

## Related issue
#2819 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.