### PR TITLE
2402 a11y violation on auto dismiss toast

### DIFF
--- a/packages/react/src/component-tests/IcToast/IcToast.cy.tsx
+++ b/packages/react/src/component-tests/IcToast/IcToast.cy.tsx
@@ -226,7 +226,7 @@ describe("IcToast visual regression and a11y tests", () => {
     cy.checkHydrated(IC_TOAST_SELECTOR);
     cy.get(IC_BUTTON_SELECTOR).click().wait(500);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "/auto-dismiss",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.004),

--- a/packages/web-components/src/components/ic-toast/ic-toast.tsx
+++ b/packages/web-components/src/components/ic-toast/ic-toast.tsx
@@ -388,7 +388,7 @@ export class Toast {
               monochrome
               size="icon"
               progress={this.timerProgress}
-              description=""
+              description="Dismiss timer"
             ></ic-loading-indicator>
           ) : (
             <ic-button

--- a/packages/web-components/src/components/ic-toast/test/basic/ic-toast.spec.ts
+++ b/packages/web-components/src/components/ic-toast/test/basic/ic-toast.spec.ts
@@ -128,7 +128,7 @@ describe("ic-toast component", () => {
               </ic-typography>
             </div>
           </div>
-          <ic-loading-indicator class="toast-dismiss-timer" description="" monochrome="" progress="100" size="icon" theme="dark"></ic-loading-indicator>
+          <ic-loading-indicator class="toast-dismiss-timer" description="Dismiss timer" monochrome="" progress="100" size="icon" theme="dark"></ic-loading-indicator>
         </div>
       </mock:shadow-root>
     </ic-toast>`);


### PR DESCRIPTION
## Summary of the changes
Added a description to auto dismiss toast loading indicator - an empty description was causing an a11y failure due to the loading indicator having an empty aria-label. The empty description was recently added to prevent the default aria-label of "Loading" being read out be screen readers - see [issue 1291](https://github.com/mi6/ic-ui-kit/issues/1291 ). Though the new description will be read out by screen readers, it prevents the a11y failure and the more relevant description should mean a better user experience.

## Related issue
#2402 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 