### PR TITLE
Fix/1873 aria expanded top nav groups

### DIFF
--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -481,7 +481,7 @@ export class NavigationGroup {
   }
 
   render() {
-    const { dropdownOpen, inTopNavSideMenu, expandable } = this;
+    const { dropdownOpen, expanded, inTopNavSideMenu, expandable } = this;
 
     const navGroupTitleClassNames = {
       ["navigation-group"]: true,
@@ -493,51 +493,49 @@ export class NavigationGroup {
       ["selected"]: dropdownOpen && !inTopNavSideMenu,
     };
 
+    const isSideNav = this.navigationType === "side";
+    const isTopNav = this.navigationType === "top";
+
+    const ariaExpanded = (isSideNav && expanded) || (isTopNav && dropdownOpen);
+
     return (
       <Host
         class={{
           ["in-side-menu"]: inTopNavSideMenu,
-          "ic-navigation-group-expanded": this.expanded,
-          "ic-navigation-group-collapsed": !this.expanded,
-          ["ic-navigation-group-side-nav"]: this.navigationType === "side",
+          "ic-navigation-group-expanded": expanded,
+          "ic-navigation-group-collapsed": !expanded,
+          ["ic-navigation-group-side-nav"]: isSideNav,
           [`ic-theme-${this.theme}`]: this.theme !== "inherit",
           ["ic-navigation-group-expandable"]: !!expandable,
         }}
         role="listitem"
       >
-        {this.expandable ||
-        (!inTopNavSideMenu && this.navigationType === "top") ? (
+        {this.expandable || (!inTopNavSideMenu && isTopNav) ? (
           <button
             onMouseEnter={
-              !inTopNavSideMenu && this.navigationType === "top"
-                ? this.handleMouseEnter
-                : undefined
+              !inTopNavSideMenu && isTopNav ? this.handleMouseEnter : undefined
             }
-            onMouseLeave={
-              this.navigationType === "top" ? this.handleMouseLeave : undefined
-            }
+            onMouseLeave={isTopNav ? this.handleMouseLeave : undefined}
             onBlur={this.handleBlur}
             onClick={this.handleClick}
             onKeyDown={this.handleKeydown}
             class={navGroupTitleClassNames}
             ref={(el) => (this.groupEl = el)}
-            aria-expanded={`${dropdownOpen || this.expanded}`}
-            aria-haspopup={`${
-              !inTopNavSideMenu && this.navigationType === "top"
-            }`}
+            aria-expanded={`${ariaExpanded}`}
+            aria-haspopup={`${!inTopNavSideMenu && isTopNav}`}
           >
             {this.renderGroupTitleText()}
-            {this.navigationType === "side" && expandable && (
+            {isSideNav && expandable && (
               <div
                 class={{
                   "chevron-toggle-icon-wrapper": true,
-                  "chevron-toggle-icon-closed": this.expanded,
+                  "chevron-toggle-icon-closed": expanded,
                 }}
                 innerHTML={chevronIcon}
               ></div>
             )}
           </button>
-        ) : this.navigationType === "side" && !this.isSideNavExpanded ? null : (
+        ) : isSideNav && !this.isSideNavExpanded ? null : (
           <div class={navGroupTitleClassNames}>
             {this.renderGroupTitleText()}
           </div>

--- a/packages/web-components/src/components/ic-navigation-group/test/basic/__snapshots__/ic-navigation-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-navigation-group/test/basic/__snapshots__/ic-navigation-group.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ic-navigation-group should render as expandable: renders-expandable 1`] = `
 <ic-navigation-group class="ic-navigation-group-expandable ic-navigation-group-expanded" expandable="true" label="Group label" role="listitem">
   <template shadowrootmode="open">
-    <button aria-expanded="true" aria-haspopup="false" class="light navigation-group">
+    <button aria-expanded="false" aria-haspopup="false" class="light navigation-group">
       <ic-typography id="nav-group-title" variant="label">
         Group label
       </ic-typography>
@@ -18,7 +18,7 @@ exports[`ic-navigation-group should render as expandable: renders-expandable 1`]
 exports[`ic-navigation-group should render correctly when in a top navigation when not expandable: renders-in-desktop-top-nav 1`] = `
 <ic-navigation-group class="ic-navigation-group-expanded" label="Group label" role="listitem">
   <template shadowrootmode="open">
-    <button aria-expanded="true" aria-haspopup="true" class="light navigation-group">
+    <button aria-expanded="false" aria-haspopup="true" class="light navigation-group">
       <ic-typography id="nav-group-title" variant="label">
         Group label
       </ic-typography>

--- a/packages/web-components/src/components/ic-navigation-group/test/basic/ic-navigation-group.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-group/test/basic/ic-navigation-group.spec.ts
@@ -18,6 +18,7 @@ const ev = {
 };
 
 const timeOut = 1000;
+const ariaExpanded = "aria-expanded";
 
 describe("ic-navigation-group", () => {
   it("should render with label", async () => {
@@ -360,6 +361,55 @@ describe("ic-navigation-group", () => {
     expect(
       page.root?.shadowRoot?.querySelector(".navigation-group")
     ).toBeNull();
+  });
+
+  it("should set aria-expanded correctly inside a side navigation", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup, NavigationItem],
+      html: `<ic-navigation-group label="Group label" expandable="true">
+        <ic-navigation-item href="/" label="Home"></ic-navigation-item>
+      </ic-navigation-group>`,
+    });
+    await waitForNavGroupLoad();
+
+    page.rootInstance.navigationType = "side";
+    await page.waitForChanges();
+
+    const navGroup = page.root?.shadowRoot?.querySelector("button");
+    expect(navGroup?.getAttribute(ariaExpanded)).toBe("true");
+
+    page.rootInstance.expanded = false;
+    await page.waitForChanges();
+    expect(navGroup?.getAttribute(ariaExpanded)).toBe("false");
+  });
+
+  it("should set aria-expanded correctly inside a top navigation", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup, NavigationItem],
+      html: `<ic-navigation-group label="Group label">
+        <ic-navigation-item href="/" label="Home"></ic-navigation-item>
+      </ic-navigation-group>`,
+    });
+    await waitForNavGroupLoad();
+
+    page.rootInstance.navigationType = "top";
+    await page.waitForChanges();
+
+    const navGroup = page.root?.shadowRoot?.querySelector("button");
+    expect(navGroup?.getAttribute(ariaExpanded)).toBe("false");
+
+    page.rootInstance.dropdownOpen = true;
+    await page.waitForChanges();
+    expect(navGroup?.getAttribute(ariaExpanded)).toBe("true");
+
+    page.rootInstance.inTopNavSideMenu = true;
+    page.root?.setAttribute("expandable", "true");
+    await page.waitForChanges();
+    expect(navGroup?.getAttribute(ariaExpanded)).toBe("true");
+
+    page.rootInstance.dropdownOpen = false;
+    await page.waitForChanges();
+    expect(navGroup?.getAttribute(ariaExpanded)).toBe("false");
   });
 
   // NOTE: This must go last as mocks getCurrentDeviceSize function, which will apply to all subsequent tests

--- a/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
@@ -247,7 +247,7 @@ exports[`ic-navigation-menu should test slotted navigation group: renders-with-s
   </template>
   <ic-navigation-group class="ic-navigation-group-expandable ic-navigation-group-expanded" expandable="true" label="Navigation group" role="listitem" slot="navigation">
     <template shadowrootmode="open">
-      <button aria-expanded="true" aria-haspopup="false" class="light navigation-group">
+      <button aria-expanded="false" aria-haspopup="false" class="light navigation-group">
         <ic-typography id="nav-group-title" variant="label">
           Navigation group
         </ic-typography>


### PR DESCRIPTION
## Summary of the changes
Updated aria-expanded on ic-navigation-group to work correctly. Added unit tests to check aria-expanded in all situations (e.g. top nav on both large and small screens, and side nav). Also reduced code duplication slightly.

Go to the "With grouped navigation" top nav story to test this. Should work on a small screen as well.

## Related issue
#1873

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.