### PR TITLE
fix(root): update where the release check is cut for the PR message

### DIFF
--- a/.github/workflows/ic-ui-kit-release.yml
+++ b/.github/workflows/ic-ui-kit-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run release check
         run: |
           RELEASE_CHECK=$((echo y; sleep 0.5; echo $'\n';) | npm run release-check)
-          echo "VERSION=$(echo $RELEASE_CHECK | cut -c 223-293)" >> $GITHUB_ENV
+          echo "VERSION=$(echo $RELEASE_CHECK | cut -c 75-342)" >> $GITHUB_ENV
           git stash
       - name: Create develop -> main PR
         run: |


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update where the release check is cut for the PR message so that we can read all of the versions
This should mean that we can see the whole message e.g.

@ukic/canary-react: 2.0.0-canary.33 => 2.0.0-canary.34 - @ukic/canary-web-components: 2.0.0-canary.33 => 2.0.0-canary.34 - @ukic/docs: 2.15.1 => 2.15.2 - @ukic/nextjs: 0.2.25 => 0.2.26 (private) - @ukic/react: 2.34.0 => 2.34.1 - @ukic/web-components: 2.34.0 => 2.35.0 

## Related issue
N/A