### PR TITLE
fix(web-components): fix double focus indicator on selected slotted s…

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -115,13 +115,6 @@ svg {
   outline: var(--ic-hc-focus-outline);
 }
 
-:host(.navigation-item-selected.dark) .link:focus,
-:host(.navigation-item.dark) ::slotted(a.active:focus) {
-  box-shadow: var(--ic-border-focus);
-  border-radius: var(--ic-border-radius);
-  outline: var(--ic-hc-focus-outline);
-}
-
 :host(.navigation-item) .link:active:not(:focus),
 :host(.navigation-item) ::slotted(a:active:not(:focus)) {
   background-color: var(--ic-theme-active);


### PR DESCRIPTION
## Summary of the changes
Fix double focus indicator on side nav item (with light theme colour / dark foreground) when it is selected and a slotted link is used.

<img src="https://github.com/user-attachments/assets/f01b1645-139f-4bc0-921a-9276dcdd838f" width="250">

(You can see the issue by going to the React storybook Theming side nav story (which makes all stories change to yellow / light theme colour) and then go to the [React Router story](https://mi6.github.io/ic-ui-kit/branches/develop/react/?path=/story/react-components-side-navigation--react-router)).


## Related issue
N/A - quick fix for issue raised by customer

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.