### PR TITLE
2894 internal issue 2841 icdatatable truncates tooltips passed in via slots

### DIFF
--- a/packages/canary-react/src/stories/ic-data-table.stories.mdx
+++ b/packages/canary-react/src/stories/ic-data-table.stories.mdx
@@ -1088,16 +1088,17 @@ const DataTable = () => {
 export default DataTable;
 ```
 
-### Links and elements in data
+### Links and slotted elements in data
 
 Custom HTML elements can be slotted or passed via the `data` prop to display in certain cells. When using the slotted method, the slot name follows the format of `{COLUMN_TAG}-{ROW_INDEX}`.
 
 <Canvas withSource="none">
-  <Story name="Links and Elements in data">
+  <Story name="Links and slotted elements in data">
     <IcDataTable
-      caption="Links and Elements in data"
+      caption="Links and slotted elements in data"
       columns={COLS_ELEMENTS}
       data={DATA_REACT_ELEMENTS}
+      showPagination
     >
       {DATA_REACT_ELEMENTS.map((_, index) => (
         <>
@@ -1105,26 +1106,27 @@ Custom HTML elements can be slotted or passed via the `data` prop to display in 
             key={`actions-${index}`}
             variant="destructive"
             slot={`actions-${index}`}
+            title="Delete row (top level tooltip)"
             onClick={() => console.log("Delete")}
           >
             Delete
           </IcButton>
+          <div key={`actions2-${index}`} slot={`actions2-${index}`}>
           <IcButton
-            key={`actions2-${index}`}
             variant="icon"
-            slot={`actions2-${index}`}
-            aria-label="Delete row"
+            aria-label="Delete row (nested tooltip)"
             onClick={() => console.log("Delete")}
           >
             <SlottedSVG path={mdiDelete} viewBox="0 0 24 24" />
           </IcButton>
+          </div>
         </>
       ))}
     </IcDataTable>
   </Story>
 </Canvas>
 
-#### Links and elements in data code example
+#### Links and slotted elements in data code example
 
 ```tsx
 import * as React from "react";
@@ -1164,11 +1166,33 @@ const data = [
 
 const DataTable = () => (
   <IcDataTable
-    caption="Links and Elements in data"
+    caption="Links and slotted elements in data"
     columns={columns}
     data={data}
+    showPagination="true"
   >
-    {data.map((_, index) => <IcButton key={index} slot={`actions-${index}`} variant="destructive" onClick={() => console.log("Delete")}>Delete</IcButton>)}
+    {data.map((_, index) => (
+        <>
+          <IcButton
+            key={`actions-${index}`}
+            variant="destructive"
+            slot={`actions-${index}`}
+            title="Delete row (top level tooltip)"
+            onClick={() => console.log("Delete")}
+          >
+            Delete
+          </IcButton>
+          <div key={`actions2-${index}`} slot={`actions2-${index}`}>
+          <IcButton
+            variant="icon"
+            aria-label="Delete row (nested tooltip)"
+            onClick={() => console.log("Delete")}
+          >
+            <SlottedSVG path={mdiDelete} viewBox="0 0 24 24" />
+          </IcButton>
+          </div>
+        </>
+      ))}
   </IcDataTable>
 );
 

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -2099,14 +2099,26 @@ export class DataTable {
   }
 
   private fixCellTooltip = (element: HTMLElement) => {
-    const tooltipEl = (
-      element.tagName === "IC-TOOLTIP"
-        ? element
-        : element.shadowRoot?.querySelector(this.IC_TOOLTIP_STRING)
-    ) as HTMLIcTooltipElement;
+    let tooltip: HTMLIcTooltipElement;
 
-    if (tooltipEl) {
-      tooltipEl.setExternalPopperProps({
+    if (element.tagName === "IC-TOOLTIP") {
+      tooltip = element as HTMLIcTooltipElement;
+    } else if (element.shadowRoot?.querySelector(this.IC_TOOLTIP_STRING)) {
+      tooltip = element.shadowRoot?.querySelector(
+        this.IC_TOOLTIP_STRING
+      ) as HTMLIcTooltipElement;
+    } else {
+      if (element.children?.length > 0) {
+        Array.from(element.children).forEach((el) => {
+          this.fixCellTooltip(el as HTMLElement);
+        });
+      } else {
+        return;
+      }
+    }
+
+    if (tooltip) {
+      tooltip.setExternalPopperProps({
         strategy: "fixed",
       });
     }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Using a code snippet provided by the internal customer, i've recreated tooltip overflow issues that they were finding in the data table (screenshots available on internal ticket) and then, using code suggested by a colleague i've made fixCellTootips search recursively through slotted elements to modify tooltips. 

Seemingly this has fixed the issue - as demonstrated by changes to the *Links and slotted elements in data* story

## Related issue
#2894 

## Checklist

### General 

- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 