### PR TITLE
Fix/3261 top nav last group items not focusable

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -10584,6 +10584,12 @@
           "passive": false
         },
         {
+          "event": "navigationGroupOpened",
+          "target": "document",
+          "capture": false,
+          "passive": false
+        },
+        {
           "event": "navItemClicked",
           "capture": false,
           "passive": false
@@ -21823,6 +21829,16 @@
       "docstring": "",
       "path": "src/components/ic-search-bar/ic-search-bar.types.ts"
     },
+    "src/utils/types.ts::IcOrientation": {
+      "declaration": "export type IcOrientation = \"horizontal\" | \"vertical\";",
+      "docstring": "",
+      "path": "src/utils/types.ts"
+    },
+    "src/components/ic-radio-group/ic-radio-group.types.ts::IcChangeEventDetail": {
+      "declaration": "export interface IcChangeEventDetail {\n  value: string;\n  selectedOption: {\n    radio: HTMLIcRadioOptionElement;\n    textFieldValue?: string;\n  };\n}",
+      "docstring": "",
+      "path": "src/components/ic-radio-group/ic-radio-group.types.ts"
+    },
     "src/components/ic-divider/ic-divider.types.tsx::IcDividerStyles": {
       "declaration": "export type IcDividerStyles = \"solid\" | \"dashed\";",
       "docstring": "",
@@ -21832,11 +21848,6 @@
       "declaration": "export type IcDividerLabelPlacement =\n  | \"left\"\n  | \"center\"\n  | \"right\"\n  | \"top\"\n  | \"bottom\";",
       "docstring": "",
       "path": "src/components/ic-divider/ic-divider.types.tsx"
-    },
-    "src/utils/types.ts::IcOrientation": {
-      "declaration": "export type IcOrientation = \"horizontal\" | \"vertical\";",
-      "docstring": "",
-      "path": "src/utils/types.ts"
     },
     "src/utils/types.ts::IcBrandForeground": {
       "declaration": "export type IcBrandForeground = \"default\" | \"dark\" | \"light\";",
@@ -21893,6 +21904,16 @@
       "docstring": "",
       "path": "src/components/ic-menu-item/ic-menu-item.types.ts"
     },
+    "src/components/ic-navigation-group/ic-navigation-group.types.ts::IcNavigationOpenEventDetail": {
+      "declaration": "export interface IcNavigationOpenEventDetail {\n  source: HTMLElement;\n}",
+      "docstring": "",
+      "path": "src/components/ic-navigation-group/ic-navigation-group.types.ts"
+    },
+    "src/components/ic-navigation-group/ic-navigation-group.types.ts::IcNavigationExpandEventDetail": {
+      "declaration": "export interface IcNavigationExpandEventDetail {\n  expanded: boolean;\n}",
+      "docstring": "",
+      "path": "src/components/ic-navigation-group/ic-navigation-group.types.ts"
+    },
     "src/components/ic-side-navigation/ic-side-navigation.types.ts::IcExpandedDetail": {
       "declaration": "export interface IcExpandedDetail {\n  sideNavExpanded: boolean;\n  sideNavMobile: boolean;\n}",
       "docstring": "",
@@ -21912,11 +21933,6 @@
       "declaration": "export type IcPaginationItemType = \"page\" | \"ellipsis\" | \"simple-current\";",
       "docstring": "",
       "path": "src/components/ic-pagination-item/ic-pagination-item.types.ts"
-    },
-    "src/components/ic-radio-group/ic-radio-group.types.ts::IcChangeEventDetail": {
-      "declaration": "export interface IcChangeEventDetail {\n  value: string;\n  selectedOption: {\n    radio: HTMLIcRadioOptionElement;\n    textFieldValue?: string;\n  };\n}",
-      "docstring": "",
-      "path": "src/components/ic-radio-group/ic-radio-group.types.ts"
     },
     "src/utils/types.ts::IcSearchMatchPositions": {
       "declaration": "export type IcSearchMatchPositions = \"start\" | \"anywhere\";",

--- a/packages/react/src/component-tests/IcNavigationMenu/IcNavigationMenu.cy.tsx
+++ b/packages/react/src/component-tests/IcNavigationMenu/IcNavigationMenu.cy.tsx
@@ -106,14 +106,18 @@ describe("IcNavigationMenu end-to-end and visual regression tests", () => {
       cy.checkShadowElVisible(TOP_NAV_SELECTOR, MENU_BUTTON_SELECTOR);
       cy.findShadowEl(TOP_NAV_SELECTOR, MENU_BUTTON_SELECTOR).click();
 
-      cy.findShadowEl(TOP_NAV_SELECTOR, NAVIGATION_MENU_SELECTOR)
+      const closeMenuButton = cy
+        .findShadowEl(TOP_NAV_SELECTOR, NAVIGATION_MENU_SELECTOR)
         .shadow()
-        .find(CLOSE_MENU_BUTTON_SELECTOR)
-        .should(HAVE_FOCUS);
+        .find(CLOSE_MENU_BUTTON_SELECTOR);
+
+      closeMenuButton.should(HAVE_FOCUS);
       cy.realPress("Tab");
       cy.get(NAVIGATION_GROUP_SELECTOR).eq(0).should(HAVE_FOCUS);
       cy.realPress("Tab");
       cy.get(NAVIGATION_GROUP_SELECTOR).eq(1).should(HAVE_FOCUS);
+      cy.realPress("Tab");
+      closeMenuButton.should(HAVE_FOCUS);
     });
 
     it("should render focus state on expandable navigation groups", () => {
@@ -136,16 +140,18 @@ describe("IcNavigationMenu end-to-end and visual regression tests", () => {
       });
     });
 
-    it.skip("should expand navigation groups and tab to navigation items within expandable navigation groups", () => {
+    it("should expand navigation groups and tab to navigation items within expandable navigation groups", () => {
       mount(<WithExpandableNavGroupAndNavItemsTopNav />);
 
       cy.checkShadowElVisible(TOP_NAV_SELECTOR, MENU_BUTTON_SELECTOR);
       cy.findShadowEl(TOP_NAV_SELECTOR, MENU_BUTTON_SELECTOR).click();
 
-      cy.findShadowEl(TOP_NAV_SELECTOR, NAVIGATION_MENU_SELECTOR)
+      const closeMenuButton = cy
+        .findShadowEl(TOP_NAV_SELECTOR, NAVIGATION_MENU_SELECTOR)
         .shadow()
-        .find(CLOSE_MENU_BUTTON_SELECTOR)
-        .should(HAVE_FOCUS);
+        .find(CLOSE_MENU_BUTTON_SELECTOR);
+
+      closeMenuButton.should(HAVE_FOCUS);
       cy.realPress("Tab");
       cy.get(NAVIGATION_GROUP_SELECTOR).eq(0).should(HAVE_FOCUS);
       cy.realPress("Enter");
@@ -157,10 +163,11 @@ describe("IcNavigationMenu end-to-end and visual regression tests", () => {
       cy.get(NAVIGATION_GROUP_SELECTOR).eq(1).should(HAVE_FOCUS);
       cy.realPress("Enter");
       cy.realPress("Tab");
-      // test fails at this point
       cy.get(NAVIGATION_ITEM_SELECTOR).eq(2).should(HAVE_FOCUS);
       cy.realPress("Tab");
       cy.get(NAVIGATION_ITEM_SELECTOR).eq(3).should(HAVE_FOCUS);
+      cy.realPress("Tab");
+      closeMenuButton.should(HAVE_FOCUS);
     });
 
     it("should render with focus state on navigation item within expandable navigation group", () => {

--- a/packages/react/src/stories/ic-top-navigation.stories.js
+++ b/packages/react/src/stories/ic-top-navigation.stories.js
@@ -379,23 +379,6 @@ export const WithGroupNavigation = {
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
       </svg>
       <IcSearchBar slot="search" placeholder="Search" label="Search" />
-      <IcNavigationButton
-        label="Button One"
-        slot="buttons"
-        onClick={() => alert("test")}
-      >
-        <svg
-          slot="icon"
-          xmlns="http://www.w3.org/2000/svg"
-          height="24px"
-          viewBox="0 0 24 24"
-          width="24px"
-          fill="#000000"
-        >
-          <path d="M0 0h24v24H0V0z" fill="none" />
-          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
-        </svg>
-      </IcNavigationButton>
       <IcNavigationGroup
         label="Navigation Group"
         expandable="true"
@@ -419,6 +402,14 @@ export const WithGroupNavigation = {
         <IcNavigationItem label="Six" href="/" />
         <IcNavigationItem label="Seven" href="/" />
         <IcNavigationItem label="Eight" href="/" />
+      </IcNavigationGroup>
+      <IcNavigationGroup
+        label="Third Nav Group"
+        expandable
+        slot="navigation"
+      >
+        <IcNavigationItem label="One" href="/" />
+        <IcNavigationItem label="Two" href="/" />
       </IcNavigationGroup>
     </IcTopNavigation>
   ),
@@ -602,24 +593,7 @@ export const WithReactRouterGrouped = {
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
       </svg>
       <IcSearchBar slot="search" placeholder="Search" label="Search" />
-      <IcNavigationButton
-        label="Button One"
-        slot="buttons"
-        onClick={() => alert("test")}
-      >
-        <svg
-          slot="icon"
-          xmlns="http://www.w3.org/2000/svg"
-          height="24px"
-          viewBox="0 0 24 24"
-          width="24px"
-          fill="#000000"
-        >
-          <path d="M0 0h24v24H0V0z" fill="none" />
-          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
-        </svg>
-      </IcNavigationButton>
-      <IcNavigationGroup label="Navigation Grouped" slot="navigation">
+      <IcNavigationGroup label="Navigation Grouped" slot="navigation" expandable>
         <IcNavigationItem>
           <NavLink to="/" slot="navigation-item">
             Home

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -20,7 +20,7 @@ import { IcLoadingSizes, IcLoadingTypes } from "./components/ic-loading-indicato
 import { IcSearchBarBlurEventDetail, IcSearchBarSearchModes } from "./components/ic-search-bar/ic-search-bar.types";
 import { IcMenuChangeEventDetail, IcMenuOptionIdEventDetail, IcOptionSelectEventDetail } from "./components/ic-menu/ic-menu.types";
 import { IcMenuItemVariants } from "./components/ic-menu-item/ic-menu-item.types";
-import { IcNavigationOpenEventDetail } from "./components/ic-navigation-group/ic-navigation-group.types";
+import { IcNavigationExpandEventDetail, IcNavigationOpenEventDetail } from "./components/ic-navigation-group/ic-navigation-group.types";
 import { IcChangeEventDetail as IcChangeEventDetail1, IcPaginationTypes } from "./components/ic-pagination/ic-pagination.types";
 import { IcPaginationItemType } from "./components/ic-pagination-item/ic-pagination-item.types";
 import { IcChangeEventDetail as IcChangeEventDetail2 } from "./components/ic-radio-group/ic-radio-group.types";
@@ -50,7 +50,7 @@ export { IcLoadingSizes, IcLoadingTypes } from "./components/ic-loading-indicato
 export { IcSearchBarBlurEventDetail, IcSearchBarSearchModes } from "./components/ic-search-bar/ic-search-bar.types";
 export { IcMenuChangeEventDetail, IcMenuOptionIdEventDetail, IcOptionSelectEventDetail } from "./components/ic-menu/ic-menu.types";
 export { IcMenuItemVariants } from "./components/ic-menu-item/ic-menu-item.types";
-export { IcNavigationOpenEventDetail } from "./components/ic-navigation-group/ic-navigation-group.types";
+export { IcNavigationExpandEventDetail, IcNavigationOpenEventDetail } from "./components/ic-navigation-group/ic-navigation-group.types";
 export { IcChangeEventDetail as IcChangeEventDetail1, IcPaginationTypes } from "./components/ic-pagination/ic-pagination.types";
 export { IcPaginationItemType } from "./components/ic-pagination-item/ic-pagination-item.types";
 export { IcChangeEventDetail as IcChangeEventDetail2 } from "./components/ic-radio-group/ic-radio-group.types";
@@ -2929,6 +2929,7 @@ declare global {
     };
     interface HTMLIcNavigationGroupElementEventMap {
         "navigationGroupOpened": IcNavigationOpenEventDetail;
+        "navigationGroupExpanded": IcNavigationExpandEventDetail;
     }
     interface HTMLIcNavigationGroupElement extends Components.IcNavigationGroup, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIcNavigationGroupElementEventMap>(type: K, listener: (this: HTMLIcNavigationGroupElement, ev: IcNavigationGroupCustomEvent<HTMLIcNavigationGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4642,6 +4643,7 @@ declare namespace LocalJSX {
           * The label to display on the group.
          */
         "label": string;
+        "onNavigationGroupExpanded"?: (event: IcNavigationGroupCustomEvent<IcNavigationExpandEventDetail>) => void;
         "onNavigationGroupOpened"?: (event: IcNavigationGroupCustomEvent<IcNavigationOpenEventDetail>) => void;
         /**
           * Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -26,7 +26,10 @@ import {
 } from "../../utils/types";
 
 import chevronIcon from "../../assets/chevron-icon.svg";
-import { IcNavigationOpenEventDetail } from "./ic-navigation-group.types";
+import {
+  IcNavigationExpandEventDetail,
+  IcNavigationOpenEventDetail,
+} from "./ic-navigation-group.types";
 
 @Component({
   tag: "ic-navigation-group",
@@ -75,9 +78,14 @@ export class NavigationGroup {
   @Prop() theme?: IcThemeMode = "inherit";
 
   /**
-   * @internal Emitted when a navigation group opens.
+   * @internal Emitted when a navigation group is opened - when within an ic-top-navigation at large screen sizes.
    */
   @Event() navigationGroupOpened: EventEmitter<IcNavigationOpenEventDetail>;
+
+  /**
+   * @internal Emitted when a navigation group is expanded - when within an ic-top-navigation at small screen sizes.
+   */
+  @Event() navigationGroupExpanded: EventEmitter<IcNavigationExpandEventDetail>;
 
   disconnectedCallback(): void {
     if (this.navigationType === "side") {
@@ -222,6 +230,8 @@ export class NavigationGroup {
 
   private toggleDropdown() {
     this.dropdownOpen = !this.dropdownOpen;
+    this.inTopNavSideMenu &&
+      this.navigationGroupExpanded.emit({ expanded: this.dropdownOpen });
   }
 
   private setGroupedNavItemTabIndex = (tabIndexValue: string) => {

--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.types.ts
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.types.ts
@@ -1,3 +1,7 @@
 export interface IcNavigationOpenEventDetail {
   source: HTMLElement;
 }
+
+export interface IcNavigationExpandEventDetail {
+  expanded: boolean;
+}

--- a/packages/web-components/src/components/ic-navigation-menu/test/basic/ic-navigation-menu.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-menu/test/basic/ic-navigation-menu.spec.ts
@@ -197,4 +197,41 @@ describe("ic-navigation-menu", () => {
 
     expect(page.root).toMatchSnapshot("renders-with-slotted-link");
   });
+
+  it("should update the last tab stop when the last navigation group is expanded", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup, NavigationItem, NavigationMenu],
+      html: `<ic-navigation-menu version="v1.0.0" status="Beta">
+        <ic-navigation-group
+          slot="navigation"
+          label="Navigation group"
+          expandable="true"
+        >
+          <ic-navigation-item label="Navigation 1" href="/"></ic-navigation-item>
+        </ic-navigation-group>
+      </ic-navigation-menu>`,
+    });
+
+    const navGroup = document.querySelector("ic-navigation-group");
+    const navItem = document.querySelector("ic-navigation-item");
+    expect(page.rootInstance.lastTabStop).toBe(navGroup);
+
+    let navGroupExpandedEvent = new CustomEvent("navigationGroupExpanded", {
+      detail: { expanded: true },
+    });
+
+    navGroup?.dispatchEvent(navGroupExpandedEvent);
+    await page.waitForChanges();
+
+    expect(page.rootInstance.lastTabStop).toBe(navItem);
+
+    navGroupExpandedEvent = new CustomEvent("navigationGroupExpanded", {
+      detail: { expanded: false },
+    });
+
+    navGroup?.dispatchEvent(navGroupExpandedEvent);
+    await page.waitForChanges();
+
+    expect(page.rootInstance.lastTabStop).toBe(navGroup);
+  });
 });

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.js
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.js
@@ -452,25 +452,6 @@ export const WithGroupedNavigation = {
         placeholder="Search"
         label="Search"
       ></ic-search-bar>
-      <ic-navigation-button
-        label="Button One"
-        slot="buttons"
-        onclick="alert('test')"
-      >
-        <svg
-          slot="icon"
-          xmlns="http://www.w3.org/2000/svg"
-          height="24px"
-          viewBox="0 0 24 24"
-          width="24px"
-          fill="#000000"
-        >
-          <path d="M0 0h24v24H0V0z" fill="none" />
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"
-          />
-        </svg>
-      </ic-navigation-button>
       <ic-navigation-group slot="navigation" label="Navigation group">
         <ic-navigation-item label="One" href="/"></ic-navigation-item>
         <ic-navigation-item label="Two" href="/"></ic-navigation-item>
@@ -499,6 +480,14 @@ export const WithGroupedNavigation = {
         <ic-navigation-item label="Another Six" href="/"></ic-navigation-item>
         <ic-navigation-item label="Another Seven" href="/"></ic-navigation-item>
         <ic-navigation-item label="Another Eight" href="/"></ic-navigation-item>
+      </ic-navigation-group>
+      <ic-navigation-group
+        slot="navigation"
+        label="Third navigation group"
+        expandable="true"
+      >
+        <ic-navigation-item label="Another One" href="/"></ic-navigation-item>
+        <ic-navigation-item label="Another Two" href="/"></ic-navigation-item>
       </ic-navigation-group>
     </ic-top-navigation>`,
 


### PR DESCRIPTION
## Summary of the changes
Update navigation menu to set the last focusable element / last tab stop correctly. If it is a navigation group, the last tab stop updates depending on whether the group is expanded or collapsed (i.e. changes between the last nav group title or the last child item within the last nav group).

Can be tested by looking at the "With grouped navigation" stories in the web components and React storybooks (See "With React Router - grouped" to see that slotted links in nav items work as well). I have removed nav buttons in some cases to allow this fix to be tested properly (otherwise they would be the last tab stop).

## Related issue
#3261 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.