### PR TITLE
docs(codemod): update codemod instructions to include "@next" when running using npx

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -14,7 +14,7 @@ Given a directory, it will scan over files and find any relevant ICDS components
 This package will be usable as an executable requiring a directory and optional test boolean argument to cover tests 
 
 ```console
-- npx @ukic/codemod <dir> <test>
+- npx @ukic/codemod@next <dir> <test>
 ```
 
 ### Options:
@@ -31,11 +31,11 @@ This package will be usable as an executable requiring a directory and optional 
 ### Examples:
 With tests
 ```console
-- npx @ukic/codemod --dir ./#path/app/src/components --test true
+- npx @ukic/codemod@next --dir ./#path/app/src/components --test true
 ```
 Without tests
 ```console
-- npx @ukic/codemod --dir ./#path/app/src/components
+- npx @ukic/codemod@next --dir ./#path/app/src/components
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary of the changes
Update codemod instructions to include "@next" in the npx command.

The issue was that when the codemod was run using npx, it was running the oldest version rather than the latest version (the "next" version on NPM). The latest version runs correctly on all files which need changing (running a locally cloned version of the codemod always runs the latest version which is why that worked fine).

Will open a PR to update the instructions on the website as well.

## Related issue
#3297 