### PR TITLE
fix(canary-web-components): truncation on first render

### DIFF
--- a/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
@@ -169,12 +169,16 @@ export class TreeItem {
       childList: true,
     });
   }
+  componentDidRender(): void {
+    this.truncateTreeItem && this.truncateTreeItemLabel(this.el);
+    if (this.expanded) {
+      this.childTreeItems.forEach((child: HTMLIcTreeItemElement) => {
+        child.truncateTreeItem && this.truncateTreeItemLabel(child);
+      });
+    }
+  }
 
   componentDidUpdate(): void {
-    // Truncation is run here because truncateTreeItem prop gets applied on second render
-    // if being passed down from parent tree view
-    this.truncateTreeItem && this.truncateTreeItemLabel(this.el);
-
     if (this.hasParentExpanded) {
       this.childTreeItems.forEach((child: HTMLIcTreeItemElement) => {
         child.truncateTreeItem && this.truncateTreeItemLabel(child);

--- a/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.tsx
@@ -98,17 +98,20 @@ export class TreeView {
 
     this.hostMutationObserver?.disconnect();
   }
-
-  componentDidLoad(): void {
+  componentWillLoad(): void {
     this.setTreeItems();
 
     this.watchSizeHandler();
     this.watchFocusInsetHandler();
     this.watchThemeHandler();
     this.watchTruncateTreeItemsHandler();
+  }
 
+  componentDidRender(): void {
     this.truncateHeading && this.truncateTreeViewHeading();
+  }
 
+  componentDidLoad(): void {
     this.addSlotChangeListener();
 
     this.hostMutationObserver = new MutationObserver((mutationList) =>
@@ -295,15 +298,7 @@ export class TreeView {
   };
 
   render() {
-    const {
-      focusInset,
-      heading,
-      isLoaded,
-      size,
-      theme,
-      truncateHeading,
-      truncateTreeItems,
-    } = this;
+    const { heading, isLoaded, size, theme, truncateHeading } = this;
 
     return (
       <Host
@@ -338,16 +333,8 @@ export class TreeView {
             </ic-typography>
           </div>
         )}
-        <div
-          // Hide tree items until fully loaded with props passed down from tree view - prevents FOUC
-          class={{
-            "tree-items-container-hidden":
-              (focusInset || size !== "medium" || truncateTreeItems) &&
-              !isLoaded,
-          }}
-        >
-          <slot></slot>
-        </div>
+
+        <slot></slot>
       </Host>
     );
   }


### PR DESCRIPTION
## Summary of the changes
modified tree view to allow tree items to truncate on first render 

to test: 
 - open storybook and go to truncated behavior, should emulate correct behavior without loading state
 - 
## Related issue
#3171 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.