### PR TITLE
fix(web-components): render only one collapsed breadcrumb when window is resized

### DIFF
--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
@@ -206,40 +206,40 @@ export class BreadcrumbGroup {
   };
 
   private renderCollapsedBreadcrumb = () => {
-    this.collapsedBreadcrumbWrapper = document.createElement("ic-breadcrumb");
-    this.collapsedBreadcrumbWrapper.classList.add(
-      "collapsed-breadcrumb-wrapper"
-    );
-    this.collapsedBreadcrumbEl = document.createElement("button");
+    if (this.collapsedBreadcrumbEl === undefined) {
+      this.collapsedBreadcrumbWrapper = document.createElement("ic-breadcrumb");
+      this.collapsedBreadcrumbWrapper.classList.add(
+        "collapsed-breadcrumb-wrapper"
+      );
+      this.collapsedBreadcrumbEl = document.createElement("button");
 
-    const ariaLabel = document.createElement("span");
-    ariaLabel.id = "collapsed-button-label";
-    ariaLabel.innerText = "Collapsed breadcrumbs";
-    ariaLabel.className = "hide";
-    this.collapsedBreadcrumbEl.setAttribute(
-      "aria-labelledby",
-      "collapsed-button-label"
-    );
+      const ariaLabel = document.createElement("span");
+      ariaLabel.id = "collapsed-button-label";
+      ariaLabel.innerText = "Collapsed breadcrumbs";
+      ariaLabel.className = "hide";
+      this.collapsedBreadcrumbEl.setAttribute(
+        "aria-labelledby",
+        "collapsed-button-label"
+      );
 
-    const ariaDescribed = document.createElement("span");
-    ariaDescribed.id = "collapsed-button-described";
-    ariaDescribed.innerText = "Select to view collapsed breadcrumbs";
-    ariaDescribed.className = "hide";
-    this.collapsedBreadcrumbEl.setAttribute(
-      "aria-describedby",
-      "collapsed-button-described"
-    );
+      const ariaDescribed = document.createElement("span");
+      ariaDescribed.id = "collapsed-button-described";
+      ariaDescribed.innerText = "Select to view collapsed breadcrumbs";
+      ariaDescribed.className = "hide";
+      this.collapsedBreadcrumbEl.setAttribute(
+        "aria-describedby",
+        "collapsed-button-described"
+      );
 
-    this.collapsedBreadcrumbEl.id = "collapsed-ellipsis";
-    this.collapsedBreadcrumbEl.innerText = "...";
-    this.collapsedBreadcrumbEl.classList.add("collapsed-breadcrumb");
-    this.collapsedBreadcrumbEl.addEventListener("click", this.clickHandler);
+      this.collapsedBreadcrumbEl.id = "collapsed-ellipsis";
+      this.collapsedBreadcrumbEl.innerText = "...";
+      this.collapsedBreadcrumbEl.classList.add("collapsed-breadcrumb");
+      this.collapsedBreadcrumbEl.addEventListener("click", this.clickHandler);
 
-    this.collapsedBreadcrumbWrapper.append(ariaDescribed);
-    this.collapsedBreadcrumbWrapper.append(ariaLabel);
-    this.collapsedBreadcrumbWrapper.append(this.collapsedBreadcrumbEl);
-
-    return this.collapsedBreadcrumbWrapper;
+      this.collapsedBreadcrumbWrapper.append(ariaDescribed);
+      this.collapsedBreadcrumbWrapper.append(ariaLabel);
+      this.collapsedBreadcrumbWrapper.append(this.collapsedBreadcrumbEl);
+    }
   };
 
   private handleHiddenCollapsedBreadcrumbs = () => {

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
@@ -48,6 +48,77 @@ exports[`ic-breadcrumb-group should handle the hidden collapsed breadcrumbs: sho
 </ic-breadcrumb-group>
 `;
 
+exports[`ic-breadcrumb-group should only render one collapse button when window is resized 1`] = `
+<ic-breadcrumb-group back-breadcrumb-only="false" class="ic-breadcrumb-group-collapsed" collapsed="true">
+  <mock:shadow-root>
+    <nav aria-label="breadcrumbs">
+      <ol>
+        <slot></slot>
+      </ol>
+    </nav>
+  </mock:shadow-root>
+  <ic-breadcrumb href="/breadcrumb-1" page-title="Breadcrumb 1" role="listitem">
+    <mock:shadow-root>
+      <div class="breadcrumb">
+        <span aria-hidden="true" class="chevron">
+          svg
+        </span>
+        <ic-link class="breadcrumb-link" href="/breadcrumb-1" theme="inherit">
+          Breadcrumb 1
+        </ic-link>
+      </div>
+    </mock:shadow-root>
+  </ic-breadcrumb>
+  <ic-breadcrumb class="collapsed-breadcrumb-wrapper" role="listitem">
+    <mock:shadow-root>
+      <div class="breadcrumb">
+        <span aria-hidden="true" class="chevron">
+          svg
+        </span>
+        <div class="slotted-link-container">
+          <span class="link-wrapper" tabindex="0">
+            <slot></slot>
+          </span>
+        </div>
+      </div>
+    </mock:shadow-root>
+    <span class="hide" id="collapsed-button-described">
+      Select to view collapsed breadcrumbs
+    </span>
+    <span class="hide" id="collapsed-button-label">
+      Collapsed breadcrumbs
+    </span>
+    <button aria-describedby="collapsed-button-described" aria-labelledby="collapsed-button-label" class="collapsed-breadcrumb" id="collapsed-ellipsis">
+      ...
+    </button>
+  </ic-breadcrumb>
+  <ic-breadcrumb class="hide" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem" show-back-icon="false">
+    <mock:shadow-root>
+      <div class="breadcrumb">
+        <span aria-hidden="true" class="chevron">
+          svg
+        </span>
+        <ic-link class="breadcrumb-link" href="/breadcrumb-2" theme="inherit">
+          Breadcrumb 2
+        </ic-link>
+      </div>
+    </mock:shadow-root>
+  </ic-breadcrumb>
+  <ic-breadcrumb aria-current="page" current="true" href="/breadcrumb-3" page-title="Breadcrumb 3" role="listitem">
+    <mock:shadow-root>
+      <div class="breadcrumb">
+        <span aria-hidden="true" class="chevron">
+          svg
+        </span>
+        <span class="current-page-container">
+          Breadcrumb 3
+        </span>
+      </div>
+    </mock:shadow-root>
+  </ic-breadcrumb>
+</ic-breadcrumb-group>
+`;
+
 exports[`ic-breadcrumb-group should render collapse on already small devices: should render collapse on already small devices 1`] = `
 <ic-breadcrumb-group class="ic-breadcrumb-group-collapsed" collapsed="true">
   <mock:shadow-root>

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/ic-breadcrumb-group.spec.ts
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/ic-breadcrumb-group.spec.ts
@@ -3,7 +3,7 @@ import { newSpecPage } from "@stencil/core/testing";
 import { Breadcrumb } from "../../../ic-breadcrumb/ic-breadcrumb";
 import { DEVICE_SIZES } from "../../../../utils/helpers";
 import * as helpers from "../../../../utils/helpers";
-import { waitForTimeout } from "../../../../testspec.setup";
+import { waitForTimeout, resizeTo } from "../../../../testspec.setup";
 
 describe("ic-breadcrumb-group", () => {
   it("should render", async () => {
@@ -85,6 +85,24 @@ describe("ic-breadcrumb-group", () => {
     });
 
     expect(page.root).toMatchSnapshot("should render with collapse button");
+  });
+
+  it("should only render one collapse button when window is resized", async () => {
+    const page = await newSpecPage({
+      components: [BreadcrumbGroup, Breadcrumb],
+      html: `
+        <ic-breadcrumb-group collapsed="true">
+          <ic-breadcrumb page-title="Breadcrumb 1" href="/breadcrumb-1"></ic-breadcrumb>
+          <ic-breadcrumb page-title="Breadcrumb 2" href="/breadcrumb-2"></ic-breadcrumb>
+          <ic-breadcrumb current="true" page-title="Breadcrumb 3" href="/breadcrumb-3"></ic-breadcrumb>
+        </ic-breadcrumb-group>`,
+    });
+    resizeTo(window, 1920, 1080);
+
+    page.rootInstance.resizeObserverCallback();
+
+    await page.waitForChanges();
+    expect(page.root).toMatchSnapshot();
   });
 
   it("should set hasShadowDom", async () => {


### PR DESCRIPTION
when the window is resized only one collapsed breadcrumb will render
