### PR TITLE
fix(web-components): update side nav menu button to correct hover and pressed colours

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.css
+++ b/packages/web-components/src/components/ic-button/ic-button.css
@@ -1076,7 +1076,7 @@ slot[name="router-item"]::slotted(a) {
   * uses secondary monochrome tokens which are duplicated here to avoid multiple copies in each component
   */
 
-:host(#menu-button.ic-theme-light) {
+:host(#menu-button.ic-theme-dark) {
   --ic-button-secondary-background-hover-monochrome: var(
     --ic-action-dark-bg-hover
   );
@@ -1097,7 +1097,7 @@ slot[name="router-item"]::slotted(a) {
   );
 }
 
-:host(#menu-button.ic-theme-dark) {
+:host(#menu-button.ic-theme-light) {
   --ic-button-secondary-background-hover-monochrome: var(
     --ic-action-light-bg-hover
   );

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -425,11 +425,7 @@ export class TopNavigation {
                           monochrome
                           size={searchButtonSize}
                           aria-label={mobileSearchButtonTitle}
-                          theme={
-                            foregroundColor == IcBrandForegroundEnum.Light
-                              ? IcBrandForegroundEnum.Dark
-                              : IcBrandForegroundEnum.Light
-                          }
+                          theme={foregroundColor as IcThemeMode}
                           onClick={searchButtonClickHandler}
                         >
                           <slot name="toggle-icon">
@@ -465,11 +461,7 @@ export class TopNavigation {
                           >
                             <ic-button
                               id="menu-button"
-                              theme={
-                                foregroundColor == IcBrandForegroundEnum.Light
-                                  ? IcBrandForegroundEnum.Dark
-                                  : IcBrandForegroundEnum.Light
-                              }
+                              theme={foregroundColor as IcThemeMode}
                               variant="secondary"
                               monochrome
                               aria-expanded="false"

--- a/packages/web-components/src/components/ic-top-navigation/test/basic/__snapshots__/ic-top-navigation.spec.ts.snap
+++ b/packages/web-components/src/components/ic-top-navigation/test/basic/__snapshots__/ic-top-navigation.spec.ts.snap
@@ -305,7 +305,7 @@ exports[`ic-top-navigation should render with slotted short-app-title: renders-w
                     Main navigation button
                   </span>
                   <nav aria-hidden="false" aria-labelledby="navigation-landmark-button-text">
-                    <ic-button aria-expanded="false" aria-haspopup="true" aria-label="Open app menu" id="menu-button" monochrome="" size="small" theme="dark" variant="secondary">
+                    <ic-button aria-expanded="false" aria-haspopup="true" aria-label="Open app menu" id="menu-button" monochrome="" size="small" theme="light" variant="secondary">
                       Menu
                       <svg fill="#ffffff" height="24px" slot="left-icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
                         <path d="M0 0h24v24H0V0z" fill="none"></path>


### PR DESCRIPTION
## Summary of the changes
Updated the menu button on side navigation (shown on small screens) to have the correct hover and pressed state colours.

Fixed for both light and dark theme colours (see "Brand" story in React storybook). 

## Related issue
#3380

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.