### PR TITLE
fix(web-components): add focus indicator, hover state and pressed sta…

### DIFF
--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.css
@@ -93,6 +93,24 @@
   fill: var(--ic-footer-icon);
 }
 
+:host(.footer-logo-link) {
+  transition: var(--ic-easing-transition-fast);
+}
+
+:host(.footer-logo-link:hover) {
+  background-color: var(--ic-footer-hover);
+}
+
+:host(.footer-logo-link:active) {
+  background-color: var(--ic-footer-pressed);
+}
+
+:host(.footer-logo-link:focus) {
+  box-shadow: var(--ic-border-focus);
+  border-radius: var(--ic-border-radius);
+  outline: var(--ic-hc-focus-outline);
+}
+
 @media (forced-colors: active) {
   :host(.footer-link-light) ::slotted(svg),
   :host(.footer-link-dark) ::slotted(svg) {

--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.tsx
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.tsx
@@ -100,6 +100,8 @@ export class FooterLink {
     } = this;
     const { small, grouped } = footerConfig;
 
+    const isLogoLink = !!this.el.closest("div[slot='logo']");
+
     return (
       <Host
         class={{
@@ -108,6 +110,7 @@ export class FooterLink {
             small ? "small" : "sparse"
           }`]: true,
           [`footer-link-${this.foregroundColor}`]: true,
+          "footer-logo-link": isLogoLink,
         }}
         role="listitem"
       >


### PR DESCRIPTION
## Summary of the changes
Add focus indicator, hover state and pressed state to footer logo links.

## Related issue
#2190 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.