### PR TITLE
Navigation groups overlapping

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -20,6 +20,7 @@ import { IcLoadingSizes, IcLoadingTypes } from "./components/ic-loading-indicato
 import { IcSearchBarBlurEventDetail, IcSearchBarSearchModes } from "./components/ic-search-bar/ic-search-bar.types";
 import { IcMenuChangeEventDetail, IcMenuOptionIdEventDetail, IcOptionSelectEventDetail } from "./components/ic-menu/ic-menu.types";
 import { IcMenuItemVariants } from "./components/ic-menu-item/ic-menu-item.types";
+import { IcNavigationOpenEventDetail } from "./components/ic-navigation-group/ic-navigation-group.types";
 import { IcChangeEventDetail as IcChangeEventDetail1, IcPaginationTypes } from "./components/ic-pagination/ic-pagination.types";
 import { IcPaginationItemType } from "./components/ic-pagination-item/ic-pagination-item.types";
 import { IcChangeEventDetail as IcChangeEventDetail2 } from "./components/ic-radio-group/ic-radio-group.types";
@@ -49,6 +50,7 @@ export { IcLoadingSizes, IcLoadingTypes } from "./components/ic-loading-indicato
 export { IcSearchBarBlurEventDetail, IcSearchBarSearchModes } from "./components/ic-search-bar/ic-search-bar.types";
 export { IcMenuChangeEventDetail, IcMenuOptionIdEventDetail, IcOptionSelectEventDetail } from "./components/ic-menu/ic-menu.types";
 export { IcMenuItemVariants } from "./components/ic-menu-item/ic-menu-item.types";
+export { IcNavigationOpenEventDetail } from "./components/ic-navigation-group/ic-navigation-group.types";
 export { IcChangeEventDetail as IcChangeEventDetail1, IcPaginationTypes } from "./components/ic-pagination/ic-pagination.types";
 export { IcPaginationItemType } from "./components/ic-pagination-item/ic-pagination-item.types";
 export { IcChangeEventDetail as IcChangeEventDetail2 } from "./components/ic-radio-group/ic-radio-group.types";
@@ -2478,6 +2480,10 @@ export interface IcMenuItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLIcMenuItemElement;
 }
+export interface IcNavigationGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLIcNavigationGroupElement;
+}
 export interface IcNavigationItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLIcNavigationItemElement;
@@ -2891,7 +2897,18 @@ declare global {
         prototype: HTMLIcNavigationButtonElement;
         new (): HTMLIcNavigationButtonElement;
     };
+    interface HTMLIcNavigationGroupElementEventMap {
+        "navigationGroupOpened": IcNavigationOpenEventDetail;
+    }
     interface HTMLIcNavigationGroupElement extends Components.IcNavigationGroup, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLIcNavigationGroupElementEventMap>(type: K, listener: (this: HTMLIcNavigationGroupElement, ev: IcNavigationGroupCustomEvent<HTMLIcNavigationGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLIcNavigationGroupElementEventMap>(type: K, listener: (this: HTMLIcNavigationGroupElement, ev: IcNavigationGroupCustomEvent<HTMLIcNavigationGroupElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLIcNavigationGroupElement: {
         prototype: HTMLIcNavigationGroupElement;
@@ -4579,6 +4596,7 @@ declare namespace LocalJSX {
           * The label to display on the group.
          */
         "label"?: string;
+        "onNavigationGroupOpened"?: (event: IcNavigationGroupCustomEvent<IcNavigationOpenEventDetail>) => void;
     }
     interface IcNavigationItem {
         "collapsedIconLabel"?: boolean;

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -7,6 +7,8 @@ import {
   Listen,
   h,
   Method,
+  Event,
+  EventEmitter,
 } from "@stencil/core";
 
 import {
@@ -18,6 +20,8 @@ import {
 import { IcNavType, IcTheme } from "../../utils/types";
 
 import chevronIcon from "../../assets/chevron-icon.svg";
+import { IcNavigationOpenEventDetail } from "./ic-navigation-group.types";
+
 @Component({
   tag: "ic-navigation-group",
   styleUrl: "ic-navigation-group.css",
@@ -57,6 +61,11 @@ export class NavigationGroup {
    * The label to display on the group.
    */
   @Prop() label: string;
+
+  /**
+   * @internal Emitted when a navigation group opens.
+   */
+  @Event() navigationGroupOpened: EventEmitter<IcNavigationOpenEventDetail>;
 
   disconnectedCallback(): void {
     if (this.navigationType === "side") {
@@ -114,6 +123,13 @@ export class NavigationGroup {
   @Listen("childBlur")
   childBlurHandler(): void {
     this.hideDropdown();
+  }
+
+  @Listen("navigationGroupOpened", { target: "document" })
+  handleNavigationGroupOpened(event: CustomEvent): void {
+    if (event.detail.source !== this.el) {
+      this.hideDropdown();
+    }
   }
 
   @Listen("navItemClicked")
@@ -242,6 +258,10 @@ export class NavigationGroup {
 
   private showDropdown() {
     if (!this.dropdownOpen) {
+      this.navigationGroupOpened.emit({
+        source: this.el,
+      });
+
       this.toggleDropdown();
     }
   }

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.types.ts
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.types.ts
@@ -1,0 +1,3 @@
+export interface IcNavigationOpenEventDetail {
+  source: HTMLElement;
+}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update navigation group so that two nav groups can't be open simultaneously

## Related issue
 #3117

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.