### PR TITLE
3010 internal issue 2949   date input extend events to include string value of date input

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -404,13 +404,7 @@
           "passive": false
         }
       ],
-      "styles": [
-        {
-          "name": "--card-horizontal-width",
-          "annotation": "prop",
-          "docs": "Width of the horizontal card"
-        }
-      ],
+      "styles": [],
       "slots": [
         {
           "name": "badge",
@@ -1883,6 +1877,30 @@
           "setter": false
         },
         {
+          "name": "emitDatePartChange",
+          "type": "boolean",
+          "complexType": {
+            "original": "boolean",
+            "resolved": "boolean",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "emit-date-part-change",
+          "reflectToAttr": false,
+          "docs": "If `true`, every individual input field completed will emit an icChange event.",
+          "docsTags": [],
+          "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
+          "optional": true,
+          "required": false,
+          "getter": false,
+          "setter": false
+        },
+        {
           "name": "helperText",
           "type": "string",
           "complexType": {
@@ -2392,11 +2410,11 @@
         },
         {
           "event": "icChange",
-          "detail": "{ value: Date; }",
+          "detail": "{ value: Date; dateObject: { day: string; month: string; year: string; }; }",
           "bubbles": true,
           "complexType": {
-            "original": "{ value: Date }",
-            "resolved": "{ value: Date; }",
+            "original": "{\r\n    value: Date;\r\n    dateObject: { day: string; month: string; year: string };\r\n  }",
+            "resolved": "{ value: Date; dateObject: { day: string; month: string; year: string; }; }",
             "references": {
               "Date": {
                 "location": "global",
@@ -2681,6 +2699,30 @@
           "attr": "disabled",
           "reflectToAttr": false,
           "docs": "If `true`, the disabled state will be set.",
+          "docsTags": [],
+          "default": "false",
+          "values": [
+            {
+              "type": "boolean"
+            }
+          ],
+          "optional": true,
+          "required": false,
+          "getter": false,
+          "setter": false
+        },
+        {
+          "name": "emitDatePartChange",
+          "type": "boolean",
+          "complexType": {
+            "original": "boolean",
+            "resolved": "boolean",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "emit-date-part-change",
+          "reflectToAttr": false,
+          "docs": "If `true`, every individual input field completed will emit an icChange event.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -3309,18 +3351,7 @@
           "passive": false
         }
       ],
-      "styles": [
-        {
-          "name": "--ic-z-index-date-picker",
-          "annotation": "prop",
-          "docs": "z-index of date picker."
-        },
-        {
-          "name": "--input-width",
-          "annotation": "prop",
-          "docs": "Width of the input field"
-        }
-      ],
+      "styles": [],
       "slots": [],
       "parts": [],
       "dependents": [],
@@ -4532,13 +4563,7 @@
           "passive": false
         }
       ],
-      "styles": [
-        {
-          "name": "--tree-view-width",
-          "annotation": "prop",
-          "docs": "Width of the tree view"
-        }
-      ],
+      "styles": [],
       "slots": [
         {
           "name": "heading",
@@ -4633,7 +4658,7 @@
       "path": "../web-components/dist/types/components/ic-pagination/ic-pagination.types.d.ts"
     },
     "src/components/ic-pagination-bar/ic-pagination-bar.types.ts::IcPageChangeEventDetail": {
-      "declaration": "export interface IcPageChangeEventDetail {\n  value: number;\n  fromItemsPerPage?: boolean;\n}",
+      "declaration": "export interface IcPageChangeEventDetail {\r\n  value: number;\r\n  fromItemsPerPage?: boolean;\r\n}",
       "docstring": "",
       "path": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts"
     },

--- a/packages/canary-react/src/component-tests/IcDateInput/IcDateInput.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDateInput/IcDateInput.cy.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-no-bind */
-/// <reference types="Cypress" />
+/// <reference types="cypress" />
 
 import React from "react";
 import { mount } from "cypress/react";
@@ -920,12 +920,15 @@ describe("IcDateInput end-to-end, visual regression and a11y tests", () => {
       .shadow()
       .find("button")
       .focus()
-      .click();
-
+      .click("top");
     cy.findShadowEl(DATE_INPUT, MONTH_INPUT_ARIA_LABEL).should(HAVE_VALUE, "");
-
     cy.get("@icDateChanged").should((stub) => {
       expect(stub.getCall(0).args[0].detail.value).to.equal(null);
+      expect(stub.getCall(0).args[0].detail.dateObject).to.deep.equal({
+        day: null,
+        month: null,
+        year: null,
+      });
     });
   });
 
@@ -997,6 +1000,39 @@ describe("IcDateInput end-to-end, visual regression and a11y tests", () => {
     cy.checkHydrated("ic-date-input");
 
     cy.findShadowEl(DATE_INPUT, "ic-input-label").should("not.exist");
+  });
+
+  it("should not fire icChange emit when a field is input and emitDatePartChange is set to false", () => {
+    mount(<IcDateInput label="Test Label" emitDatePartChange={false} />);
+
+    cy.checkHydrated(DATE_INPUT);
+
+    cy.get(DATE_INPUT).invoke("on", "icChange", cy.stub().as("icDateChanged"));
+    cy.findShadowEl(DATE_INPUT, DAY_INPUT_ARIA_LABEL).type("18");
+
+    cy.findShadowEl(DATE_INPUT, DAY_INPUT_ARIA_LABEL).should(HAVE_VALUE, "18");
+    cy.get("@icDateChanged").should((stub) => {
+      expect(stub.getCall(0)).to.equal(null);
+    });
+  });
+
+  it("should fire icChange emit when a field is input and emitDatePartChange is set to true", () => {
+    mount(<IcDateInput label="Test Label" emitDatePartChange={true} />);
+
+    cy.checkHydrated(DATE_INPUT);
+
+    cy.get(DATE_INPUT).invoke("on", "icChange", cy.stub().as("icDateChanged"));
+    cy.findShadowEl(DATE_INPUT, DAY_INPUT_ARIA_LABEL).type("18");
+
+    cy.findShadowEl(DATE_INPUT, DAY_INPUT_ARIA_LABEL).should(HAVE_VALUE, "18");
+    cy.get("@icDateChanged").should((stub) => {
+      expect(stub.getCall(0).args[0].detail.value).to.equal(null);
+      expect(stub.getCall(0).args[0].detail.dateObject).to.deep.equal({
+        day: "18",
+        month: null,
+        year: null,
+      });
+    });
   });
 });
 

--- a/packages/canary-react/src/component-tests/IcDatePicker/IcDatePicker.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDatePicker/IcDatePicker.cy.tsx
@@ -2820,6 +2820,28 @@ describe("IcDatePicker end-to-end, visual regression and a11y tests", () => {
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.024),
     });
   });
+
+  it("should emit icChange when emitDatePartChange is true", () => {
+    mount(<IcDatePicker label={DEFAULT_LABEL} emitDatePartChange />);
+
+    cy.checkHydrated(DATE_PICKER);
+
+    cy.get(DATE_PICKER).invoke("on", "icChange", cy.stub().as("icDateChanged"));
+
+    cy.findShadowEl(DATE_PICKER, DATE_INPUT)
+      .shadow()
+      .find(DAY_INPUT_ARIA_LABEL)
+      .type("18");
+
+    cy.get("@icDateChanged").should((stub) => {
+      expect(stub.getCall(0).args[0].detail.value).to.equal(null);
+      expect(stub.getCall(0).args[0].detail.dateObject).to.deep.equal({
+        day: "18",
+        month: null,
+        year: null,
+      });
+    });
+  });
 });
 
 describe("IcDatePicker visual regression tests in high contrast mode", () => {

--- a/packages/canary-web-components/src/components.d.ts
+++ b/packages/canary-web-components/src/components.d.ts
@@ -261,6 +261,10 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * If `true`, every individual input field completed will emit an icChange event.
+         */
+        "emitDatePartChange"?: boolean;
+        /**
           * Returns the value as a Date object
           * @returns Date
          */
@@ -367,6 +371,10 @@ export namespace Components {
           * If `true`, the disabled state will be set.
          */
         "disabled"?: boolean;
+        /**
+          * If `true`, every individual input field completed will emit an icChange event.
+         */
+        "emitDatePartChange"?: boolean;
         /**
           * The helper text that will be displayed for additional field guidance. This will default to the text "Use format" along with the `dateFormat` value.
          */
@@ -670,7 +678,10 @@ declare global {
     interface HTMLIcDateInputElementEventMap {
         "calendarButtonClicked": { value: Date };
         "icBlur": { value: Date };
-        "icChange": { value: Date };
+        "icChange": {
+    value: Date;
+    dateObject: { day: string; month: string; year: string };
+  };
         "icFocus": { value: Date };
     }
     interface HTMLIcDateInputElement extends Components.IcDateInput, HTMLStencilElement {
@@ -1010,6 +1021,10 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * If `true`, every individual input field completed will emit an icChange event.
+         */
+        "emitDatePartChange"?: boolean;
+        /**
           * The helper text that will be displayed for additional field guidance. This will default to the text "Use format" along with the `dateFormat` value.
          */
         "helperText"?: string;
@@ -1053,7 +1068,10 @@ declare namespace LocalJSX {
         /**
           * Emitted when the value has changed.
          */
-        "onIcChange"?: (event: IcDateInputCustomEvent<{ value: Date }>) => void;
+        "onIcChange"?: (event: IcDateInputCustomEvent<{
+    value: Date;
+    dateObject: { day: string; month: string; year: string };
+  }>) => void;
         /**
           * Emitted when the input gains focus.
          */
@@ -1121,6 +1139,10 @@ declare namespace LocalJSX {
           * If `true`, the disabled state will be set.
          */
         "disabled"?: boolean;
+        /**
+          * If `true`, every individual input field completed will emit an icChange event.
+         */
+        "emitDatePartChange"?: boolean;
         /**
           * The helper text that will be displayed for additional field guidance. This will default to the text "Use format" along with the `dateFormat` value.
          */

--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.stories.js
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.stories.js
@@ -363,3 +363,22 @@ export const WithClearingValue = {
     </script>`,
   name: "With clearing value",
 };
+
+/**
+ * The `IcChange` event is emitted by the date input every time an input field is changed.
+ */
+export const IcChangeEmitDatePartChanges = {
+  render: () => html`<ic-date-input
+      emit-date-part-change="true"
+      label="When would you like to collect your coffee?"
+    ></ic-date-input>
+    <script>
+      var dateInput = document.querySelector("ic-date-input");
+      {
+        dateInput.addEventListener("icChange", function (event) {
+          console.log("icChange", event.detail);
+        });
+      }
+    </script>`,
+  name: "IcChange with emitDatePartChange",
+};

--- a/packages/canary-web-components/src/components/ic-date-input/readme.md
+++ b/packages/canary-web-components/src/components/ic-date-input/readme.md
@@ -17,6 +17,7 @@
 | `disablePast`          | `disable-past`           | If `true`, dates in the past are not allowed. A validation message will appear if a date in the past is entered.                                                                                                                                       | `boolean`                                      | `false`                                                                                                 |
 | `disablePastMessage`   | `disable-past-message`   | The text to display as the validation message when `disablePast` is true and a date in the past is entered.                                                                                                                                            | `string`                                       | `"Dates in the past are not allowed. Please select a date in the future."`                              |
 | `disabled`             | `disabled`               | If `true`, the disabled state will be set.                                                                                                                                                                                                             | `boolean`                                      | `false`                                                                                                 |
+| `emitDatePartChange`   | `emit-date-part-change`  | If `true`, every individual input field completed will emit an icChange event.                                                                                                                                                                         | `boolean`                                      | `false`                                                                                                 |
 | `helperText`           | `helper-text`            | The helper text that will be displayed for additional field guidance. This will default to the text "Use format" along with the `dateFormat` value.                                                                                                    | `string`                                       | `undefined`                                                                                             |
 | `hideHelperText`       | `hide-helper-text`       | If `true`, the helper text will be visually hidden, but still read out by screenreaders.                                                                                                                                                               | `boolean`                                      | `false`                                                                                                 |
 | `hideLabel`            | `hide-label`             | If `true`, the label will be visually hidden, but will still be read out by screen readers.                                                                                                                                                            | `boolean`                                      | `false`                                                                                                 |
@@ -37,11 +38,11 @@
 
 ## Events
 
-| Event      | Description                         | Type                            |
-| ---------- | ----------------------------------- | ------------------------------- |
-| `icBlur`   | Emitted when the input loses focus. | `CustomEvent<{ value: Date; }>` |
-| `icChange` | Emitted when the value has changed. | `CustomEvent<{ value: Date; }>` |
-| `icFocus`  | Emitted when the input gains focus. | `CustomEvent<{ value: Date; }>` |
+| Event      | Description                         | Type                                                                                       |
+| ---------- | ----------------------------------- | ------------------------------------------------------------------------------------------ |
+| `icBlur`   | Emitted when the input loses focus. | `CustomEvent<{ value: Date; }>`                                                            |
+| `icChange` | Emitted when the value has changed. | `CustomEvent<{ value: Date; dateObject: { day: string; month: string; year: string; }; }>` |
+| `icFocus`  | Emitted when the input gains focus. | `CustomEvent<{ value: Date; }>`                                                            |
 
 
 ## Methods

--- a/packages/canary-web-components/src/components/ic-date-input/test/basic/ic-date-input.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-date-input/test/basic/ic-date-input.spec.tsx
@@ -703,6 +703,7 @@ describe("ic-date-input component", () => {
         expect.objectContaining({
           detail: expect.objectContaining({
             value: date,
+            dateObject: { day: "01", month: "01", year: "2000" },
           }),
         })
       );
@@ -1085,7 +1086,7 @@ describe("ic-date-input component", () => {
 
       componentInstance.day = "31";
       componentInstance.month = "8";
-      componentInstance.year = "2024";
+      componentInstance.year = "2050";
 
       componentInstance.setValidationMessage();
 

--- a/packages/canary-web-components/src/components/ic-date-picker/ic-date-picker.stories.js
+++ b/packages/canary-web-components/src/components/ic-date-picker/ic-date-picker.stories.js
@@ -9,6 +9,7 @@ import {
   HideButtons,
   HideOutsideMonth,
   IcChangeDate,
+  IcChangeDateEmitDatePartChanges,
   JSDates,
   MaxMin,
   MaxWidth,
@@ -181,5 +182,14 @@ export const JavascriptDates = {
 export const IcChangeEvent = {
   render: () => IcChangeDate(),
   name: "IcChange event",
+  height: "540px",
+};
+
+/**
+ * The `IcChange` event is emitted by the date picker every time an input field is changed.
+ */
+export const IcChangeEventEmitDatePartChange = {
+  render: () => IcChangeDateEmitDatePartChanges(),
+  name: "IcChange event with emitDatePartChange",
   height: "540px",
 };

--- a/packages/canary-web-components/src/components/ic-date-picker/ic-date-picker.tsx
+++ b/packages/canary-web-components/src/components/ic-date-picker/ic-date-picker.tsx
@@ -61,6 +61,7 @@ interface IcDateInputProps {
   disableFutureMessage?: string;
   disablePast?: boolean;
   disablePastMessage?: string;
+  emitDatePartChange?: boolean;
   helperText?: string;
   hideHelperText?: boolean;
   hideLabel?: boolean;
@@ -143,6 +144,11 @@ export class DatePicker {
   watchDisabledHandler(): void {
     removeDisabledFalse(this.disabled, this.el);
   }
+
+  /**
+   *  If `true`, every individual input field completed will emit an icChange event.
+   */
+  @Prop() emitDatePartChange?: boolean = false;
 
   /**
    * The days of the week to disable.
@@ -1246,6 +1252,7 @@ export class DatePicker {
       showClearButton: true,
       showCalendarButton: true,
       value: this.value,
+      emitDatePartChange: this.emitDatePartChange,
     };
 
     if (this.dateFormat !== DEFAULT_DATE_FORMAT) {

--- a/packages/canary-web-components/src/components/ic-date-picker/readme.md
+++ b/packages/canary-web-components/src/components/ic-date-picker/readme.md
@@ -17,6 +17,7 @@
 | `disablePast`           | `disable-past`             | If `true`, dates in the past are not allowed. A validation message will appear if a date in the past is entered.                                                                                                                                       | `boolean`                                                                                                                                                 | `false`                                                                                                 |
 | `disablePastMessage`    | `disable-past-message`     | The text to display as the validation message when `disablePast` is `true` and a date in the past is entered.                                                                                                                                          | `string`                                                                                                                                                  | `"Dates in the past are not allowed. Please select a date in the future."`                              |
 | `disabled`              | `disabled`                 | If `true`, the disabled state will be set.                                                                                                                                                                                                             | `boolean`                                                                                                                                                 | `false`                                                                                                 |
+| `emitDatePartChange`    | `emit-date-part-change`    | If `true`, every individual input field completed will emit an icChange event.                                                                                                                                                                         | `boolean`                                                                                                                                                 | `false`                                                                                                 |
 | `helperText`            | `helper-text`              | The helper text that will be displayed for additional field guidance. This will default to the text "Use format" along with the `dateFormat` value.                                                                                                    | `string`                                                                                                                                                  | `undefined`                                                                                             |
 | `hideHelperText`        | `hide-helper-text`         | If `true`, the helper text will be visually hidden, but still read out by screenreaders.                                                                                                                                                               | `boolean`                                                                                                                                                 | `false`                                                                                                 |
 | `hideLabel`             | `hide-label`               | If `true`, the label will be visually hidden, but the required label will still be read out by screen readers.                                                                                                                                         | `boolean`                                                                                                                                                 | `false`                                                                                                 |
@@ -44,14 +45,6 @@
 | Event      | Description                         | Type                            |
 | ---------- | ----------------------------------- | ------------------------------- |
 | `icChange` | Emitted when the value has changed. | `CustomEvent<{ value: Date; }>` |
-
-
-## CSS Custom Properties
-
-| Name                       | Description              |
-| -------------------------- | ------------------------ |
-| `--ic-z-index-date-picker` | z-index of date picker.  |
-| `--input-width`            | Width of the input field |
 
 
 ## Dependencies

--- a/packages/canary-web-components/src/components/ic-date-picker/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-date-picker/story-data.ts
@@ -159,11 +159,31 @@ const updateSelectedDate = (ev: CustomEvent): void => {
     text += ev.detail.value;
   }
   el.innerHTML = text;
-  console.log("ic-change", ev.detail.value);
+  console.log("ic-change", ev.detail);
 };
 
 export const IcChangeDate = (): HTMLElement => {
   const datePicker = createDatePickerElement();
+  datePicker.addEventListener("icChange", updateSelectedDate);
+  const container = document.createElement("div");
+
+  const selDate = document.createElement("span");
+  selDate.innerText = "Selected date:";
+  selDate.id = "selected-date";
+
+  container.appendChild(datePicker);
+  container.appendChild(selDate);
+
+  container.style.display = "flex";
+  container.style.flexDirection = "column";
+  container.style.gap = "50px";
+
+  return container;
+};
+
+export const IcChangeDateEmitDatePartChanges = (): HTMLElement => {
+  const datePicker = createDatePickerElement();
+  datePicker.emitDatePartChange = true;
   datePicker.addEventListener("icChange", updateSelectedDate);
   const container = document.createElement("div");
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added a dateObject field to IcChange return detail, IcChange is now emitted after every section of input date is completed.

showInputs is an additional prop added so that any current implementations of datePicker or dateInput will not be affected by these changes rather setting showInputs to `true` will enable the emit on each field input

## Related issue
#3010 

## Checklist

### General 

- [X] Changes to docs package checked and committed.
- [X] All acceptance criteria reviewed and met. 

### Testing

- [X] Relevant unit tests and visual regression tests added. 
- [X] Visual testing against Figma component specification completed. 
- [X] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [X] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [X] Accessibility Insights FastPass performed.
- [X] A11y unit test added and yields no issues.
- [X] A11y plug-in on Storybook yields no issues. 
- [X] Manual screen reader testing performed using NVDA and VoiceOver. 
- [X] Manual keyboard testing for keyboard controls and logical focus order. 
- [X] Correct roles used and ARIA attributes used correctly where required. 
- [X] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [X] Page can be zoomed to 400% with no loss of content. 
- [X] Screen magnifier used with no issues. 
- [X] Text resized to 200% with no loss of content.
- [X] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [X] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [X] Windows High Contrast mode tested with no loss of content.
- [X] System light and dark mode tested with no loss of content.
- [X] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [X] Min/max content examples tested with no loss of content or overflow. 
- [X] All prop combinations work without issue. 
- [X] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [X] Controlled and uncontrolled input components tested.
- [X] Props/slots can be updated after initial render.