### PR TITLE
fix(web-components): fix circular loading indicator showing as complete circle

### DIFF
--- a/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.tsx
+++ b/packages/web-components/src/components/ic-loading-indicator/ic-loading-indicator.tsx
@@ -275,19 +275,19 @@ export class LoadingIndicator {
   };
 
   private setDashSteps = (radius: number) => {
-    if (this.circularMeter && this.progress) {
-      const max = this.max!;
-      const min = this.min!;
-      const dashArray = 2 * Math.PI * radius;
-      const progress = Math.min(Math.max(this.progress, min), max);
-      const proportion = -1 - (progress - min) / (max - min);
+    const dashArray = 2 * Math.PI * radius;
 
+    if (this.circularMeter) {
       this.circularMeter.style.setProperty(
         "--stroke-dasharray",
         `${dashArray}px`
       );
 
-      if (!this.indeterminate) {
+      if (!this.indeterminate && this.progress) {
+        const min = this.min!;
+        const max = this.max!;
+        const progress = Math.min(Math.max(this.progress, min), max);
+        const proportion = -1 - (progress - min) / (max - min);
         this.circularMeter.style.setProperty(
           "--circular-steps-max",
           String(this.max)


### PR DESCRIPTION
## Summary of the changes
Fixed issue which I noticed was introduced by my TypeScript strict mode PR where circular indeterminate variant of the loading indicator was just showing as a complete circle.

<img src="https://github.com/user-attachments/assets/99d9b812-0bc8-484c-90e9-cd8ff214839b" width="100">

(I think the v3 develop branch has not updated properly so isn't showing the bug - look at a build on another PR if not)

## Related issue
N/A