### PR TITLE
ci(root): improve RELEASE_CHECK file layout and check versions match

### DIFF
--- a/.github/workflows/ic-ui-kit-release-check.yml
+++ b/.github/workflows/ic-ui-kit-release-check.yml
@@ -24,8 +24,29 @@ jobs:
       - name: Run release check
         run: |
           RELEASE_CHECK=$((echo y; sleep 0.5; echo $'\n';) | npm run release-check)
-          echo "VERSION=$(echo $RELEASE_CHECK)" >> $GITHUB_ENV
+          RELEASE_CHECK=$(echo "$RELEASE_CHECK" | sed 's/ - @/\n- @/g')
+          echo "VERSION<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_CHECK" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
           git stash
+      - name: Extract and compare versions
+        run: |
+          REACT_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/react' | sed -n 's/.*=> \([0-9.]*\(-[a-zA-Z0-9.]*\)*\).*/\1/p')
+          WEB_COMPONENTS_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/web-components' | sed -n 's/.*=> \([0-9.]*\(-[a-zA-Z0-9.]*\)*\).*/\1/p')
+          CANARY_REACT_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/canary-react' | sed -n 's/.*=> \([0-9.]*-canary.[0-9]*\).*/\1/p')
+          CANARY_WEB_COMPONENTS_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/canary-web-components' | sed -n 's/.*=> \([0-9.]*-canary.[0-9]*\).*/\1/p')
+          echo "React version: $REACT_VERSION"
+          echo "Web Components version: $WEB_COMPONENTS_VERSION"
+          echo "Canary React version: $CANARY_REACT_VERSION"
+          echo "Canary Web Components version: $CANARY_WEB_COMPONENTS_VERSION"
+          if [ "$REACT_VERSION" != "$WEB_COMPONENTS_VERSION" ]; then
+            echo "Error: The versions of @ukic/react and @ukic/web-components packages are not identical."
+            exit 1
+          fi
+          if [ "$CANARY_REACT_VERSION" != "$CANARY_WEB_COMPONENTS_VERSION" ]; then
+            echo "Error: The versions of @ukic/canary-react and @ukic/canary-web-components packages are not identical."
+            exit 1
+          fi
       - name: Configure Git user
         run: |
           git config --global user.name ${{ secrets.USERNAME }}

--- a/.github/workflows/ic-ui-kit-release-v3-check.yml
+++ b/.github/workflows/ic-ui-kit-release-v3-check.yml
@@ -24,8 +24,29 @@ jobs:
       - name: Run release check
         run: |
           RELEASE_CHECK=$((echo y; sleep 0.5; echo $'\n';) | npm run release-check)
-          echo "VERSION=$(echo $RELEASE_CHECK)" >> $GITHUB_ENV
+          RELEASE_CHECK=$(echo "$RELEASE_CHECK" | sed 's/ - @/\n- @/g')
+          echo "VERSION<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_CHECK" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
           git stash
+      - name: Extract and compare versions
+        run: |
+          REACT_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/react' | sed -n 's/.*=> \([0-9.]*\(-[a-zA-Z0-9.]*\)*\).*/\1/p')
+          WEB_COMPONENTS_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/web-components' | sed -n 's/.*=> \([0-9.]*\(-[a-zA-Z0-9.]*\)*\).*/\1/p')
+          CANARY_REACT_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/canary-react' | sed -n 's/.*=> \([0-9.]*-canary.[0-9]*\).*/\1/p')
+          CANARY_WEB_COMPONENTS_VERSION=$(echo "${{ env.VERSION }}" | grep '@ukic/canary-web-components' | sed -n 's/.*=> \([0-9.]*-canary.[0-9]*\).*/\1/p')
+          echo "React version: $REACT_VERSION"
+          echo "Web Components version: $WEB_COMPONENTS_VERSION"
+          echo "Canary React version: $CANARY_REACT_VERSION"
+          echo "Canary Web Components version: $CANARY_WEB_COMPONENTS_VERSION"
+          if [ "$REACT_VERSION" != "$WEB_COMPONENTS_VERSION" ]; then
+            echo "Error: The versions of @ukic/react and @ukic/web-components packages are not identical."
+            exit 1
+          fi
+          if [ "$CANARY_REACT_VERSION" != "$CANARY_WEB_COMPONENTS_VERSION" ]; then
+            echo "Error: The versions of @ukic/canary-react and @ukic/canary-web-components packages are not identical."
+            exit 1
+          fi
       - name: Configure Git user
         run: |
           git config --global user.name ${{ secrets.USERNAME }}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
As a follow up to https://github.com/mi6/ic-ui-kit/pull/3156

improve the layout of the release check file, so it is easily readable on new lines. Additionally, the versions for react and web-components will be checked in canary/stable, including the v3 branches

## Related issue
#2765 