### PR TITLE
[IcPaginationBar]: itemsPerPage select fix

### DIFF
--- a/packages/canary-react/src/component-tests/IcPaginationBar/IcPaginationBar.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcPaginationBar/IcPaginationBar.cy.tsx
@@ -12,7 +12,10 @@ import {
   HAVE_TEXT,
 } from "@ukic/react/src/component-tests/utils/constants";
 import { setThresholdBasedOnEnv } from "@ukic/react/cypress/utils/helpers";
-import { PaginationBarItemsPerPage } from "./IcPaginationBarTestData";
+import {
+  PaginationBarItemsPerPage,
+  PaginationBarItemsPerPageWithButtons,
+} from "./IcPaginationBarTestData";
 
 const PAGINATION_BAR = "ic-pagination-bar";
 const DEFAULT_TEST_THRESHOLD = 0.027;
@@ -589,6 +592,65 @@ describe("IcPaginationBar end-to-end tests", () => {
       PAGINATION_BAR,
       "ic-typography.item-pagination-label"
     ).should(HAVE_TEXT, "1 - 10 of 100 rows");
+  });
+
+  it("should stay set to All when manually setting the totalItems to 5 and then 30 after initially setting to All", () => {
+    mount(<PaginationBarItemsPerPageWithButtons />);
+
+    cy.checkHydrated(PAGINATION_BAR);
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .click();
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find("li[role='option']")
+      .last()
+      .click();
+
+    cy.get(".set-5").click();
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "All");
+
+    cy.get(".set-30").click();
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "All");
+  });
+
+  it("should set items per page to 20 when manually setting totalItems to 5 and then 30 after initially setting to 20", () => {
+    mount(<PaginationBarItemsPerPageWithButtons />);
+
+    cy.checkHydrated(PAGINATION_BAR);
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .click();
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find("li[role='option'][data-value='20']")
+      .click();
+
+    cy.get(".set-5").click();
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "All");
+
+    cy.get(".set-30").click();
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "20");
   });
 });
 

--- a/packages/canary-react/src/component-tests/IcPaginationBar/IcPaginationBarTestData.tsx
+++ b/packages/canary-react/src/component-tests/IcPaginationBar/IcPaginationBarTestData.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { IcPaginationBar } from "../../components";
+import { IcButton } from "@ukic/react";
 
 export const PaginationBarItemsPerPage = (props) => (
   <IcPaginationBar
@@ -12,3 +13,29 @@ export const PaginationBarItemsPerPage = (props) => (
     {...props}
   />
 );
+
+export const PaginationBarItemsPerPageWithButtons = (props) => {
+  const [totalItems, setTotalItems] = useState(100);
+  const handleSetTotalItems = (value: number) => {
+    setTotalItems(value);
+  };
+  return (
+    <>
+      <IcPaginationBar
+        totalItems={totalItems}
+        showItemsPerPageControl
+        itemsPerPageOptions={[
+          { value: "10", label: "10" },
+          { value: "20", label: "20" },
+        ]}
+        {...props}
+      />
+      <IcButton className="set-5" onClick={() => handleSetTotalItems(5)}>
+        Set to 5
+      </IcButton>
+      <IcButton className="set-30" onClick={() => handleSetTotalItems(30)}>
+        Set to 30
+      </IcButton>
+    </>
+  );
+};

--- a/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.stories.mdx
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.stories.mdx
@@ -513,5 +513,5 @@ The `current-page` prop can be used to programmatically set the current page. If
   show-items-per-page-control="true"
   show-go-to-page-control="true"
   current-page="-1"
-></ic-pa
+></ic-pagination-bar>
 ```

--- a/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.tsx
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.tsx
@@ -34,6 +34,7 @@ export class PaginationBar {
   private pageInputTooltipEl: HTMLIcTooltipElement;
   private paginationBarEl: HTMLElement;
   private paginationEl: HTMLIcPaginationElement;
+  private userSetItemsPerPage: number;
 
   @Element() el: HTMLIcPaginationBarElement;
 
@@ -272,6 +273,8 @@ export class PaginationBar {
 
   private changeItemsPerPage = () => {
     this.setItemsPerPage(Number(this.pageDropdownEl.value));
+
+    this.userSetItemsPerPage = Number(this.pageDropdownEl.value);
   };
 
   private changePage = (page: number) => {
@@ -479,16 +482,25 @@ export class PaginationBar {
     this.setItemsPerPageOptions();
 
     let lastOptionValue = 0;
-    const updated = this.displayedItemsPerPageOptions.some(({ value }) => {
-      lastOptionValue = Number(value);
-      return this.itemsPerPage <= lastOptionValue;
-    });
 
-    this.setItemsPerPage(
-      updated || (!updated && this.itemsPerPage > lastOptionValue)
-        ? lastOptionValue
-        : this.itemsPerPage
-    );
+    if (this.userSetItemsPerPage) {
+      this.displayedItemsPerPageOptions.some(({ value }) => {
+        lastOptionValue = Number(value);
+        return this.userSetItemsPerPage <= lastOptionValue;
+      });
+      this.setItemsPerPage(lastOptionValue);
+    } else {
+      const updated = this.displayedItemsPerPageOptions.some(({ value }) => {
+        lastOptionValue = Number(value);
+        return this.itemsPerPage <= lastOptionValue;
+      });
+
+      this.setItemsPerPage(
+        updated || (!updated && this.itemsPerPage > lastOptionValue)
+          ? lastOptionValue
+          : this.itemsPerPage
+      );
+    }
   };
 
   private setUpperBound = () => {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
ItemsPerPage has been updated to store the value when the user has explicitly set a value. This an update to totalItems which needs to be paginated to go from 'All' back to the itemsPerPage the user previously set.

## Related issue
#3223 

## Checklist

### General 

- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
