### PR TITLE
fix(web-components): ic-popover-menu close sub menus fix

### DIFF
--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.stories.mdx
@@ -400,6 +400,8 @@ import menuGroupReadme from "../ic-menu-group/readme.md";
               variant="toggle"
             ></ic-menu-item>
           </ic-popover-menu>
+        </div>
+        <div>
           <ic-popover-menu anchor="button-2" aria-label="popover" id="popover2">
             <ic-menu-item label="Copy code" disabled="true"></ic-menu-item>
             <ic-menu-group label="View">

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
@@ -72,7 +72,17 @@ export class PopoverMenu {
 
   @Watch("open")
   watchOpenHandler(): void {
+    const popoverArr = this.el.parentElement?.querySelectorAll(
+      `ic-popover-menu`
+    ) as NodeListOf<HTMLIcPopoverMenuElement>;
     if (this.open) {
+      if (popoverArr.length > 0) {
+        popoverArr.forEach((popover) => {
+          if (popover !== this.el) {
+            popover.open = false;
+          }
+        });
+      }
       if (
         this.parentPopover !== undefined &&
         !this.popoverMenuEls.some((menuItem) => menuItem.id)
@@ -84,6 +94,13 @@ export class PopoverMenu {
       // Needed so that anchorEl isn't always focused
       setTimeout(this.setButtonFocus, 50);
     } else if (this.popperInstance) {
+      if (popoverArr.length > 0) {
+        popoverArr.forEach((popover) => {
+          if (popover !== this.el) {
+            popover.open = false;
+          }
+        });
+      }
       this.popperInstance.destroy();
       this.popperInstance = null;
     }


### PR DESCRIPTION
fix for when ic-popover-menu sub-menu is open and the anchor button is clicked all menus close

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
To test go to the default storybook story, open the menu, click into a sub menu, click the anchor/menu button. All menus should close.

## Related issue
#2853 
