### PR TITLE
2826 Added ability to slot other elements into radio-option `additional-field` slot

### DIFF
--- a/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadio.cy.tsx
@@ -1,4 +1,4 @@
-/// <reference types="Cypress" />
+/// <reference types="cypress" />
 
 import React from "react";
 import { mount } from "cypress/react";
@@ -20,6 +20,8 @@ import {
   TabbableSelected,
   ConditionalDynamicTextFieldValue,
   InAForm,
+  RadioGroupInAdditionalField,
+  StaticChildRadioGroup,
 } from "./IcRadioTestData";
 import {
   HAVE_PROP,
@@ -31,6 +33,7 @@ import {
   HAVE_ATTR,
   NOT_BE_VISIBLE,
   HAVE_BEEN_CALLED,
+  BE_VISIBLE,
 } from "../utils/constants";
 import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
 
@@ -40,6 +43,7 @@ const IC_BUTTON = "ic-button";
 const BUTTON = "button";
 const INPUT = "input";
 const TEXT_FIELD_SELECTOR = "ic-text-field";
+const CONTAINER_CLASS = ".container";
 const DEFAULT_TEST_THRESHOLD = 0.026;
 
 describe("IcRadio end-to-end tests", () => {
@@ -126,7 +130,7 @@ describe("IcRadio end-to-end tests", () => {
     mount(<Uncontrolled />);
 
     cy.spy(window.console, "log").as("spyWinConsoleLog");
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get("@spyWinConsoleLog").should(HAVE_BEEN_CALLED_WITH, true);
   });
 
@@ -158,10 +162,10 @@ describe("IcRadio end-to-end tests", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
 
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).shadow().find(CONTAINER_CLASS).click();
     cy.realPress("ArrowDown");
     cy.get(RADIO_SELECTOR).eq(2).should(HAVE_PROP, "selected", false);
     cy.realPress("ArrowUp");
@@ -174,11 +178,11 @@ describe("IcRadio end-to-end tests", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", true);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", false);
     cy.findShadowEl(TEXT_FIELD_SELECTOR, INPUT).type("test");
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "value", "test");
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).shadow().find(CONTAINER_CLASS).click();
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", true);
   });
 
@@ -190,20 +194,20 @@ describe("IcRadio end-to-end tests", () => {
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should(NOT_BE_VISIBLE);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
-    cy.get(TEXT_FIELD_SELECTOR).eq(0).should("be.visible");
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
+    cy.get(TEXT_FIELD_SELECTOR).eq(0).should(BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should(NOT_BE_VISIBLE);
 
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).shadow().find(CONTAINER_CLASS).click();
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(NOT_BE_VISIBLE);
-    cy.get(TEXT_FIELD_SELECTOR).eq(1).should("be.visible");
+    cy.get(TEXT_FIELD_SELECTOR).eq(1).should(BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(2).should(NOT_BE_VISIBLE);
 
-    cy.get(RADIO_SELECTOR).eq(2).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(2).shadow().find(CONTAINER_CLASS).click();
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(NOT_BE_VISIBLE);
     cy.get(TEXT_FIELD_SELECTOR).eq(1).should(NOT_BE_VISIBLE);
-    cy.get(TEXT_FIELD_SELECTOR).eq(2).should("be.visible");
+    cy.get(TEXT_FIELD_SELECTOR).eq(2).should(BE_VISIBLE);
   });
 
   it("should emit icChange and icCheck events when radio option is selected", () => {
@@ -221,7 +225,7 @@ describe("IcRadio end-to-end tests", () => {
       cy.stub().as("icCheck")
     );
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
 
     cy.get("@icChange").should(HAVE_BEEN_CALLED);
@@ -304,7 +308,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
     cy.realPress("Tab");
     cy.get(TEXT_FIELD_SELECTOR).eq(0).should(HAVE_FOCUS);
@@ -315,7 +319,7 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
     cy.get(TEXT_FIELD_SELECTOR).should(HAVE_PROP, "disabled", false);
     cy.realPress("ArrowDown");
@@ -345,7 +349,7 @@ describe("IcRadio end-to-end tests", () => {
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
     cy.spy(window.console, "log").as("spyWinConsoleLog");
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
     cy.get("input[type='submit']").click();
     cy.get("@spyWinConsoleLog").should(
@@ -359,12 +363,58 @@ describe("IcRadio end-to-end tests", () => {
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
 
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", true);
 
     cy.get("input[type='reset']").click();
 
     cy.get(RADIO_SELECTOR).eq(0).should(HAVE_PROP, "selected", false);
+  });
+
+  it("should handle keyboard navigation of a slotted radio-group within an additional-field", () => {
+    mount(<RadioGroupInAdditionalField />);
+
+    cy.checkHydrated(RADIO_GROUP_SELECTOR);
+
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find("input").focus();
+    cy.realPress("Tab").realPress("ArrowDown");
+
+    cy.get(`${RADIO_SELECTOR}[label="child-option-2"]`).should(
+      HAVE_PROP,
+      "selected",
+      true
+    );
+    cy.get(`${RADIO_SELECTOR}[label="option2"]`).should(
+      HAVE_PROP,
+      "selected",
+      false
+    );
+  });
+
+  it("should select parent radio if a child radio is selected when additionFieldDisplay is static", () => {
+    mount(<StaticChildRadioGroup />);
+
+    cy.checkHydrated(RADIO_GROUP_SELECTOR);
+
+    cy.get(`${RADIO_SELECTOR}[label="option2"]`).should(
+      HAVE_PROP,
+      "selected",
+      false
+    );
+
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find("input").focus();
+    cy.realPress("Tab").realPress("Space");
+
+    cy.get(`${RADIO_SELECTOR}[label="child-option-1"]`).should(
+      HAVE_PROP,
+      "selected",
+      true
+    );
+    cy.get(`${RADIO_SELECTOR}[label="option2"]`).should(
+      HAVE_PROP,
+      "selected",
+      true
+    );
   });
 });
 
@@ -528,7 +578,7 @@ describe("IcRadio visual regression and a11y tests", () => {
     mount(<ConditionalDynamic />);
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
-    cy.get(RADIO_SELECTOR).eq(0).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(0).shadow().find(CONTAINER_CLASS).click();
 
     cy.checkA11yWithWait();
     cy.compareSnapshot({
@@ -541,7 +591,7 @@ describe("IcRadio visual regression and a11y tests", () => {
     mount(<ConditionalDynamic />);
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).shadow().find(CONTAINER_CLASS).click();
 
     cy.checkA11yWithWait();
     cy.compareSnapshot({
@@ -591,7 +641,7 @@ describe("IcRadio visual regression tests in high contrast mode", () => {
     mount(<ConditionalDynamic />);
 
     cy.checkHydrated(RADIO_GROUP_SELECTOR);
-    cy.get(RADIO_SELECTOR).eq(1).shadow().find(".container").click();
+    cy.get(RADIO_SELECTOR).eq(1).shadow().find(CONTAINER_CLASS).click();
 
     cy.compareSnapshot({
       name: "conditional-dynamic-high-contrast",

--- a/packages/react/src/component-tests/IcRadio/IcRadioTestData.tsx
+++ b/packages/react/src/component-tests/IcRadio/IcRadioTestData.tsx
@@ -413,3 +413,68 @@ export const InAForm = () => {
     </form>
   );
 };
+
+export const RadioGroupInAdditionalField = (): JSX.Element => (
+  <IcRadioGroup label="Parent" name="radio-group-1">
+    <IcRadioOption
+      additional-field-display="dynamic"
+      value="valueName1"
+      label="option1"
+      selected
+    >
+      <IcRadioGroup
+        slot="additional-field"
+        helperText="Child Group Helper Text"
+        label="Children"
+        name="radio-group-2"
+      >
+        <IcRadioOption
+          key="child-option-1"
+          label="child-option-1"
+          value="child-option-1"
+        ></IcRadioOption>
+        <IcRadioOption
+          key="child-option-2"
+          label="child-option-2"
+          value="child-option-2"
+        ></IcRadioOption>
+      </IcRadioGroup>
+    </IcRadioOption>
+    <IcRadioOption
+      additional-field-display="dynamic"
+      value="valueName2"
+      label="option2"
+    >
+      <IcTextField
+        slot="additional-field"
+        placeholder="Placeholder"
+        label="What's your favourite type of coffee?"
+      />
+    </IcRadioOption>
+  </IcRadioGroup>
+);
+
+export const StaticChildRadioGroup = (): JSX.Element => (
+  <IcRadioGroup label="Conditional static" name="1">
+    <IcRadioOption value="valueName1" label="option1" />
+    <IcRadioOption value="valueName2" label="option2">
+      <IcRadioGroup
+        slot="additional-field"
+        helperText="Child Group Helper Text"
+        label="Children"
+        name="radio-group-2"
+      >
+        <IcRadioOption
+          key="child-option-1"
+          label="child-option-1"
+          value="child-option-1"
+        ></IcRadioOption>
+        <IcRadioOption
+          key="child-option-2"
+          label="child-option-2"
+          value="child-option-2"
+        ></IcRadioOption>
+      </IcRadioGroup>
+    </IcRadioOption>
+  </IcRadioGroup>
+);

--- a/packages/react/src/stories/ic-radio-group.stories.mdx
+++ b/packages/react/src/stories/ic-radio-group.stories.mdx
@@ -112,18 +112,30 @@ import { useState, useEffect, useRef } from "react";
       <IcRadioOption
         additionalFieldDisplay="dynamic"
         value="valueName1"
-        label="option1"
+        label="Option with Radio as conditional slotted additional field"
       >
-        <IcTextField
+        <IcRadioGroup
           slot="additional-field"
-          placeholder="Placeholder"
-          label="What's your favourite type of coffee? "
-        />
+          helperText="Child Group Helper Text"
+          label="Children"
+          name="radio-group-2"
+        >
+          <IcRadioOption
+            key="child-option-1"
+            label="child-option-1"
+            value="child-option-1"
+          ></IcRadioOption>
+          <IcRadioOption
+            key="child-option-2"
+            label="child-option-2"
+            value="child-option-2"
+          ></IcRadioOption>
+        </IcRadioGroup>
       </IcRadioOption>
       <IcRadioOption
         additionalFieldDisplay="dynamic"
         value="valueName2"
-        label="option2 - error example"
+        label="Option with Text-field as conditional slotted additional field"
       >
         <IcTextField
           validationStatus="error"
@@ -136,13 +148,9 @@ import { useState, useEffect, useRef } from "react";
       <IcRadioOption
         additionalFieldDisplay="dynamic"
         value="valueName3"
-        label="option3"
+        label="Option with Button as conditional slotted additional field"
       >
-        <IcTextField
-          slot="additional-field"
-          placeholder="Placeholder"
-          label="What's your favourite type of coffee? "
-        />
+        <IcButton slot="additional-field">Hello world</IcButton>
       </IcRadioOption>
     </IcRadioGroup>
   </Story>
@@ -152,14 +160,32 @@ import { useState, useEffect, useRef } from "react";
 
 <Canvas>
   <Story name="Conditional static">
-    <IcRadioGroup label="Conditional dynamic" name="1">
+    <IcRadioGroup label="Conditional static" name="1">
       <IcRadioOption value="valueName1" label="option1">
         <IcTextField
           slot="additional-field"
           label="What's your favourite type of coffee?"
         />
       </IcRadioOption>
-      <IcRadioOption value="valueName2" label="option2" />
+      <IcRadioOption value="valueName2" label="option2">
+        <IcRadioGroup
+          slot="additional-field"
+          helperText="Child Group Helper Text"
+          label="Children"
+          name="radio-group-2"
+        >
+          <IcRadioOption
+            key="child-option-1"
+            label="child-option-1"
+            value="child-option-1"
+          ></IcRadioOption>
+          <IcRadioOption
+            key="child-option-2"
+            label="child-option-2"
+            value="child-option-2"
+          ></IcRadioOption>
+        </IcRadioGroup>
+      </IcRadioOption>
     </IcRadioGroup>
   </Story>
 </Canvas>

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.mdx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.mdx
@@ -155,24 +155,39 @@ import readme from "./readme.md";
           document
             .querySelector("ic-radio-group")
             .addEventListener("icChange", handleIcChange);
+          document
+            .querySelector("ic-button")
+            .addEventListener("click", () => alert("Button"));
         </script>
         <ic-radio-group label="Conditional dynamic" name="1">
           <ic-radio-option
             additional-field-display="dynamic"
             value="valueName1"
-            label="option1"
+            label="Option with Radio as conditional slotted additional field"
             selected
           >
-            <ic-text-field
+            <ic-radio-group
               slot="additional-field"
-              placeholder="Placeholder"
-              label="What's your favourite type of coffee?"
-            ></ic-text-field>
+              helperText="Child Group Helper Text"
+              label="Children"
+              name="radio-group-2"
+            >
+              <ic-radio-option
+                key="child-option-1"
+                label="child-option-1"
+                value="child-option-1"
+              ></ic-radio-option>
+              <ic-radio-option
+                key="child-option-2"
+                label="child-option-2"
+                value="child-option-2"
+              ></ic-radio-option>
+            </ic-radio-group>
           </ic-radio-option>
           <ic-radio-option
             additional-field-display="dynamic"
             value="valueName2"
-            label="option2 - error example"
+            label="Option with Text-field as conditional slotted additional field"
           >
             <ic-text-field
               validation-status="error"
@@ -186,13 +201,9 @@ import readme from "./readme.md";
           <ic-radio-option
             additional-field-display="dynamic"
             value="valueName3"
-            label="option3"
+            label="Option with Button as conditional slotted additional field"
           >
-            <ic-text-field
-              slot="additional-field"
-              placeholder="Placeholder"
-              label="What's your favourite type of coffee?"
-            ></ic-text-field>
+            <ic-button slot="additional-field">Hello world</ic-button>
           </ic-radio-option>
         </ic-radio-group>
       `
@@ -214,6 +225,23 @@ import readme from "./readme.md";
             ></ic-text-field>
           </ic-radio-option>
           <ic-radio-option value="valueName2" label="option2">
+            <ic-radio-group
+              slot="additional-field"
+              helperText="Child Group Helper Text"
+              label="Children"
+              name="radio-group-2"
+            >
+              <ic-radio-option
+                key="child-option-1"
+                label="child-option-1"
+                value="child-option-1"
+              ></ic-radio-option>
+              <ic-radio-option
+                key="child-option-2"
+                label="child-option-2"
+                value="child-option-2"
+              ></ic-radio-option>
+            </ic-radio-group>
           </ic-radio-option>
         </ic-radio-group>
       `

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -149,25 +149,27 @@ export class RadioGroup {
   }
 
   @Listen("icCheck")
-  selectHandler({ detail, target }: CustomEvent<IcValueEventDetail>): void {
-    this.checkedValue = detail.value;
-    const selectedOption = target as HTMLIcRadioOptionElement;
-    this.icChange.emit({
-      value: this.checkedValue,
-      selectedOption: {
-        radio: selectedOption,
-        textFieldValue: selectedOption?.querySelector("ic-text-field")?.value,
-      },
-    });
-
-    if (this.radioOptions !== undefined) {
-      this.radioOptions.forEach((radioOption, index) => {
-        radioOption.selected = selectedOption === radioOption;
-        if (radioOption.selected) {
-          this.selectedChild = index;
-        }
+  selectHandler(event: CustomEvent<IcValueEventDetail>): void {
+    if ((event.target as HTMLElement).parentElement === this.el) {
+      this.checkedValue = event.detail.value;
+      const selectedOption = event.target as HTMLIcRadioOptionElement;
+      this.icChange.emit({
+        value: this.checkedValue,
+        selectedOption: {
+          radio: selectedOption,
+          textFieldValue: selectedOption?.querySelector("ic-text-field")?.value,
+        },
       });
-      this.setFirstRadioOptionTabIndex(this.selectedChild > 0 ? -1 : 0);
+
+      if (this.radioOptions !== undefined) {
+        this.radioOptions.forEach((radioOption, index) => {
+          radioOption.selected = selectedOption === radioOption;
+          if (radioOption.selected) {
+            this.selectedChild = index;
+          }
+        });
+        this.setFirstRadioOptionTabIndex(this.selectedChild > 0 ? -1 : 0);
+      }
     }
   }
 
@@ -223,6 +225,7 @@ export class RadioGroup {
   }
 
   private handleKeyDown = (event: KeyboardEvent): void => {
+    event.stopPropagation();
     switch (event.key) {
       case "ArrowDown":
       case "ArrowRight":
@@ -278,7 +281,9 @@ export class RadioGroup {
   private setRadioOptions = () => {
     this.selectedChild = -1;
     this.checkedValue = "";
-    this.radioOptions = Array.from(this.el.querySelectorAll("ic-radio-option"));
+    this.radioOptions = Array.from(this.el.children).filter(
+      (el) => el.tagName === "IC-RADIO-OPTION"
+    ) as HTMLIcRadioOptionElement[];
     if (this.radioOptions.length > 0) {
       this.radioOptions.forEach((radioOption, index) => {
         if (!radioOption.selected) {

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
@@ -155,7 +155,10 @@ describe("ic-radio-group", () => {
 
     const callbackFn = jest.fn();
     page.doc.addEventListener("icChange", callbackFn);
-    page.rootInstance.selectHandler({ detail: { value: "true" } });
+    page.rootInstance.selectHandler({
+      detail: { value: "true" },
+      target: page.root.querySelector("ic-radio-option"),
+    });
     await page.waitForChanges();
 
     expect(callbackFn).toHaveBeenCalled();

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
@@ -6,7 +6,8 @@
   width: fit-content;
 }
 
-:host([additional-field-display="static"]) ::slotted(ic-text-field) {
+:host([additional-field-display="static"])
+  ::slotted([slot="additional-field"]) {
   margin-top: calc(var(--ic-space-sm) / 2);
   margin-left: var(--ic-space-xl);
 }

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
@@ -127,6 +127,16 @@ export class RadioOption {
    * Emitted when the radio option is selected.
    */
   @Event() icCheck: EventEmitter<IcValueEventDetail>;
+  @Listen("icCheck")
+  handleCheck(ev: CustomEvent<IcValueEventDetail>): void {
+    const children = Array.from(this.el.children);
+    const targetEl = ev.target as Element;
+    if (
+      this.additionalFieldDisplay === "static" &&
+      (children.includes(targetEl.parentElement) || children.includes(targetEl))
+    )
+      this.icCheck.emit({ value: this.value });
+  }
 
   /**
    * @deprecated This event should not be used anymore. Use icCheck instead.
@@ -225,7 +235,7 @@ export class RadioOption {
 
       if (this.hasAdditionalField) {
         this.value =
-          this.el.querySelector(TEXT_FIELD_SELECTOR).value ||
+          this.el.querySelector(TEXT_FIELD_SELECTOR)?.value ||
           this.defaultRadioValue;
       }
 
@@ -273,7 +283,7 @@ export class RadioOption {
 
     return (
       <Host onClick={handleClick} class={{ disabled }}>
-        <div class={{ ["container"]: true, disabled }}>
+        <div class={{ container: true, disabled }}>
           <div>
             <input
               role="radio"


### PR DESCRIPTION
## Summary of the changes
- Adjusted some event listeners to not propagate the event higher up the tree. This is for when (as in the example stackblitz in the ticket) a radio-group is slotted as a child element in the additional field. This enables keyboard interaction without overriding the radio-group higher up the tree.
- Added a test for the keyboard interaction.
- Updated storybook to show different elements being used in the slot.

## Related issue
#2826 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.