### PR TITLE
ci(root): fix v3 release script

### DIFF
--- a/.github/workflows/ic-ui-kit-release-v3-check.yml
+++ b/.github/workflows/ic-ui-kit-release-v3-check.yml
@@ -36,14 +36,14 @@ jobs:
           git push origin --delete release || true
       - name: Create release branch with latest versions
         run: |
-          git fetch origin develop
+          git fetch origin v3.0.0/develop
           RELEASE_BRANCH="release"
-          git checkout -b $RELEASE_BRANCH origin/develop
+          git checkout -b $RELEASE_BRANCH origin/v3.0.0/develop
           echo "${{ env.VERSION }}" > DEVELOPMENT_RELEASE_CHECK.md
           git add DEVELOPMENT_RELEASE_CHECK.md
           git commit -m "chore(release): update v3 development release version check file"
           git push origin $RELEASE_BRANCH
-      - name: Create release branch -> develop PR 
+      - name: Create release branch -> v3.0.0/develop PR 
         run: |
           curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/mi6/ic-ui-kit/pulls" -d '{"title":"V3 Release -> V3 Develop","body":"Updates in the file changes.","head":"v3.0.0/release","base":"v3.0.0/develop"}'
           


### PR DESCRIPTION
replace references to regular develop with v3 develop

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
V3 Release workflow has been getting 422 failures - we think this is because it was referencing the develop branch.

This change to the script replaces those references with ones for v3.0.0/develop