### PR TITLE
fix(web-components): fix double focus indicator on selected slotted s…

### DIFF
--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -128,13 +128,6 @@ svg {
   outline: var(--ic-hc-focus-outline);
 }
 
-:host(.navigation-item-selected.dark) .link:focus,
-:host(.navigation-item.dark) ::slotted(a.active:focus) {
-  box-shadow: var(--ic-border-focus);
-  border-radius: var(--ic-border-radius);
-  outline: var(--ic-hc-focus-outline);
-}
-
 :host(.navigation-item) .link:active:not(:focus),
 :host(.navigation-item) ::slotted(a:active:not(:focus)) {
   background-color: var(--ic-brand-active);


### PR DESCRIPTION
## Summary of the changes
Cherry-pick into v3 of PR #3159 

Fix double focus indicator on side nav item (with light theme colour / dark foreground) when it is selected and a slotted link is used.

## Related issue
N/A