### PR TITLE
Prevent IcDataTable action element clicks from selecting the table row

### DIFF
--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
@@ -90,6 +90,7 @@ const PAGINATION_GO_TO_PAGE_TEXT_FIELD_SELECTOR =
 const PAGINATION_GO_TO_PAGE_BUTTON_SELECTOR = ".go-to-page-holder ic-button";
 const ITEMS_PER_PAGE_SELECTOR = ".items-per-page-input";
 const ACTION_ELEMENT = "action-element";
+const TABLE_ROW_SELECTED = "table-row-selected";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const BasicDataTable = (dataTableProps?: any): ReactElement => (
@@ -1091,7 +1092,7 @@ describe("IcDataTables", () => {
     cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
       .eq(0)
       .find("span")
-      .should(HAVE_CLASS, "action-element")
+      .should(HAVE_CLASS, ACTION_ELEMENT)
       .find("ic-button")
       .should("be.visible");
 
@@ -1142,7 +1143,7 @@ describe("IcDataTables", () => {
       .should(HAVE_CSS, "grid-template-columns", "156.797px 32px");
 
     cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
-      .should(HAVE_CLASS, "action-element")
+      .should(HAVE_CLASS, ACTION_ELEMENT)
       .should(HAVE_CSS, "justify-content", "right");
   });
 
@@ -4470,6 +4471,38 @@ describe("IcDataTable row selection", () => {
         capture: "viewport",
       },
     });
+  });
+
+  it("should not highlight the selected row when the action element click event is stopped from propagating", () => {
+    mount(
+      <IcDataTable
+        columns={COLS}
+        data={ACTION_DATA_ELEMENTS}
+        caption="Data tables"
+      ></IcDataTable>
+    );
+
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+    cy.get(DATA_TABLE_SELECTOR)
+      .shadow()
+      .find(`[data-testid="copy-button"]`)
+      .eq(0)
+      .click();
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "tr")
+      .eq(1)
+      .should(NOT_HAVE_CLASS, TABLE_ROW_SELECTED);
+
+    cy.get(DATA_TABLE_SELECTOR)
+      .shadow()
+      .find(`[data-testid="copy-button"]`)
+      .eq(1)
+      .click();
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "tr")
+      .eq(2)
+      .should(HAVE_CLASS, TABLE_ROW_SELECTED);
   });
 
   it("should emit icSelectedRowChange event when the selected row changes", () => {

--- a/packages/canary-react/src/stories/ic-data-table.stories.mdx
+++ b/packages/canary-react/src/stories/ic-data-table.stories.mdx
@@ -2108,7 +2108,10 @@ const DATA = [
     firstName: {
       data: "Joe",
       actionElement: `<ic-button variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons">  <svg  aria-label="refresh button"  xmlns="http://www.w3.org/2000/svg"    width="24"    height="24"    viewBox="0 0 24 24"    fill="#000000"  >    <path d="M0 0h24v24H0V0z" fill="none"></path>    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>  </svg></ic-button>`,
-      actionOnClick: () => console.log("hello")
+      actionOnClick: (event: Event) => {
+        event?.stopPropagation();
+        console.log("hello");
+      },
     },
     lastName: "Bloggs",
     age: 30,

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -1525,7 +1525,7 @@ export class DataTable {
                   // eslint-disable-next-line react/jsx-no-bind
                   onClick={
                     cell.actionOnClick
-                      ? () => this.handleClick(cell.actionOnClick)
+                      ? (event) => this.handleClick(event, cell.actionOnClick)
                       : undefined
                   }
                 ></span>
@@ -2113,7 +2113,8 @@ export class DataTable {
     });
   };
 
-  private handleClick = (callback: () => void) => callback();
+  private handleClick = (event: Event, callback: (event: Event) => void) =>
+    callback(event);
 
   private renderTableBody = (
     data: IcDataTableDataType[],

--- a/packages/canary-web-components/src/components/ic-data-table/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/story-data.ts
@@ -22,11 +22,11 @@ const userIconSVG =
 const alertIconSVG =
   '<svg aria-label="alert-icon" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 24 24" fill="#000000"><path d="M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z"/></svg>';
 const copyButton =
-  '<ic-button variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="copy-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg> </ic-button>';
+  '<ic-button data-testid="copy-button" variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="copy-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg> </ic-button>';
 const cellphoneButton =
-  '<ic-button variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="cellphone-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M17,19H7V5H17M17,1H7C5.89,1 5,1.89 5,3V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V3C19,1.89 18.1,1 17,1Z"/></svg> </ic-button>';
+  '<ic-button data-testid="cellphone-button" variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="cellphone-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M17,19H7V5H17M17,1H7C5.89,1 5,1.89 5,3V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V3C19,1.89 18.1,1 17,1Z"/></svg> </ic-button>';
 const downloadButton =
-  '<ic-button variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="download-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg> </ic-button>';
+  '<ic-button data-testid="download-button" variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="download-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg> </ic-button>';
 
 // TODO: Add columnOptions
 export const COLS: IcDataTableColumnObject[] = [
@@ -983,7 +983,8 @@ export const ACTION_DATA_ELEMENTS = [
     firstName: {
       data: "Joe",
       actionElement: `${downloadButton}${cellphoneButton}${copyButton}`,
-      actionOnClick: () => {
+      actionOnClick: (event: Event) => {
+        event?.stopPropagation();
         console.log("hello");
       },
     },

--- a/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
@@ -415,7 +415,10 @@ const dataWithActionElement = [
     name: {
       data: name1,
       actionElement: `<ic-button size="small" variant="icon"  aria-label="you can disable tooltips on icon buttons"  disable-tooltip="true">  <svg    xmlns="http://www.w3.org/2000/svg"    width="24"    height="24"    viewBox="0 0 24 24"    fill="#000000"  >    <path d="M0 0h24v24H0V0z" fill="none"></path>    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>  </svg></ic-button>`,
-      actionOnClick: () => console.log("hello"),
+      actionOnClick: (event: Event) => {
+        event?.stopPropagation();
+        console.log("hello");
+      },
     },
     age: 36,
     department: "Accounts",


### PR DESCRIPTION
## Summary of the changes
Provide access to the the click event in the Data Table action element, thereby allowing the event propagation to be stopped in individual data table action element click handlers.

This is to prevent IcDataTable rows from becoming selected when the row contains an IcButton in an action element and the button is clicked.

![IcButton prevent propagation](https://github.com/user-attachments/assets/dd85eea5-5ca7-4066-aba0-0efd23ca6b5f)

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.