### PR TITLE
docs(react): fix small mistake in dialog storybook from PR 3218

### DIFF
--- a/packages/react/src/stories/ic-dialog.mdx
+++ b/packages/react/src/stories/ic-dialog.mdx
@@ -257,7 +257,7 @@ export const showHiddenCloseButtonDialog = () => {
 };
 
 <Canvas>
-  <Story of={IcDialogStories.ShowHideInteractiveElements} />
+  <Story of={IcDialogStories.HiddenCloseButton} />
 </Canvas>
 
 ### Auto opening


### PR DESCRIPTION
## Summary of the changes
Fix small mistake in dialog storybook which I've just noticed in PR #3218 - accidentally made a change to the wrong story

## Related issue
#2773 