### PR TITLE
fix(web-components): fix ic-page-header nav element aria label

### DIFF
--- a/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
@@ -170,9 +170,11 @@ export class PageHeader {
       theme,
     } = this;
 
-    const navAriaLabel = heading
-      ? `${heading} page sections`
-      : "navigation-landmark-page-header";
+    const navAriaLabel = `${
+      isSlotUsed(this.el, "heading")
+        ? this.el.querySelector('[slot="heading"]')?.textContent ?? ""
+        : heading ?? ""
+    } page sections`;
 
     return (
       <Host

--- a/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
+++ b/packages/web-components/src/components/ic-page-header/test/basic/__snapshots__/ic-page-header.spec.ts.snap
@@ -236,6 +236,57 @@ exports[`ic-page-header component renders additional functionality should render
 </ic-page-header>
 `;
 
+exports[`ic-page-header component renders additional functionality should render tabs & slotted heading: should render tabs & slotted heading 1`] = `
+<ic-page-header aria-label="page header" subheading="This is a simple page header component and this is the text.">
+  <template shadowrootmode="open">
+    <header class="border-bottom tabs" role="presentation">
+      <ic-section-container aligned="left" fullheight="">
+        <div class="main-content">
+          <div class="title-area">
+            <div class="header-content">
+              <slot name="heading">
+                <ic-typography class="heading" variant="h2">
+                  <h2></h2>
+                </ic-typography>
+              </slot>
+              <slot name="heading-adornment"></slot>
+            </div>
+            <div class="subheading-content">
+              <slot name="subheading">
+                <ic-typography variant="body">
+                  This is a simple page header component and this is the text.
+                </ic-typography>
+              </slot>
+            </div>
+          </div>
+        </div>
+        <div class="navigation-area">
+          <nav aria-label="
+          
+            Coffee recipes
+          
+         page sections">
+            <ic-horizontal-scroll>
+              <ul class="tabs-slot">
+                <slot name="tabs"></slot>
+              </ul>
+            </ic-horizontal-scroll>
+          </nav>
+        </div>
+      </ic-section-container>
+    </header>
+  </template>
+  <ic-typography slot="heading" variant="h2">
+    <h2>
+      Coffee recipes
+    </h2>
+  </ic-typography>
+  <ic-status-tag label="Beta" slot="heading-adornment"></ic-status-tag>
+  <ic-navigation-item href="/all-recipes" label="All recipes" selected="" slot="tabs"></ic-navigation-item>
+  <ic-navigation-item href="/favourites" label="Favourites" slot="tabs"></ic-navigation-item>
+</ic-page-header>
+`;
+
 exports[`ic-page-header component renders additional functionality should render tabs: should render tabs 1`] = `
 <ic-page-header aria-label="page header" heading="Coffee recipes" subheading="This is a simple page header component and this is the text.">
   <template shadowrootmode="open">

--- a/packages/web-components/src/components/ic-page-header/test/basic/ic-page-header.spec.ts
+++ b/packages/web-components/src/components/ic-page-header/test/basic/ic-page-header.spec.ts
@@ -115,6 +115,35 @@ describe("ic-page-header component renders additional functionality", () => {
     expect(page.root).toMatchSnapshot("should render tabs");
   });
 
+  it("should render tabs & slotted heading", async () => {
+    const page = await newSpecPage({
+      components: [PageHeader],
+      html: `
+      <ic-page-header aria-label="page header" subheading="This is a simple page header component and this is the text.">
+        <ic-typography variant="h2" slot="heading">
+          <h2>
+            Coffee recipes
+          </h2>
+        </ic-typography>
+        <ic-status-tag slot="heading-adornment" label="Beta"></ic-status-tag>
+        <ic-navigation-item
+          slot="tabs"
+          label="All recipes"
+          href="/all-recipes"
+          selected
+        ></ic-navigation-item>
+        <ic-navigation-item
+          slot="tabs"
+          label="Favourites"
+          href="/favourites"
+        ></ic-navigation-item>
+      </ic-page-header>
+      `,
+    });
+
+    expect(page.root).toMatchSnapshot("should render tabs & slotted heading");
+  });
+
   it("should render actions, input & tabs", async () => {
     const page = await newSpecPage({
       components: [PageHeader],


### PR DESCRIPTION
change nav aria label to reflect slotted heading text content and remove redundant "navigation landmark"

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
 Remove redundant "navigation landmark" from the <nav> aria label on the ic-page-header (used with slotted tabs).
The aria label is `myHeading page sections` using the heading prop if used or the slotted heading `textContent` if not.

Unit test added to ensure this aria label is correct when a slotted heading is used.

## Related issue
#3120 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.