### PR TITLE
Changelog updates for v3 release

### DIFF
--- a/packages/canary-docs/CHANGELOG.md
+++ b/packages/canary-docs/CHANGELOG.md
@@ -17,17 +17,48 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @ukic/canary-docs
 
-# [3.0.0]
+# [3.0.0-canary.8](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.7...@ukic/canary-docs@3.0.0-canary.8) (2025-02-20)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# [3.0.0-canary.7](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.6...@ukic/canary-docs@3.0.0-canary.7) (2025-01-22)
 
 ### Bug Fixes
 
 - **canary-docs:** add icSelectedRowChange event to IcDataTable ([2c32253](https://github.com/mi6/ic-ui-kit/commit/2c32253e21b05c8535ecb34b5a5e908ad2d6a265)), closes [#1226](https://github.com/mi6/ic-ui-kit/issues/1226)
 - **canary-docs:** set IcPaginationBar to the first page when the items per page changes ([8ac2c2b](https://github.com/mi6/ic-ui-kit/commit/8ac2c2bed604d9bf09d1297bc85820bae490729b)), closes [#2639](https://github.com/mi6/ic-ui-kit/issues/2639)
-- **canary-docs:** update docs to have updated data table prop description ([28bcecb](https://github.com/mi6/ic-ui-kit/commit/28bcecbc868f81fddb4b0c3abe5d52d2216abc83))
+
+# [3.0.0-canary.6](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.5...@ukic/canary-docs@3.0.0-canary.6) (2025-01-08)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# [3.0.0-canary.5](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.4...@ukic/canary-docs@3.0.0-canary.5) (2024-12-09)
 
 ### Documentation
 
 - **canary-docs:** changes to canary-docs ([2ec62c9](https://github.com/mi6/ic-ui-kit/commit/2ec62c949fcbb052cb1d0f90c9376003f88a02a6))
+
+### BREAKING CHANGES
+
+- **canary-docs:** dark mode
+
+# [3.0.0-canary.4](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.3...@ukic/canary-docs@3.0.0-canary.4) (2024-11-14)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# [3.0.0-canary.3](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.2...@ukic/canary-docs@3.0.0-canary.3) (2024-10-31)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# [3.0.0-canary.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@3.0.0-canary.1...@ukic/canary-docs@3.0.0-canary.2) (2024-10-17)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# 3.0.0-canary.1 (2024-10-04)
+
+### Bug Fixes
+
+- **canary-docs:** update docs to have updated data table prop description ([28bcecb](https://github.com/mi6/ic-ui-kit/commit/28bcecbc868f81fddb4b0c3abe5d52d2216abc83))
 
 ### Code Refactoring
 
@@ -35,10 +66,30 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-- **canary-docs:** dark mode
 - **docs:** Size prop type changed from 'default' to 'medium'
 
-# 2.0.0-canary.28 (2025-02-12)
+
+# [2.0.0-canary.32](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@2.0.0-canary.31...@ukic/canary-docs@2.0.0-canary.32) (2025-04-16)
+
+### Features
+
+- **canary-docs:** add ability to hide the icdateinput in the icdatepicker ([63f882d](https://github.com/mi6/ic-ui-kit/commit/63f882d2f47e95356cb3f9efdc5ebf9f01bdd2a8)), closes [#3357](https://github.com/mi6/ic-ui-kit/issues/3357)
+
+# [2.0.0-canary.31](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@2.0.0-canary.30...@ukic/canary-docs@2.0.0-canary.31) (2025-04-07)
+
+### Features
+
+- **canary-docs:** add ability to hide the icdateinput in the icdatepicker ([51fb149](https://github.com/mi6/ic-ui-kit/commit/51fb149743f3ce291c041e03681017bc65ed4437)), closes [#3357](https://github.com/mi6/ic-ui-kit/issues/3357)
+
+# [2.0.0-canary.30](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@2.0.0-canary.29...@ukic/canary-docs@2.0.0-canary.30) (2025-03-05)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# [2.0.0-canary.29](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@2.0.0-canary.28...@ukic/canary-docs@2.0.0-canary.29) (2025-02-19)
+
+**Note:** Version bump only for package @ukic/canary-docs
+
+# [2.0.0-canary.28](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-docs@2.0.0-canary.27...@ukic/canary-docs@2.0.0-canary.28) (2025-02-12)
 
 ### Bug Fixes
 

--- a/packages/canary-react/CHANGELOG.md
+++ b/packages/canary-react/CHANGELOG.md
@@ -14,7 +14,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-- **canary-react:** No longer truncates on mobile
+- **canary-react:** removed truncation from mobile view of tree-view
 
 # [3.0.0-canary.13](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.12...@ukic/canary-react@3.0.0-canary.13) (2025-04-08)
 
@@ -50,43 +50,117 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **canary-react:** showBackground has been removed from loading options
 
-# [3.0.0]
+# [3.0.0-canary.10](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.9...@ukic/canary-react@3.0.0-canary.10) (2025-02-20)
 
 ### Bug Fixes
-
-- **canary-react:** add Cypress visual regression for date picker clear icon dark mode ([ee1c1e7](https://github.com/mi6/ic-ui-kit/commit/ee1c1e74ade79f995b5362975ac699a67602184d))
-- **canary-react:** added cypress tests and baseline images ([30037d3](https://github.com/mi6/ic-ui-kit/commit/30037d3aa1cf54628c7b85432dcb60fd9a5f9454))
-- **canary-react:** allow IcDataTable action-element to support tooltips ([d71ba60](https://github.com/mi6/ic-ui-kit/commit/d71ba6076ab7100baa5c0eaf400deb3d0c831230)), closes [#2964](https://github.com/mi6/ic-ui-kit/issues/2964)
-- **canary-react:** allow IcPaginationBar items per page to be set programmatically ([a2962d1](https://github.com/mi6/ic-ui-kit/commit/a2962d1a172d22bbe14971843d5612221e7991ac)), closes [#2525](https://github.com/mi6/ic-ui-kit/issues/2525)
-- **canary-react:** prevent IcDataTable action element clicks from selecting the table row ([7ed7bd0](https://github.com/mi6/ic-ui-kit/commit/7ed7bd01706bf91b995b12a13d613409fe602b84))
-- **canary-react:** update date input Cypress test to check helper text doesn't exist ([9df6b95](https://github.com/mi6/ic-ui-kit/commit/9df6b9577ad9587408d110ccda3b1ffdbb7ad9eb)), closes [#2370](https://github.com/mi6/ic-ui-kit/issues/2370)
-
-### Features
 
 - **canary-react:** implement disableAutoSort prop on data table ([da93cb0](https://github.com/mi6/ic-ui-kit/commit/da93cb08780555119596486bd8e0edfe1e2fca9b)), closes [#2415](https://github.com/mi6/ic-ui-kit/issues/2415)
 - **canary-react:** update tree view truncation story to have expanded items ([2c6546c](https://github.com/mi6/ic-ui-kit/commit/2c6546c65196bc2c4dfc8737601faa3856204674))
 
+# [3.0.0-canary.9](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.8...@ukic/canary-react@3.0.0-canary.9) (2025-02-05)
+
 ### Bug Fixes
 
 - **canary-react:** add Cypress visual regression for date picker clear icon dark mode ([ee1c1e7](https://github.com/mi6/ic-ui-kit/commit/ee1c1e74ade79f995b5362975ac699a67602184d))
 - **canary-react:** allow IcDataTable action-element to support tooltips ([d71ba60](https://github.com/mi6/ic-ui-kit/commit/d71ba6076ab7100baa5c0eaf400deb3d0c831230)), closes [#2964](https://github.com/mi6/ic-ui-kit/issues/2964)
 
+# [3.0.0-canary.8](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.7...@ukic/canary-react@3.0.0-canary.8) (2025-01-24)
+
 ### Bug Fixes
 
 - **canary-react:** allow IcDataTable action-element to support tooltips ([d71ba60](https://github.com/mi6/ic-ui-kit/commit/d71ba6076ab7100baa5c0eaf400deb3d0c831230)), closes [#2964](https://github.com/mi6/ic-ui-kit/issues/2964)
-- **root:** fixes after big rebase ([490c292](https://github.com/mi6/ic-ui-kit/commit/490c292e9294c97d938575ea114f769a730628bc))
-- **canary-react:** adds test for icon data-table fix ([9d46ce7](https://github.com/mi6/ic-ui-kit/commit/9d46ce70c06c313400491c64294ce0b177b062ba))
-- **canary-react:** fixes data-table column width example ([d52ba3a](https://github.com/mi6/ic-ui-kit/commit/d52ba3a6d3e19f3331c6066be4ce0f974a9d7097))
-- **canary-react:** fixes tooltip display in data-tables ([66adb5b](https://github.com/mi6/ic-ui-kit/commit/66adb5b28cbbb248a6894ae33a74e2de751b6119))
-- **canary-react:** adds test for tooltip fix ([a35bc74](https://github.com/mi6/ic-ui-kit/commit/a35bc744ff0d5655c2c80b18f4f0d2408e32ee19))
-- **canary-react:** update tree view stories to include expanded example ([fe66b26](https://github.com/mi6/ic-ui-kit/commit/fe66b264e6787a2a3bf5c5a8778e52bc7b5ccc2b))
+
+# [3.0.0-canary.7](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.6...@ukic/canary-react@3.0.0-canary.7) (2025-01-22)
+
+### Bug Fixes
+
+- **canary-react:** add icSelectedRowChange event to IcDataTable ([75f6e3a](https://github.com/mi6/ic-ui-kit/commit/75f6e3a282755aa81547ec36c3106c63ec28312b)), closes [#1226](https://github.com/mi6/ic-ui-kit/issues/1226)
+- **canary-react:** set IcPaginationBar to the first page when the items per page changes ([9864637](https://github.com/mi6/ic-ui-kit/commit/9864637c07b216639caba93188284a276e19ae9c)), closes [#2639](https://github.com/mi6/ic-ui-kit/issues/2639)
+
+### Features
+
+- **canary-react:** add action onclick to action element on dataTable ([1d20153](https://github.com/mi6/ic-ui-kit/commit/1d20153fc5bc07c9fba8c9eaf314d96723b6b2fc))
+- **canary-react:** updated data table story to include overlay copy ([be10b49](https://github.com/mi6/ic-ui-kit/commit/be10b492f03f4d8e920b3974dd90046956474f73)), closes [#2968](https://github.com/mi6/ic-ui-kit/issues/2968)
+
+# [3.0.0-canary.6](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.5...@ukic/canary-react@3.0.0-canary.6) (2025-01-08)
+
+### Bug Fixes
+
+- **canary-react:** Allow the IcDataTable to handle empty cell data values ([099fc98](https://github.com/mi6/ic-ui-kit/commit/099fc98384c91eeee55991e5831c38687daad2fb))
+
+### Features
+
+- **canary-react:** add action-element tests and story ([35e0fc5](https://github.com/mi6/ic-ui-kit/commit/35e0fc5a3ede5ed6e547fd4c4a15cac801bc7094))
+- **canary-react:** update storybook example for links in IcDataTable to include new target key ([dd74fc5](https://github.com/mi6/ic-ui-kit/commit/dd74fc55e697b305f3a170b1963cf433a76715c8)), closes [#2751](https://github.com/mi6/ic-ui-kit/issues/2751)
+- **canary-react:** update tree view/tree item to text wrap by default ([0220f96](https://github.com/mi6/ic-ui-kit/commit/0220f96c70ef9de0fb138738d16723bd9c615640))
+
+# [3.0.0-canary.5](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.4...@ukic/canary-react@3.0.0-canary.5) (2024-12-09)
+
+### Bug Fixes
+
+- **canary-react:** update cypress images after colour/token update ([2db79d5](https://github.com/mi6/ic-ui-kit/commit/2db79d590395084d3a2f63b957c0b4cc30445e64))
+
+### Features
+
+- **canary-react:** added dark mode features, stories & tests to data-table ([34f4a66](https://github.com/mi6/ic-ui-kit/commit/34f4a6694e7bb35c9554ff72d118a22eb94275bc))
+- **canary-react:** adds tests & storybook playground for theme prop ([a977327](https://github.com/mi6/ic-ui-kit/commit/a977327a4e280e36f2b0e58556bae5a19e330608))
+- **canary-react:** dark mode ([2e6013e](https://github.com/mi6/ic-ui-kit/commit/2e6013e31604fa11b53a4395183b633aa926b987))
+
+### BREAKING CHANGES
+
+- **canary-react:** new theme prop and colour switching
+- **canary-react:** dark mode
+- **canary-react:** removed appearance option from updatingOptions, loadingOptions & paginationOptions
+
+# [3.0.0-canary.4](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.3...@ukic/canary-react@3.0.0-canary.4) (2024-11-14)
+
+### Bug Fixes
+
 - **canary-react:** fixes version in package-lock ([57dd93c](https://github.com/mi6/ic-ui-kit/commit/57dd93c6ae0050fcc14612c62dd8c19e178e24e4))
 - **canary-react:** remove appearance from pagination stories and fix cypress tests ([e159b2c](https://github.com/mi6/ic-ui-kit/commit/e159b2cb6062cd46f33e1342a68b56f56bfd1f7d))
 - **canary-react:** update broken date picker test ([071c547](https://github.com/mi6/ic-ui-kit/commit/071c547ccd8a8a06f5e64a4a95e8c458a568ce4f))
-- **canary-react:** update cypress images after colour/token update ([2db79d5](https://github.com/mi6/ic-ui-kit/commit/2db79d590395084d3a2f63b957c0b4cc30445e64))
-- **canary-react:** Allow the IcDataTable to handle empty cell data values ([099fc98](https://github.com/mi6/ic-ui-kit/commit/099fc98384c91eeee55991e5831c38687daad2fb))
-- **canary-react:** add icSelectedRowChange event to IcDataTable ([75f6e3a](https://github.com/mi6/ic-ui-kit/commit/75f6e3a282755aa81547ec36c3106c63ec28312b)), closes [#1226](https://github.com/mi6/ic-ui-kit/issues/1226)
-- **canary-react:** set IcPaginationBar to the first page when the items per page changes ([9864637](https://github.com/mi6/ic-ui-kit/commit/9864637c07b216639caba93188284a276e19ae9c)), closes [#2639](https://github.com/mi6/ic-ui-kit/issues/2639)
+
+### Features
+
+- **canary-react:** added theme prop to IcCardHorizontal ([83a475f](https://github.com/mi6/ic-ui-kit/commit/83a475f7a0f5d22ae6416770398c34d4b39f5481))
+- **canary-react:** data-table column header truncation ([a9e996c](https://github.com/mi6/ic-ui-kit/commit/a9e996c2a7b4fb80452703189a441a7386027880))
+- **canary-react:** remove appearance prop and add theme prop to tree view ([9d1c2a8](https://github.com/mi6/ic-ui-kit/commit/9d1c2a8e8823c4aa7c05be70b3dce83e8135cef1))
+
+# [3.0.0-canary.3](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.2...@ukic/canary-react@3.0.0-canary.3) (2024-10-31)
+
+### Bug Fixes
+
+- **canary-react:** adds test for tooltip fix ([a35bc74](https://github.com/mi6/ic-ui-kit/commit/a35bc744ff0d5655c2c80b18f4f0d2408e32ee19))
+- **canary-react:** update tree view stories to include expanded example ([fe66b26](https://github.com/mi6/ic-ui-kit/commit/fe66b264e6787a2a3bf5c5a8778e52bc7b5ccc2b))
+
+### Features
+
+- **canary-react:** add focus inset prop to tree view items ([6ba7285](https://github.com/mi6/ic-ui-kit/commit/6ba7285c1a18367ae136a6322053faca83e7f2ee))
+- **canary-react:** added tests for date input ([c1f6c8d](https://github.com/mi6/ic-ui-kit/commit/c1f6c8d38a2a91142ea5dc663d6b82255f28efa5))
+- **canary-react:** implement hideAllFromItemsPerPage & remove limit on itemsPerPage opts ([ba7ca3b](https://github.com/mi6/ic-ui-kit/commit/ba7ca3bf9afebcd2b3a1db9bdd1987527d141738))
+- **canary-react:** remove all multi-select files (moved to core package) ([d7fb59a](https://github.com/mi6/ic-ui-kit/commit/d7fb59af37384bf77a0440d1bb5ad286732cc3a7))
+
+### Performance Improvements
+
+- **canary-react:** add the ability to change between themes in Storybook toolbar ([dd34ce8](https://github.com/mi6/ic-ui-kit/commit/dd34ce8da9a8d1fec8db1542120820d836c977ec))
+
+# [3.0.0-canary.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@3.0.0-canary.1...@ukic/canary-react@3.0.0-canary.2) (2024-10-17)
+
+### Bug Fixes
+
+- **canary-react:** adds test for icon data-table fix ([9d46ce7](https://github.com/mi6/ic-ui-kit/commit/9d46ce70c06c313400491c64294ce0b177b062ba))
+- **canary-react:** fixes data-table column width example ([d52ba3a](https://github.com/mi6/ic-ui-kit/commit/d52ba3a6d3e19f3331c6066be4ce0f974a9d7097))
+- **canary-react:** fixes tooltip display in data-tables ([66adb5b](https://github.com/mi6/ic-ui-kit/commit/66adb5b28cbbb248a6894ae33a74e2de751b6119))
+
+### Features
+
+- **canary-react:** adds currentPage prop to pagination bar ([7d4d2b8](https://github.com/mi6/ic-ui-kit/commit/7d4d2b89fea55f4080884dce9b323da721bd97f7))
+
+# 3.0.0-canary.1 (2024-10-04)
+
+### Bug Fixes
+
+- **root:** fixes after big rebase ([490c292](https://github.com/mi6/ic-ui-kit/commit/490c292e9294c97d938575ea114f769a730628bc))
 
 ### Code Refactoring
 
@@ -99,31 +173,36 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **canary-react:** added column width tests ([c2d59dd](https://github.com/mi6/ic-ui-kit/commit/c2d59dd79368bf012ed7d72b1c0394d5305e772c))
 - **canary-react:** change multi-select E2E, a11y and visual tests to use Cypress ([adce3e3](https://github.com/mi6/ic-ui-kit/commit/adce3e32d26f9c8e46b5b893b698e7efc4c74fff))
 - **canary-react:** ic-typography color changes ([1c8112e](https://github.com/mi6/ic-ui-kit/commit/1c8112ed377c64143bfb3b153e08123040cfdc8f))
-- **canary-react:** adds currentPage prop to pagination bar ([7d4d2b8](https://github.com/mi6/ic-ui-kit/commit/7d4d2b89fea55f4080884dce9b323da721bd97f7))
-- **canary-react:** add focus inset prop to tree view items ([6ba7285](https://github.com/mi6/ic-ui-kit/commit/6ba7285c1a18367ae136a6322053faca83e7f2ee))
-- **canary-react:** added tests for date input ([c1f6c8d](https://github.com/mi6/ic-ui-kit/commit/c1f6c8d38a2a91142ea5dc663d6b82255f28efa5))
-- **canary-react:** implement hideAllFromItemsPerPage & remove limit on itemsPerPage opts ([ba7ca3b](https://github.com/mi6/ic-ui-kit/commit/ba7ca3bf9afebcd2b3a1db9bdd1987527d141738))
-- **canary-react:** remove all multi-select files (moved to core package) ([d7fb59a](https://github.com/mi6/ic-ui-kit/commit/d7fb59af37384bf77a0440d1bb5ad286732cc3a7))
-- **canary-react:** added theme prop to IcCardHorizontal ([83a475f](https://github.com/mi6/ic-ui-kit/commit/83a475f7a0f5d22ae6416770398c34d4b39f5481))
-- **canary-react:** data-table column header truncation ([a9e996c](https://github.com/mi6/ic-ui-kit/commit/a9e996c2a7b4fb80452703189a441a7386027880))
-- **canary-react:** remove appearance prop and add theme prop to tree view ([9d1c2a8](https://github.com/mi6/ic-ui-kit/commit/9d1c2a8e8823c4aa7c05be70b3dce83e8135cef1))
-- **canary-react:** added dark mode features, stories & tests to data-table ([34f4a66](https://github.com/mi6/ic-ui-kit/commit/34f4a6694e7bb35c9554ff72d118a22eb94275bc))
-- **canary-react:** adds tests & storybook playground for theme prop ([a977327](https://github.com/mi6/ic-ui-kit/commit/a977327a4e280e36f2b0e58556bae5a19e330608))
-- **canary-react:** dark mode ([2e6013e](https://github.com/mi6/ic-ui-kit/commit/2e6013e31604fa11b53a4395183b633aa926b987))
-- **canary-react:** add action-element tests and story ([35e0fc5](https://github.com/mi6/ic-ui-kit/commit/35e0fc5a3ede5ed6e547fd4c4a15cac801bc7094))
-- **canary-react:** update storybook example for links in IcDataTable to include new target key ([dd74fc5](https://github.com/mi6/ic-ui-kit/commit/dd74fc55e697b305f3a170b1963cf433a76715c8)), closes [#2751](https://github.com/mi6/ic-ui-kit/issues/2751)
-- **canary-react:** update tree view/tree item to text wrap by default ([0220f96](https://github.com/mi6/ic-ui-kit/commit/0220f96c70ef9de0fb138738d16723bd9c615640))- **canary-react:** add action onclick to action element on dataTable ([1d20153](https://github.com/mi6/ic-ui-kit/commit/1d20153fc5bc07c9fba8c9eaf314d96723b6b2fc))
-- **canary-react:** updated data table story to include overlay copy ([be10b49](https://github.com/mi6/ic-ui-kit/commit/be10b492f03f4d8e920b3974dd90046956474f73)), closes [#2968](https://github.com/mi6/ic-ui-kit/issues/2968)
 
-### Performance Improvements
+# [2.0.0-canary.40](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@2.0.0-canary.38...@ukic/canary-react@2.0.0-canary.40) (2025-04-16)
 
-- **canary-react:** add the ability to change between themes in Storybook toolbar ([dd34ce8](https://github.com/mi6/ic-ui-kit/commit/dd34ce8da9a8d1fec8db1542120820d836c977ec))
+### Features
 
-### BREAKING CHANGES
+- **canary-react:** add ability to hide the icdateinput in the icdatepicker ([9e6128b](https://github.com/mi6/ic-ui-kit/commit/9e6128bd6deddfd70c4dabcda28bdcf8872a879c)), closes [#3357](https://github.com/mi6/ic-ui-kit/issues/3357)
 
-- **canary-react:** dark mode
-- **canary-react:** new theme prop and colour switching
-- **canary-react:** removed appearance option from updatingOptions, loadingOptions & paginationOptions
+# [2.0.0-canary.39](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@2.0.0-canary.38...@ukic/canary-react@2.0.0-canary.39) (2025-04-07)
+
+### Features
+
+- **canary-react:** add ability to hide the icdateinput in the icdatepicker ([f080d01](https://github.com/mi6/ic-ui-kit/commit/f080d01ab30ba5bc1150a6df2485a6c5509bbffe)), closes [#3357](https://github.com/mi6/ic-ui-kit/issues/3357)
+
+# [2.0.0-canary.38](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@2.0.0-canary.37...@ukic/canary-react@2.0.0-canary.38) (2025-03-19)
+
+### Bug Fixes
+
+- **canary-react:** adds test for data-table slotted element fix ([e7a40f5](https://github.com/mi6/ic-ui-kit/commit/e7a40f58fe183cf8533dd8e2bb7d70c224c59918))
+
+### Features
+
+- **canary-react:** added light mode styles for IcTreeView ([9400545](https://github.com/mi6/ic-ui-kit/commit/9400545f521830dbdfcc988b926ee65ef47c13c4))
+
+# [2.0.0-canary.37](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@2.0.0-canary.36...@ukic/canary-react@2.0.0-canary.37) (2025-03-05)
+
+### Features
+
+- **canary-react:** add the ability to backspace through a date input to delete the date ([534252c](https://github.com/mi6/ic-ui-kit/commit/534252c27288c242fad14e47897c975241d493ef)), closes [#2244](https://github.com/mi6/ic-ui-kit/issues/2244)
+- **canary-react:** added Cypress tests ([5e6fccd](https://github.com/mi6/ic-ui-kit/commit/5e6fccd003fa49ca003167e308f5eaffb67381c9))
+- **canary-react:** improve data table column object by adding excludeColumnFromSort ([3e532f1](https://github.com/mi6/ic-ui-kit/commit/3e532f1c1bad86e49b6daba4fc24918bf4c1e9b8))
 
 # [2.0.0-canary.36](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-react@2.0.0-canary.35...@ukic/canary-react@2.0.0-canary.36) (2025-02-19)
 

--- a/packages/canary-web-components/CHANGELOG.md
+++ b/packages/canary-web-components/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
+- **canary-web-components:** update data table row hover colours for dark mode ([85ac59e](https://github.com/mi6/ic-ui-kit/commit/85ac59efcd6683eb611261f3aa4235ba8ca4f397)), closes [#3022](https://github.com/mi6/ic-ui-kit/issues/3022)
 - **canary-web-components:** added dark mode colours for data table cell descriptions and icons ([412f8bf](https://github.com/mi6/ic-ui-kit/commit/412f8bfcdf261f0d2736615cc028531380d6493c))
 
 ### Features
@@ -60,7 +61,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **canary-web-components:** showBackground has been removed from loading options
 
-# [3.0.0]
+# [3.0.0-canary.10](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.9...@ukic/canary-web-components@3.0.0-canary.10) (2025-02-20)
 
 ### Bug Fixes
 
@@ -78,92 +79,205 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **canary-web-components:** implement disableAutoSort prop on data table ([d46d357](https://github.com/mi6/ic-ui-kit/commit/d46d35778386e25648c4c7c4b478ea6e3d190c81)), closes [#2415](https://github.com/mi6/ic-ui-kit/issues/2415)
 
+# [3.0.0-canary.9](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.8...@ukic/canary-web-components@3.0.0-canary.9) (2025-02-05)
+
 ### Bug Fixes
 
 - **canary-web-components:** added check to prevent duplicate tooltips being added ([4e0972c](https://github.com/mi6/ic-ui-kit/commit/4e0972c0a6bea1ab2b1565dfe9d40185ba466728))
 - **canary-web-components:** support for nested tooltips in data-table slotted elements ([6709b04](https://github.com/mi6/ic-ui-kit/commit/6709b042b974c65cab4a54632ee84373254f60c8))
 - **canary-web-components:** update data input clear icon css so that it matches other clear icons ([e1d07a2](https://github.com/mi6/ic-ui-kit/commit/e1d07a2948f2c9125a06f59f58d7015bc83aec47)), closes [#2923](https://github.com/mi6/ic-ui-kit/issues/2923)
 
+# [3.0.0-canary.8](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.7...@ukic/canary-web-components@3.0.0-canary.8) (2025-01-24)
+
 ### Bug Fixes
 
 - **canary-web-components:** allow IcDataTable action-element to support tooltips ([a2d4bb3](https://github.com/mi6/ic-ui-kit/commit/a2d4bb357fd6c34b052c62e5e2f05657f4b02da7)), closes [#2964](https://github.com/mi6/ic-ui-kit/issues/2964)
-- **canary-web-components:** dont generate timestamp in stencil ([ae07d9d](https://github.com/mi6/ic-ui-kit/commit/ae07d9d5c655024da0b0ce7cdc1eb5c31ecaadf3))
-- **canary-web-components:** ensures that slotted columns now render data in correct order ([264f247](https://github.com/mi6/ic-ui-kit/commit/264f247dc8a0f40e59484c346f0b57e2e5bb366a))
-- **canary-web-components:** reapply truncation data on sort ([a0d472b](https://github.com/mi6/ic-ui-kit/commit/a0d472b2771f2ac83b942787c01dfaf8dc9304a4))
-- **canary-web-components:** update data table prop description to have spaces ([718fa55](https://github.com/mi6/ic-ui-kit/commit/718fa5503a94c0c3fc6c52cff66192cfb7c723a9))
-- **canary-web-components:** fixes data-table column width example ([5d19758](https://github.com/mi6/ic-ui-kit/commit/5d1975839d30486669140e57b34f8a141ee8f273))
-- **canary-web-components:** fixes issue with icons in datatable ([25be337](https://github.com/mi6/ic-ui-kit/commit/25be3370412c9ece108c1e55187a2f1bca083416))
-- **canary-web-components:** fixes tooltips being hidden in datatables ([38d9383](https://github.com/mi6/ic-ui-kit/commit/38d938359b2ea9fe345b0cb0f7fc1addf10fd92c))
-- **canary-web-components:** updated breakpoint for data-table ([1c38cea](https://github.com/mi6/ic-ui-kit/commit/1c38cea311219124d663b8dad18d471da5fe8447))
-- **canary-web-components:** fixes tooltip display issue in data-table ([462ec4f](https://github.com/mi6/ic-ui-kit/commit/462ec4fb416a42d31150f3d8c11d99baeee2a7cf))
-- **canary-web-components:** update tree view with heading and expanded improvements ([b821d10](https://github.com/mi6/ic-ui-kit/commit/b821d10c845dfb94b1824fb15a63a047ad7bc4c5))
-- **canary-web-components:** add check to event.key to ensure it exists in date input ([a373b58](https://github.com/mi6/ic-ui-kit/commit/a373b5882752c4e2149f4670293c239ef5695ab5)), closes [#1967](https://github.com/mi6/ic-ui-kit/issues/1967)
-- **canary-web-components:** adjust spacing between helper text and input field to match designs ([c190a24](https://github.com/mi6/ic-ui-kit/commit/c190a245d646e69a8dc1b74bb8b292c912a66ea1)), closes [#2301](https://github.com/mi6/ic-ui-kit/issues/2301)
-- **canary-web-components:** fixes truncation of tree items ([add24b7](https://github.com/mi6/ic-ui-kit/commit/add24b77f1ac94bba36db87a81e17b506570211b))
-- **canary-web-components:** fixes version in package-lock ([6e0426f](https://github.com/mi6/ic-ui-kit/commit/6e0426f1114e23fb354d4b9bf8a3a441f398c0fb))
-- **canary-web-components:** [#2848](https://github.com/mi6/ic-ui-kit/issues/2848) Default ic-pagination-bar totalItems prop to zero if data is null ([da9477c](https://github.com/mi6/ic-ui-kit/commit/da9477ce8c139fa2c6bc21c63a8674f3c035a3a4))
-- **canary-web-components:** add slotted columns to correct positions, skip the column if present in data ([8db7cb9](https://github.com/mi6/ic-ui-kit/commit/8db7cb9ca43b162868b1af2a12564f2b7803be9d)), closes [#2743](https://github.com/mi6/ic-ui-kit/issues/2743)
-- **canary-web-components:** update canary css files based on colour/token updates ([5645647](https://github.com/mi6/ic-ui-kit/commit/5645647aeb50feaf802d1156934fb19a322b5dc2))
-- **canary-web-components:** update showLoadingIndicator to check this.loadingIndicator exists ([16778a6](https://github.com/mi6/ic-ui-kit/commit/16778a694aecbd84925cd67b5830715f5652a840)), closes [#2789](https://github.com/mi6/ic-ui-kit/issues/2789)
-- **canary-web-components:** updated card horizontal border colours to align with dark-mode ([6fc7b92](https://github.com/mi6/ic-ui-kit/commit/6fc7b92ba81f6f0222a06185f20bde665e4ce7a2))
+
+### Features
+
+- **canary-web-components:** add description to data table cells, update tests and storybook ([abda14a](https://github.com/mi6/ic-ui-kit/commit/abda14a92f1e924cc8323633b91f4bfeea449889))
+
+# [3.0.0-canary.7](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.6...@ukic/canary-web-components@3.0.0-canary.7) (2025-01-22)
+
+### Bug Fixes
+
+- **canary-web-components:** add icSelectedRowChange event to IcDataTable ([a944bc9](https://github.com/mi6/ic-ui-kit/commit/a944bc90862c080339852b167fd892bf9f0a2539)), closes [#1226](https://github.com/mi6/ic-ui-kit/issues/1226)
+- **canary-web-components:** set IcPaginationBar to the first page when the items per page changes ([fed2c21](https://github.com/mi6/ic-ui-kit/commit/fed2c2126dad7aa14a7ac2c7cfb8aea1139ecec1)), closes [#2639](https://github.com/mi6/ic-ui-kit/issues/2639)
+
+### Features
+
+- **canary-web-components:** add action onclick to actionElement in dataTable ([9362200](https://github.com/mi6/ic-ui-kit/commit/936220017f1c7ae92f93ce2b1b46a8d2f47bba13))
+- **canary-web-components:** new overlay property for loadingOptions ([7bfa49a](https://github.com/mi6/ic-ui-kit/commit/7bfa49ab9b10cf0aed8e9af5d39984ee12d5c8f4)), closes [#2968](https://github.com/mi6/ic-ui-kit/issues/2968)
+- **canary-web-components:** updated mutationObserver function ([440ec7f](https://github.com/mi6/ic-ui-kit/commit/440ec7f3d24062f757cfe6978c95d8118453c69b))
+
+# [3.0.0-canary.6](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.5...@ukic/canary-web-components@3.0.0-canary.6) (2025-01-08)
+
+### Bug Fixes
+
 - **canary-web-components:** Allow the IcDataTable to handle empty cell data values ([e35433f](https://github.com/mi6/ic-ui-kit/commit/e35433f03721b39d8fbafa6ee0ed1867bcce7ef6))
 - **canary-web-components:** fix for items displayed on brand color background ([81dbda4](https://github.com/mi6/ic-ui-kit/commit/81dbda4b894b9caf4adbd5f2578b79c595410ae9))
 - **canary-web-components:** prevent mutation of ic-pagination-bar items per page options prop ([e28c005](https://github.com/mi6/ic-ui-kit/commit/e28c005fb53e18e428e5d9a822af60697bde3747))
 - **canary-web-components:** removed disabled attribute from components ([786c21d](https://github.com/mi6/ic-ui-kit/commit/786c21d893508044bc3527b71eb00dede545e724))
 - **canary-web-components:** set horizontal card image size directly on image to fix Safari issue ([d0c344f](https://github.com/mi6/ic-ui-kit/commit/d0c344f7dee7d18606b986ab78b98a6e72f5cc7b))
 - **canary-web-components:** update webkit autofill colours for date input dark mode ([2800ef2](https://github.com/mi6/ic-ui-kit/commit/2800ef20a4daadb2fcff019e4218fc03f107e114)), closes [#2915](https://github.com/mi6/ic-ui-kit/issues/2915)
-- **canary-web-components:** add icSelectedRowChange event to IcDataTable ([a944bc9](https://github.com/mi6/ic-ui-kit/commit/a944bc90862c080339852b167fd892bf9f0a2539)), closes [#1226](https://github.com/mi6/ic-ui-kit/issues/1226)
-- **canary-web-components:** set IcPaginationBar to the first page when the items per page changes ([fed2c21](https://github.com/mi6/ic-ui-kit/commit/fed2c2126dad7aa14a7ac2c7cfb8aea1139ecec1)), closes [#2639](https://github.com/mi6/ic-ui-kit/issues/2639)
 
 ### Features
 
-- **canary-web-components:** add description to data table cells, update tests and storybook ([abda14a](https://github.com/mi6/ic-ui-kit/commit/abda14a92f1e924cc8323633b91f4bfeea449889))
+- **canary-web-components:** added action-element, tests and stories ([7538788](https://github.com/mi6/ic-ui-kit/commit/75387882a0cbd629c62972b5d7184782a6dfc015))
+- **canary-web-components:** allow specifying target for anchor in ic-data-table cell ([69fd1b6](https://github.com/mi6/ic-ui-kit/commit/69fd1b6fe3273d3222776e2905c3ef89e2d77e34)), closes [#2751](https://github.com/mi6/ic-ui-kit/issues/2751)
+- **canary-web-components:** update tree view/tree item to text wrap by default ([e156511](https://github.com/mi6/ic-ui-kit/commit/e15651173bf550b41901dcebb3e90417d00217e1)), closes [#2895](https://github.com/mi6/ic-ui-kit/issues/2895)
+- **canary-web-components:** updates due to ic-theme components changes ([6b5afe3](https://github.com/mi6/ic-ui-kit/commit/6b5afe37727bca895a897b89f50fe7db7e557eaa))
+
+### BREAKING CHANGES
+
+- **canary-web-components:** change to IcTheme types, now IcBrand
+- **canary-web-components:** Default behaviour for tree view changed from truncation to text wrap
+
+# [3.0.0-canary.5](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.4...@ukic/canary-web-components@3.0.0-canary.5) (2024-12-09)
+
+### Bug Fixes
+
+- **canary-web-components:** [#2848](https://github.com/mi6/ic-ui-kit/issues/2848) Default ic-pagination-bar totalItems prop to zero if data is null ([da9477c](https://github.com/mi6/ic-ui-kit/commit/da9477ce8c139fa2c6bc21c63a8674f3c035a3a4))
+- **canary-web-components:** add slotted columns to correct positions, skip the column if present in data ([8db7cb9](https://github.com/mi6/ic-ui-kit/commit/8db7cb9ca43b162868b1af2a12564f2b7803be9d)), closes [#2743](https://github.com/mi6/ic-ui-kit/issues/2743)
+- **canary-web-components:** update canary css files based on colour/token updates ([5645647](https://github.com/mi6/ic-ui-kit/commit/5645647aeb50feaf802d1156934fb19a322b5dc2))
+- **canary-web-components:** update showLoadingIndicator to check this.loadingIndicator exists ([16778a6](https://github.com/mi6/ic-ui-kit/commit/16778a694aecbd84925cd67b5830715f5652a840)), closes [#2789](https://github.com/mi6/ic-ui-kit/issues/2789)
+- **canary-web-components:** updated card horizontal border colours to align with dark-mode ([6fc7b92](https://github.com/mi6/ic-ui-kit/commit/6fc7b92ba81f6f0222a06185f20bde665e4ce7a2))
+
+### Features
+
+- **canary-web-components:** added theme prop to ic-data-table ([1c7df06](https://github.com/mi6/ic-ui-kit/commit/1c7df06547c1b26d1b2aa554dcc3f659eb1d23c0))
+- **canary-web-components:** adds dark mode theme prop for date components ([a4588fd](https://github.com/mi6/ic-ui-kit/commit/a4588fd435b2649705fcd7ce4c4346fac2135718))
+- **canary-web-components:** dark mode ([1ff7629](https://github.com/mi6/ic-ui-kit/commit/1ff76297de3e96bb7a4745cd1124b7c57b3a6448))
+- **react:** add dark mode page header story and Cypress test ([bb17dfe](https://github.com/mi6/ic-ui-kit/commit/bb17dfee2ea3ad0ced16a6fc172809b8465d2026)), closes [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
+- **web-components:** add dark mode tokens for page header and add dark mode page header story ([541ce78](https://github.com/mi6/ic-ui-kit/commit/541ce7894c0917cf12689939fc431bbea562818d)), closes [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
+
+### BREAKING CHANGES
+
+- **canary-web-components:** new theme prop and colour switching
+- **canary-web-components:** dark mode
+- **canary-web-components:** removed appearance option from loadingOptions and updatingOptions
+
+# [3.0.0-canary.4](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.3...@ukic/canary-web-components@3.0.0-canary.4) (2024-11-14)
+
+### Bug Fixes
+
+- **canary-web-components:** add check to event.key to ensure it exists in date input ([a373b58](https://github.com/mi6/ic-ui-kit/commit/a373b5882752c4e2149f4670293c239ef5695ab5)), closes [#1967](https://github.com/mi6/ic-ui-kit/issues/1967)
+- **canary-web-components:** adjust spacing between helper text and input field to match designs ([c190a24](https://github.com/mi6/ic-ui-kit/commit/c190a245d646e69a8dc1b74bb8b292c912a66ea1)), closes [#2301](https://github.com/mi6/ic-ui-kit/issues/2301)
+- **canary-web-components:** fixes truncation of tree items ([add24b7](https://github.com/mi6/ic-ui-kit/commit/add24b77f1ac94bba36db87a81e17b506570211b))
+- **canary-web-components:** fixes version in package-lock ([6e0426f](https://github.com/mi6/ic-ui-kit/commit/6e0426f1114e23fb354d4b9bf8a3a441f398c0fb))
+
+### Features
+
+- **canary-web-components:** add pagination styles to pagination bar with theme prop ([267b821](https://github.com/mi6/ic-ui-kit/commit/267b8212f4fbf5af4e81a1567e9bf2eddc1a930e))
+- **canary-web-components:** added theme prop to ic-card-horizontal ([2972e07](https://github.com/mi6/ic-ui-kit/commit/2972e0787ed960eb357325f649cd45efb9bc5902))
+- **canary-web-components:** implements column header truncation ([d33da48](https://github.com/mi6/ic-ui-kit/commit/d33da48213cd9c68e15434f6fd3e7ab8592243a4))
+- **canary-web-components:** remove appearance prop and add theme prop to tree view ([84f69d0](https://github.com/mi6/ic-ui-kit/commit/84f69d0ce48b4442f5a0191416595c8937b2aaa8))
+
+### BREAKING CHANGES
+
+- **canary-web-components:** adding new theme prop
+- **canary-web-components:** Increase the size of the component overall
+
+# [3.0.0-canary.3](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.2...@ukic/canary-web-components@3.0.0-canary.3) (2024-10-31)
+
+### Bug Fixes
+
+- **canary-web-components:** fixes tooltip display issue in data-table ([462ec4f](https://github.com/mi6/ic-ui-kit/commit/462ec4fb416a42d31150f3d8c11d99baeee2a7cf))
+- **canary-web-components:** update tree view with heading and expanded improvements ([b821d10](https://github.com/mi6/ic-ui-kit/commit/b821d10c845dfb94b1824fb15a63a047ad7bc4c5))
+
+### Features
+
+- **canary-web-components:** add focus inset prop to tree view items ([37d969d](https://github.com/mi6/ic-ui-kit/commit/37d969d959bb19f378e6ad6518611260475076bb))
+- **canary-web-components:** added new hidelabel prop ([23067fa](https://github.com/mi6/ic-ui-kit/commit/23067fa0fcf043639b469164ba7c3022f535cbcd))
+- **canary-web-components:** implement hideAllFromItemsPerPage & remove limit on itemsPerPage opts ([d338294](https://github.com/mi6/ic-ui-kit/commit/d338294cbd688c923f16c9e17c4ed7315c281cd5)), closes [#1950](https://github.com/mi6/ic-ui-kit/issues/1950)
+- **canary-web-components:** remove all multi-select files (moved to core package) ([39431bd](https://github.com/mi6/ic-ui-kit/commit/39431bd397548750f08fa0c827c07e7f74e7d48d))
+- **react:** update Cypress visual regression test baseline images ([f8c044f](https://github.com/mi6/ic-ui-kit/commit/f8c044f946fffa17f490bd5bf6477bf0f4fdeb08))
+
+### Performance Improvements
+
+- **canary-web-components:** add the ability to change between themes in Storybook toolbar ([6a40ac1](https://github.com/mi6/ic-ui-kit/commit/6a40ac12b84251505bcf66470505b239e3384196))
+
+# [3.0.0-canary.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@3.0.0-canary.1...@ukic/canary-web-components@3.0.0-canary.2) (2024-10-17)
+
+### Bug Fixes
+
+- **canary-web-components:** fixes data-table column width example ([5d19758](https://github.com/mi6/ic-ui-kit/commit/5d1975839d30486669140e57b34f8a141ee8f273))
+- **canary-web-components:** fixes issue with icons in datatable ([25be337](https://github.com/mi6/ic-ui-kit/commit/25be3370412c9ece108c1e55187a2f1bca083416))
+- **canary-web-components:** fixes tooltips being hidden in datatables ([38d9383](https://github.com/mi6/ic-ui-kit/commit/38d938359b2ea9fe345b0cb0f7fc1addf10fd92c))
+- **canary-web-components:** updated breakpoint for data-table ([1c38cea](https://github.com/mi6/ic-ui-kit/commit/1c38cea311219124d663b8dad18d471da5fe8447))
+
+### Features
+
+- **canary-web-components:** added monochrome option to loading indicator options in ic-data-table ([bf29ea1](https://github.com/mi6/ic-ui-kit/commit/bf29ea1fcd6abdb650f52ab7930622d1254fb669))
+- **canary-web-components:** adds currentPage prop to pagination bar ([14f985b](https://github.com/mi6/ic-ui-kit/commit/14f985bb3a9cdb1f371c1fd32d2997461c4e5985))
+- **canary-web-components:** update existing CSS tokens after the renaming of global tokens ([9dfb23d](https://github.com/mi6/ic-ui-kit/commit/9dfb23daa31262d82e2620b5e439ca2d78b4cc19)), closes [#2466](https://github.com/mi6/ic-ui-kit/issues/2466) [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
+
+### BREAKING CHANGES
+
+- **canary-web-components:** Rename some of the existing CSS tokens following the move towards primitive, semantic and component tokens
+
+# 3.0.0-canary.1 (2024-10-04)
+
+### Bug Fixes
+
+- **canary-web-components:** dont generate timestamp in stencil ([ae07d9d](https://github.com/mi6/ic-ui-kit/commit/ae07d9d5c655024da0b0ce7cdc1eb5c31ecaadf3))
+- **canary-web-components:** ensures that slotted columns now render data in correct order ([264f247](https://github.com/mi6/ic-ui-kit/commit/264f247dc8a0f40e59484c346f0b57e2e5bb366a))
+- **canary-web-components:** reapply truncation data on sort ([a0d472b](https://github.com/mi6/ic-ui-kit/commit/a0d472b2771f2ac83b942787c01dfaf8dc9304a4))
+- **canary-web-components:** update data table prop description to have spaces ([718fa55](https://github.com/mi6/ic-ui-kit/commit/718fa5503a94c0c3fc6c52cff66192cfb7c723a9))
+
+### Code Refactoring
+
+- **canary-web-components:** size prop changed ([2f24a63](https://github.com/mi6/ic-ui-kit/commit/2f24a63e256a06748874cf1a2043746ac73c5df4))
+
+### Features
+
 - **canary-web-components:** add invalidDateMessage prop to date input and date picker ([6ab5d5f](https://github.com/mi6/ic-ui-kit/commit/6ab5d5f575e05e93724280ff4701e6bc0120b849)), closes [#2248](https://github.com/mi6/ic-ui-kit/issues/2248)
 - **canary-web-components:** added data table column width functionality ([cb8d8e0](https://github.com/mi6/ic-ui-kit/commit/cb8d8e005cf994a7cbd752627a24ef552b67dfee)), closes [#1005](https://github.com/mi6/ic-ui-kit/issues/1005)
 - **canary-web-components:** delete old visual test screenshots, accessibility tests and E2E tests ([d19b572](https://github.com/mi6/ic-ui-kit/commit/d19b5721baa2d19fdb59ef6ac009f5d830ea8ef2))
 - **canary-web-components:** exported missing types for data tables ([195c211](https://github.com/mi6/ic-ui-kit/commit/195c211430a0e402527dd2bc8bc1a9b3c23a1991))
 - **canary-web-components:** fixes colors after typography color token change ([5d2b554](https://github.com/mi6/ic-ui-kit/commit/5d2b554a857660c11e6b791c94316f6eb4f27faa))
 - **canary-web-components:** update sort on data tables to emit event ([9ff601c](https://github.com/mi6/ic-ui-kit/commit/9ff601c142a8a988049660767e17eaa9290a5042)), closes [#2179](https://github.com/mi6/ic-ui-kit/issues/2179)
-- **canary-web-components:** added monochrome option to loading indicator options in ic-data-table ([bf29ea1](https://github.com/mi6/ic-ui-kit/commit/bf29ea1fcd6abdb650f52ab7930622d1254fb669))
-- **canary-web-components:** adds currentPage prop to pagination bar ([14f985b](https://github.com/mi6/ic-ui-kit/commit/14f985bb3a9cdb1f371c1fd32d2997461c4e5985))
-- **canary-web-components:** update existing CSS tokens after the renaming of global tokens ([9dfb23d](https://github.com/mi6/ic-ui-kit/commit/9dfb23daa31262d82e2620b5e439ca2d78b4cc19)), closes [#2466](https://github.com/mi6/ic-ui-kit/issues/2466) [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
-- **canary-web-components:** add focus inset prop to tree view items ([37d969d](https://github.com/mi6/ic-ui-kit/commit/37d969d959bb19f378e6ad6518611260475076bb))
-- **canary-web-components:** added new hidelabel prop ([23067fa](https://github.com/mi6/ic-ui-kit/commit/23067fa0fcf043639b469164ba7c3022f535cbcd))
-- **canary-web-components:** implement hideAllFromItemsPerPage & remove limit on itemsPerPage opts ([d338294](https://github.com/mi6/ic-ui-kit/commit/d338294cbd688c923f16c9e17c4ed7315c281cd5)), closes [#1950](https://github.com/mi6/ic-ui-kit/issues/1950)
-- **canary-web-components:** remove all multi-select files (moved to core package) ([39431bd](https://github.com/mi6/ic-ui-kit/commit/39431bd397548750f08fa0c827c07e7f74e7d48d))
-- **react:** update Cypress visual regression test baseline images ([f8c044f](https://github.com/mi6/ic-ui-kit/commit/f8c044f946fffa17f490bd5bf6477bf0f4fdeb08))
-- **canary-web-components:** add pagination styles to pagination bar with theme prop ([267b821](https://github.com/mi6/ic-ui-kit/commit/267b8212f4fbf5af4e81a1567e9bf2eddc1a930e))
-- **canary-web-components:** added theme prop to ic-card-horizontal ([2972e07](https://github.com/mi6/ic-ui-kit/commit/2972e0787ed960eb357325f649cd45efb9bc5902))
-- **canary-web-components:** implements column header truncation ([d33da48](https://github.com/mi6/ic-ui-kit/commit/d33da48213cd9c68e15434f6fd3e7ab8592243a4))
-- **canary-web-components:** remove appearance prop and add theme prop to tree view ([84f69d0](https://github.com/mi6/ic-ui-kit/commit/84f69d0ce48b4442f5a0191416595c8937b2aaa8))
-- **canary-web-components:** added theme prop to ic-data-table ([1c7df06](https://github.com/mi6/ic-ui-kit/commit/1c7df06547c1b26d1b2aa554dcc3f659eb1d23c0))
-- **canary-web-components:** adds dark mode theme prop for date components ([a4588fd](https://github.com/mi6/ic-ui-kit/commit/a4588fd435b2649705fcd7ce4c4346fac2135718))
-- **canary-web-components:** dark mode ([1ff7629](https://github.com/mi6/ic-ui-kit/commit/1ff76297de3e96bb7a4745cd1124b7c57b3a6448))
-- **react:** add dark mode page header story and Cypress test ([bb17dfe](https://github.com/mi6/ic-ui-kit/commit/bb17dfee2ea3ad0ced16a6fc172809b8465d2026)), closes [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
-- **web-components:** add dark mode tokens for page header and add dark mode page header story ([541ce78](https://github.com/mi6/ic-ui-kit/commit/541ce7894c0917cf12689939fc431bbea562818d)), closes [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
-- **canary-web-components:** added action-element, tests and stories ([7538788](https://github.com/mi6/ic-ui-kit/commit/75387882a0cbd629c62972b5d7184782a6dfc015))
-- **canary-web-components:** allow specifying target for anchor in ic-data-table cell ([69fd1b6](https://github.com/mi6/ic-ui-kit/commit/69fd1b6fe3273d3222776e2905c3ef89e2d77e34)), closes [#2751](https://github.com/mi6/ic-ui-kit/issues/2751)
-- **canary-web-components:** update tree view/tree item to text wrap by default ([e156511](https://github.com/mi6/ic-ui-kit/commit/e15651173bf550b41901dcebb3e90417d00217e1)), closes [#2895](https://github.com/mi6/ic-ui-kit/issues/2895)
-- **canary-web-components:** updates due to ic-theme components changes ([6b5afe3](https://github.com/mi6/ic-ui-kit/commit/6b5afe37727bca895a897b89f50fe7db7e557eaa))
-- **canary-web-components:** add action onclick to actionElement in dataTable ([9362200](https://github.com/mi6/ic-ui-kit/commit/936220017f1c7ae92f93ce2b1b46a8d2f47bba13))
-- **canary-web-components:** new overlay property for loadingOptions ([7bfa49a](https://github.com/mi6/ic-ui-kit/commit/7bfa49ab9b10cf0aed8e9af5d39984ee12d5c8f4)), closes [#2968](https://github.com/mi6/ic-ui-kit/issues/2968)
-- **canary-web-components:** updated mutationObserver function ([440ec7f](https://github.com/mi6/ic-ui-kit/commit/440ec7f3d24062f757cfe6978c95d8118453c69b))
-
-### Performance Improvements
-
-- **canary-web-components:** add the ability to change between themes in Storybook toolbar ([6a40ac1](https://github.com/mi6/ic-ui-kit/commit/6a40ac12b84251505bcf66470505b239e3384196))
-
-### Code Refactoring
-
-- **canary-web-components:** size prop changed ([2f24a63](https://github.com/mi6/ic-ui-kit/commit/2f24a63e256a06748874cf1a2043746ac73c5df4))
 
 ### BREAKING CHANGES
 
-- **canary-web-components:** dark mode
-- **canary-web-components:** change to IcTheme types, now IcBrand
-- **canary-web-components:** Default behaviour for tree view changed from truncation to text wrap
-- **canary-web-components:** Rename some of the existing CSS tokens following the move towards primitive, semantic and component tokens
-- **canary-web-components:** removed appearance option from loadingOptions and updatingOptions
+- **canary-web-components:** size prop change
+
+# [2.0.0-canary.40](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@2.0.0-canary.38...@ukic/canary-web-components@2.0.0-canary.40) (2025-04-16)
+
+### Features
+
+- **canary-web-components:** add ability to hide the icdateinput in the icdatepicker ([b3483a8](https://github.com/mi6/ic-ui-kit/commit/b3483a8f14222dbb5cadd8228841fabdb1788bd2)), closes [#3357](https://github.com/mi6/ic-ui-kit/issues/3357)
+
+# [2.0.0-canary.39](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@2.0.0-canary.38...@ukic/canary-web-components@2.0.0-canary.39) (2025-04-07)
+
+### Features
+
+- **canary-web-components:** add ability to hide the icdateinput in the icdatepicker ([85da776](https://github.com/mi6/ic-ui-kit/commit/85da776091eff9685b3caf4b18a1b2d8a093e178)), closes [#3357](https://github.com/mi6/ic-ui-kit/issues/3357)
+
+# [2.0.0-canary.38](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@2.0.0-canary.37...@ukic/canary-web-components@2.0.0-canary.38) (2025-03-19)
+
+### Bug Fixes
+
+- **canary-web-components:** fixes issue with data-table slotted elements ([16bffab](https://github.com/mi6/ic-ui-kit/commit/16bffab52dfe6a46371619dc3478235deda09b51))
+
+### Features
+
+- **canary-web-components:** added updated styles for tree-view light mode ([373c777](https://github.com/mi6/ic-ui-kit/commit/373c777640fcfdff37495b117c8118c10520b5a7))
+
+# [2.0.0-canary.37](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@2.0.0-canary.36...@ukic/canary-web-components@2.0.0-canary.37) (2025-03-05)
+
+### Bug Fixes
+
+- **canary-web-components:** added high contrast styling to ic-data-table ([5178102](https://github.com/mi6/ic-ui-kit/commit/51781023ebbb1ca111c6447643a8836dbf2b6b15))
+- **canary-web-components:** allow tree items and tree heading to truncate on first render ([095c452](https://github.com/mi6/ic-ui-kit/commit/095c4520e6a4deeb24acd7301faf2a258111403b))
+- **canary-web-components:** update the screen reader text on data table to use column title ([e7dfa3b](https://github.com/mi6/ic-ui-kit/commit/e7dfa3b3165e57b7a4e6d46c25d079caa51d0290)), closes [#3015](https://github.com/mi6/ic-ui-kit/issues/3015)
+
+### Features
+
+- **canary-web-components:** add the ability to backspace through a date input to delete the date ([c9042b4](https://github.com/mi6/ic-ui-kit/commit/c9042b406563346c91a688ab1d179e0850bc6945)), closes [#2244](https://github.com/mi6/ic-ui-kit/issues/2244)
+- **canary-web-components:** fix to revert items per page to correct value ([2c34d5e](https://github.com/mi6/ic-ui-kit/commit/2c34d5e5f8be24bc44687d19df92defd559b00bf)), closes [#3223](https://github.com/mi6/ic-ui-kit/issues/3223)
+- **canary-web-components:** improve data table column object by adding excludeColumnFromSort ([e8bddd8](https://github.com/mi6/ic-ui-kit/commit/e8bddd85103fb00a034003f869821f20aaf55f10)), closes [#2416](https://github.com/mi6/ic-ui-kit/issues/2416)
+
 
 # [2.0.0-canary.36](https://github.com/mi6/ic-ui-kit/compare/@ukic/canary-web-components@2.0.0-canary.35...@ukic/canary-web-components@2.0.0-canary.36) (2025-02-19)
 

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,36 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.0.0-alpha.14](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@3.0.0-alpha.13...@ukic/docs@3.0.0-alpha.14) (2025-04-16)
-
-**Note:** Version bump only for package @ukic/docs
-
-# [3.0.0-alpha.13](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@3.0.0-alpha.12...@ukic/docs@3.0.0-alpha.13) (2025-04-08)
-
-### Features
-
-- **web-components:** update second half of web-components files to resolve strict mode errors ([b939971](https://github.com/mi6/ic-ui-kit/commit/b9399713cc98798fcca669db083869b134f82ca1)), closes [.#266](https://github.com/./issues/266) [#3349](https://github.com/mi6/ic-ui-kit/issues/3349)
-
-# [3.0.0-alpha.12](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@3.0.0-alpha.11...@ukic/docs@3.0.0-alpha.12) (2025-03-19)
-
-**Note:** Version bump only for package @ukic/docs
-
-# [3.0.0-alpha.11](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@3.0.0-alpha.9...@ukic/docs@3.0.0-alpha.11) (2025-03-05)
-
-### Bug Fixes
-
-- **docs:** expose IcToolTip disableClick prop ([9589e6a](https://github.com/mi6/ic-ui-kit/commit/9589e6a49f1d0fc0d36563a0979c0e033de0c24d)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-
 # [3.0.0]
-
-### Bug Fixes
-
-- **docs:** expose IcToolTip disableClick prop ([973321f](https://github.com/mi6/ic-ui-kit/commit/973321f28b8c2c6eaab98e43f3d25b92c4e5e432)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
 
 ### Bug Fixes
 
 - **web-components:** ic-text-field bug ([6ac9480](https://github.com/mi6/ic-ui-kit/commit/6ac9480c28ac4ecf7012df09b647f539a1fbfa02))
 - **web-components:** update icpopoverclosed event to include relevant information ([c134f2b](https://github.com/mi6/ic-ui-kit/commit/c134f2b53c7581f73a8a30c3e615c01299cf1090)), closes [#2665](https://github.com/mi6/ic-ui-kit/issues/2665)
+- **docs:** expose IcToolTip disableClick prop ([9589e6a](https://github.com/mi6/ic-ui-kit/commit/9589e6a49f1d0fc0d36563a0979c0e033de0c24d)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
 
 ### Documentation
 
@@ -88,6 +65,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **docs:** Size prop type changed from 'default' to 'medium'
 - **docs:** Rename toggleChecked prop to checked in ic-menu-item
 - **docs:** prop rename to more closely align with native html attribute
+
+## [2.15.6](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@2.15.5...@ukic/docs@2.15.6) (2025-04-16)
+
+**Note:** Version bump only for package @ukic/docs
+
+## [2.15.5](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@2.15.4...@ukic/docs@2.15.5) (2025-04-07)
+
+**Note:** Version bump only for package @ukic/docs
+
+## [2.15.4](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@2.15.3...@ukic/docs@2.15.4) (2025-03-05)
+
+**Note:** Version bump only for package @ukic/docs
 
 ## [2.15.3](https://github.com/mi6/ic-ui-kit/compare/@ukic/docs@2.15.2...@ukic/docs@2.15.3) (2025-02-19)
 

--- a/packages/fonts/CHANGELOG.md
+++ b/packages/fonts/CHANGELOG.md
@@ -13,6 +13,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **fonts:** update fonts package to alpha versioning for v3 ([d7395ea](https://github.com/mi6/ic-ui-kit/commit/d7395eae355de1db87fd53bf0d0f7f71be33198e))
 
+## [2.6.7](https://github.com/mi6/ic-ui-kit/compare/@ukic/fonts@2.6.6...@ukic/fonts@2.6.7) (2025-04-16)
+
+**Note:** Version bump only for package @ukic/fonts
+
+## 2.6.6 (2025-02-19)
+
+**Note:** Version bump only for package @ukic/fonts
+
+## 2.6.5 (2024-12-18)
+
+### Bug Fixes
+
+- **fonts:** update @ukic/fonts version to fix failing release ([927bfea](https://github.com/mi6/ic-ui-kit/commit/927bfeac66880f7f79e53bc9ac444ec533cb8688))
+
 ## 2.6.4 (2024-12-09)
 
 **Note:** Version bump only for package @ukic/fonts

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -3,51 +3,89 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.0.0-alpha.10](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.9...@ukic/nextjs@3.0.0-alpha.10) (2025-04-08)
+# [3.0.0]
+
+### Bug Fixes
+
+- **nextjs:** updating packages ([d976876](https://github.com/mi6/ic-ui-kit/commit/d976876d51eeb751c213030ab4b4f755e8b50718))
 
 ### Features
 
 - **nextjs:** upgraded storybook to v8 ([d148358](https://github.com/mi6/ic-ui-kit/commit/d148358235f7e39ee5adb3e1755fac759f84306e))
 
-# [3.0.0-alpha.9](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.8...@ukic/nextjs@3.0.0-alpha.9) (2025-03-19)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.8](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.6...@ukic/nextjs@3.0.0-alpha.8) (2025-03-05)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.7](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.6...@ukic/nextjs@3.0.0-alpha.7) (2025-02-20)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.6](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.5...@ukic/nextjs@3.0.0-alpha.6) (2025-02-05)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.5](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.4...@ukic/nextjs@3.0.0-alpha.5) (2025-01-08)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.4](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.3...@ukic/nextjs@3.0.0-alpha.4) (2024-12-09)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.3](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.2...@ukic/nextjs@3.0.0-alpha.3) (2024-11-14)
-
-**Note:** Version bump only for package @ukic/nextjs
-
-# [3.0.0-alpha.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@3.0.0-alpha.1...@ukic/nextjs@3.0.0-alpha.2) (2024-10-31)
-
 ### Performance Improvements
 
 - **nextjs:** add the ability to change between themes in Storybook toolbar ([5b72148](https://github.com/mi6/ic-ui-kit/commit/5b721487ecf3800a2e82477b8ba44e6ff7e3da64))
 
-# 3.0.0-alpha.1 (2024-10-04)
+## [0.2.32](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.30...@ukic/nextjs@0.2.32) (2025-04-16)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.31](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.30...@ukic/nextjs@0.2.31) (2025-04-07)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.30](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.29...@ukic/nextjs@0.2.30) (2025-03-19)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.29](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.28...@ukic/nextjs@0.2.29) (2025-03-05)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.28](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.27...@ukic/nextjs@0.2.28) (2025-02-19)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.27](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.26...@ukic/nextjs@0.2.27) (2025-02-12)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.26](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.25...@ukic/nextjs@0.2.26) (2025-02-05)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.25](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.24...@ukic/nextjs@0.2.25) (2025-01-22)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.24](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.23...@ukic/nextjs@0.2.24) (2025-01-08)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.23](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.22...@ukic/nextjs@0.2.23) (2024-12-18)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.22](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.21...@ukic/nextjs@0.2.22) (2024-11-27)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.21](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.20...@ukic/nextjs@0.2.21) (2024-11-13)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.20](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.19...@ukic/nextjs@0.2.20) (2024-10-30)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.19](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.18...@ukic/nextjs@0.2.19) (2024-10-16)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.18](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.17...@ukic/nextjs@0.2.18) (2024-10-02)
+
+**Note:** Version bump only for package @ukic/nextjs
+
+## [0.2.17](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.16...@ukic/nextjs@0.2.17) (2024-09-23)
 
 ### Bug Fixes
 
-- **nextjs:** updating packages ([d976876](https://github.com/mi6/ic-ui-kit/commit/d976876d51eeb751c213030ab4b4f755e8b50718))
+- **nextjs:** updating packages ([c5103be](https://github.com/mi6/ic-ui-kit/commit/c5103be4850bc24f2d9f5edf283d050e04d45770))
+
+## 0.2.16 (2024-09-05)
+
+**Note:** Version bump only for package @ukic/nextjs
 
 ## [0.2.15](https://github.com/mi6/ic-ui-kit/compare/@ukic/nextjs@0.2.14...@ukic/nextjs@0.2.15) (2024-08-28)
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,92 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.0.0-alpha.14](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@3.0.0-alpha.13...@ukic/react@3.0.0-alpha.14) (2025-04-16)
-
-### Bug Fixes
-
-- **react:** baseline image update ([e8f2040](https://github.com/mi6/ic-ui-kit/commit/e8f20407c9d3d1986dc0a3546caa0324930335e0))
-- **react:** expose IcToolTip disableClick prop ([01fe9ed](https://github.com/mi6/ic-ui-kit/commit/01fe9ed2b12eef7428d74f4afc854a1de4981156)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **react:** fixed docs tab for react storybook ([62bb763](https://github.com/mi6/ic-ui-kit/commit/62bb76307c75f38ec7c83144c2f8a2560fffd9e5))
-- **react:** fixes card button focus color in high contrast mode ([720b098](https://github.com/mi6/ic-ui-kit/commit/720b0984ea40c27d0229a7ffef6ba8a0d4474c9f))
-- **react:** set the focus in the icpopovermenu when the open prop has been provided ([bc6fa9b](https://github.com/mi6/ic-ui-kit/commit/bc6fa9b1b56b9eff7f6cb6dd9f726dba77d1c57c))
-- **react:** update Cypress tests after button updates to show slotted content with router item slot ([1e53f9b](https://github.com/mi6/ic-ui-kit/commit/1e53f9b225d7b02edaf3db0c39417d266550edaf))
-- **react:** update Cypress visual regression images after removing side nav shadow ([1d37c42](https://github.com/mi6/ic-ui-kit/commit/1d37c427e97daa8e70c94ab20667ccf239131c7e)), closes [#2624](https://github.com/mi6/ic-ui-kit/issues/2624)
-- **react:** update Cypress visual regression test baseline images ([1d06e25](https://github.com/mi6/ic-ui-kit/commit/1d06e2578abc649162b7f38aefdee5e979d2472a))
-- **react:** update IcTopNavigation visual regression image ([e7a94d1](https://github.com/mi6/ic-ui-kit/commit/e7a94d1caba7df2b75e6130f476224e40c0f8458))
-- **react:** update side nav to append badge to iconWrapper when slotted nav item used ([0a0ba96](https://github.com/mi6/ic-ui-kit/commit/0a0ba961a39cdd1dc9e270b3d004ea5ad6f42fc1)), closes [#1701](https://github.com/mi6/ic-ui-kit/issues/1701)
-- **react:** update visual regression images in IcAlert and IcTheme, fix storybook example ([577af0f](https://github.com/mi6/ic-ui-kit/commit/577af0fbfcf668b22b8728658a3a3f29ae34b48e))
-- **react:** updates dialog stories and tests after focus fix ([c6f8dc9](https://github.com/mi6/ic-ui-kit/commit/c6f8dc94708b227eb19758345c7b96bd37ea882c))
-- **react:** updates tests for select change ([4357eda](https://github.com/mi6/ic-ui-kit/commit/4357eda5bc46ad12acb9c4a675bd203757c3e779))
-
-### Features
-
-- **react:** add Cypress test for slotting interactive content after first load ([868d75a](https://github.com/mi6/ic-ui-kit/commit/868d75a8f064b8c02aa44bad9a4797606f801122)), closes [.#2773](https://github.com/./issues/2773)
-- **react:** add tests for footer and top nav fixes for slotted link colours ([7b1e3ef](https://github.com/mi6/ic-ui-kit/commit/7b1e3eff2b0116cc497edbe2b0011ea9dcd6b184)), closes [.#3234](https://github.com/./issues/3234)
-- **react:** added new react component for ic-skip-link ([d00a04f](https://github.com/mi6/ic-ui-kit/commit/d00a04feb55e6de14bb5116f392e29068554a5ae))
-- **react:** remove hashtag from skip link's target prop following prefixing of hashtag in prop ([d13356f](https://github.com/mi6/ic-ui-kit/commit/d13356f1605972a03e078c91f318dcc2a9c47053))
-- **react:** update empty state to have theme prop ([1d7925d](https://github.com/mi6/ic-ui-kit/commit/1d7925d56b42180abdd1b5d19776a923247922e4))
-- **react:** update nav menu and top nav tests and stories following nav group focus fix ([825e392](https://github.com/mi6/ic-ui-kit/commit/825e392032df1d9e1c4c2a6919db6927dfa70425)), closes [.#3261](https://github.com/./issues/3261)
-
-# [3.0.0-alpha.13](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@3.0.0-alpha.12...@ukic/react@3.0.0-alpha.13) (2025-04-08)
-
-### Bug Fixes
-
-- **react:** baseline image update ([e8f2040](https://github.com/mi6/ic-ui-kit/commit/e8f20407c9d3d1986dc0a3546caa0324930335e0))
-- **react:** expose IcToolTip disableClick prop ([01fe9ed](https://github.com/mi6/ic-ui-kit/commit/01fe9ed2b12eef7428d74f4afc854a1de4981156)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **react:** fixed docs tab for react storybook ([62bb763](https://github.com/mi6/ic-ui-kit/commit/62bb76307c75f38ec7c83144c2f8a2560fffd9e5))
-- **react:** fixes card button focus color in high contrast mode ([720b098](https://github.com/mi6/ic-ui-kit/commit/720b0984ea40c27d0229a7ffef6ba8a0d4474c9f))
-- **react:** update Cypress visual regression images after removing side nav shadow ([1d37c42](https://github.com/mi6/ic-ui-kit/commit/1d37c427e97daa8e70c94ab20667ccf239131c7e)), closes [#2624](https://github.com/mi6/ic-ui-kit/issues/2624)
-- **react:** update Cypress visual regression test baseline images ([1d06e25](https://github.com/mi6/ic-ui-kit/commit/1d06e2578abc649162b7f38aefdee5e979d2472a))
-- **react:** update IcTopNavigation visual regression image ([e7a94d1](https://github.com/mi6/ic-ui-kit/commit/e7a94d1caba7df2b75e6130f476224e40c0f8458))
-- **react:** update visual regression images in IcAlert and IcTheme, fix storybook example ([577af0f](https://github.com/mi6/ic-ui-kit/commit/577af0fbfcf668b22b8728658a3a3f29ae34b48e))
-- **react:** updates dialog stories and tests after focus fix ([c6f8dc9](https://github.com/mi6/ic-ui-kit/commit/c6f8dc94708b227eb19758345c7b96bd37ea882c))
-- **react:** updates tests for select change ([4357eda](https://github.com/mi6/ic-ui-kit/commit/4357eda5bc46ad12acb9c4a675bd203757c3e779))
-
-### Features
-
-- **react:** add Cypress test for slotting interactive content after first load ([868d75a](https://github.com/mi6/ic-ui-kit/commit/868d75a8f064b8c02aa44bad9a4797606f801122)), closes [.#2773](https://github.com/./issues/2773)
-- **react:** add tests for footer and top nav fixes for slotted link colours ([7b1e3ef](https://github.com/mi6/ic-ui-kit/commit/7b1e3eff2b0116cc497edbe2b0011ea9dcd6b184)), closes [.#3234](https://github.com/./issues/3234)
-- **react:** added new react component for ic-skip-link ([d00a04f](https://github.com/mi6/ic-ui-kit/commit/d00a04feb55e6de14bb5116f392e29068554a5ae))
-- **react:** update empty state to have theme prop ([1d7925d](https://github.com/mi6/ic-ui-kit/commit/1d7925d56b42180abdd1b5d19776a923247922e4))
-
-# [3.0.0-alpha.12](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@3.0.0-alpha.11...@ukic/react@3.0.0-alpha.12) (2025-03-19)
-
-### Bug Fixes
-
-- **react:** baseline image update ([e8f2040](https://github.com/mi6/ic-ui-kit/commit/e8f20407c9d3d1986dc0a3546caa0324930335e0))
-- **react:** expose IcToolTip disableClick prop ([01fe9ed](https://github.com/mi6/ic-ui-kit/commit/01fe9ed2b12eef7428d74f4afc854a1de4981156)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **react:** fixed docs tab for react storybook ([62bb763](https://github.com/mi6/ic-ui-kit/commit/62bb76307c75f38ec7c83144c2f8a2560fffd9e5))
-- **react:** fixes card button focus color in high contrast mode ([720b098](https://github.com/mi6/ic-ui-kit/commit/720b0984ea40c27d0229a7ffef6ba8a0d4474c9f))
-- **react:** update Cypress visual regression test baseline images ([1d06e25](https://github.com/mi6/ic-ui-kit/commit/1d06e2578abc649162b7f38aefdee5e979d2472a))
-- **react:** update IcTopNavigation visual regression image ([e7a94d1](https://github.com/mi6/ic-ui-kit/commit/e7a94d1caba7df2b75e6130f476224e40c0f8458))
-- **react:** update visual regression images in IcAlert and IcTheme, fix storybook example ([577af0f](https://github.com/mi6/ic-ui-kit/commit/577af0fbfcf668b22b8728658a3a3f29ae34b48e))
-
-### Features
-
-- **react:** add Cypress test for slotting interactive content after first load ([868d75a](https://github.com/mi6/ic-ui-kit/commit/868d75a8f064b8c02aa44bad9a4797606f801122)), closes [.#2773](https://github.com/./issues/2773)
-- **react:** add tests for footer and top nav fixes for slotted link colours ([7b1e3ef](https://github.com/mi6/ic-ui-kit/commit/7b1e3eff2b0116cc497edbe2b0011ea9dcd6b184)), closes [.#3234](https://github.com/./issues/3234)
-- **react:** update empty state to have theme prop ([1d7925d](https://github.com/mi6/ic-ui-kit/commit/1d7925d56b42180abdd1b5d19776a923247922e4))
-
-# [3.0.0-alpha.11](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@3.0.0-alpha.9...@ukic/react@3.0.0-alpha.11) (2025-03-05)
-
-### Bug Fixes
-
-- **react:** added cypress test for backBreadcrumbOnly when using react router ([a20c2d9](https://github.com/mi6/ic-ui-kit/commit/a20c2d9aef4b7952660bb937fd21c8254a3d4d23))
-- **react:** expose IcToolTip disableClick prop ([01fe9ed](https://github.com/mi6/ic-ui-kit/commit/01fe9ed2b12eef7428d74f4afc854a1de4981156)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **react:** fixed docs tab for react storybook ([62bb763](https://github.com/mi6/ic-ui-kit/commit/62bb76307c75f38ec7c83144c2f8a2560fffd9e5))
-- **react:** fixes card button focus color in high contrast mode ([720b098](https://github.com/mi6/ic-ui-kit/commit/720b0984ea40c27d0229a7ffef6ba8a0d4474c9f))
-- **react:** update Cypress visual regression test baseline images ([1d06e25](https://github.com/mi6/ic-ui-kit/commit/1d06e2578abc649162b7f38aefdee5e979d2472a))
-- **react:** update IcTopNavigation visual regression image ([e7a94d1](https://github.com/mi6/ic-ui-kit/commit/e7a94d1caba7df2b75e6130f476224e40c0f8458))
-- **react:** update visual regression images in IcAlert and IcTheme, fix storybook example ([577af0f](https://github.com/mi6/ic-ui-kit/commit/577af0fbfcf668b22b8728658a3a3f29ae34b48e))
-
-### Features
-
-- **react:** add Cypress test for slotting interactive content after first load ([868d75a](https://github.com/mi6/ic-ui-kit/commit/868d75a8f064b8c02aa44bad9a4797606f801122)), closes [.#2773](https://github.com/./issues/2773)
-- **react:** add tests for footer and top nav fixes for slotted link colours ([7b1e3ef](https://github.com/mi6/ic-ui-kit/commit/7b1e3eff2b0116cc497edbe2b0011ea9dcd6b184)), closes [.#3234](https://github.com/./issues/3234)
-- **react:** update empty state to have theme prop ([1d7925d](https://github.com/mi6/ic-ui-kit/commit/1d7925d56b42180abdd1b5d19776a923247922e4))
-- **react:** update visual test screenshots - scrollbar on dialog ([f2e3585](https://github.com/mi6/ic-ui-kit/commit/f2e358529696614c388af0e0fc9cdb4ba5379372)), closes [.#2868](https://github.com/./issues/2868)
-
 # [3.0.0]
 
 ### Bug Fixes
@@ -108,79 +22,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** update icon colours for dark mode badge ([ede2a04](https://github.com/mi6/ic-ui-kit/commit/ede2a04ffa9f6295f391283af1180e75a7c5a6e4))
 - **react:** update IcTopNavigation visual regression image ([1d861c3](https://github.com/mi6/ic-ui-kit/commit/1d861c32475205db3826b94764b333bab7c9c2f3))
 - **react:** update visual regression images in IcAlert and IcTheme, fix storybook example ([b50a1e8](https://github.com/mi6/ic-ui-kit/commit/b50a1e8203eb00c755ce3cf766208b59ac4aa269))
-- **web-components:** bugfix: props passed correctly to child in group ([e4a4e41](https://github.com/mi6/ic-ui-kit/commit/e4a4e41178df8d6c150dba602bd86e16ee649cde))
-
-### Features
-
-- **react:** add tooltip placement prop on toggle button to match ic button ([04e9f59](https://github.com/mi6/ic-ui-kit/commit/04e9f59b2bf4ae509b5d8f0608026574f6b41b5a))
-- **react:** ic-theme component changes ([c2484c8](https://github.com/mi6/ic-ui-kit/commit/c2484c839655252de25d2654eec00faa64f7b325))
-- **react:** removed showState from IcSwitch ([19af8d4](https://github.com/mi6/ic-ui-kit/commit/19af8d4ce18b6a688a31bbc6bf00eb5f55d3f446))
-- **react:** update empty state to have theme prop ([c02a6c2](https://github.com/mi6/ic-ui-kit/commit/c02a6c244c27b288b2f5f6cc9ef0f5156e879fad))
-- **web-components:** Fix/able to select no options when select has empty options array ([cccf3fe](https://github.com/mi6/ic-ui-kit/commit/cccf3febc0edfa65474bda6ce08b2e8f8c895a6d))
-
-### Tests
-
-- **react:** updated cypress tests to include new native input element in IcSearchBar ([77d0af0](https://github.com/mi6/ic-ui-kit/commit/77d0af02699c4b647252dc6b89bb1cbb08bd9353))
-
-### BREAKING CHANGES
-
-- **react:** removed showState prop
-- **react:** removed IcTextField component, which may break tests
-- **react:** BREAKING CHANGE: color prop renamed to brandColor
-  icThemeChange event renamed to icBrandChange
-  changes to types:
-  IcThemeForegroundEnum now IcBrandForegroundEnum
-  IcThemeForeground now IcBrandForeground
-  IcThemeForegroundNoDefault now IcBrandForegroundNoDefault
-  IcTheme now IcBrand
-
-### Bug Fixes
-
-- **react:** add Cypress visual regression for select/search clear icon dark mode ([2532e27](https://github.com/mi6/ic-ui-kit/commit/2532e27b1d3a6c23f8fdd02dbf5a1f2c210e0902))
-- **react:** add Cypress visual regression tests for ag grid wrapper ([7db1566](https://github.com/mi6/ic-ui-kit/commit/7db1566298164c180facb6f22fa26c08885a6f76))
-- **react:** adds a story for toggling hidden input on text field ([ed2b689](https://github.com/mi6/ic-ui-kit/commit/ed2b6897abe644f63e90f1ef3e04e5e6b0e8094a))
-- **react:** allow the IcTextField to be able to handle null or undefined values ([6712d6a](https://github.com/mi6/ic-ui-kit/commit/6712d6a2a0bbdfbb54592389df3c1e7f15e2ec43)), closes [#2813](https://github.com/mi6/ic-ui-kit/issues/2813)
-- **react:** enables test for search-icon in high contrast mode ([faa53fb](https://github.com/mi6/ic-ui-kit/commit/faa53fbd17c4b46596874c3f0a0ef177ebde0d62))
-- **react:** fix for items displayed on brand color background ([bfdc38c](https://github.com/mi6/ic-ui-kit/commit/bfdc38ced77380feb7c8b0324e71bdde3b16c2f3))
-- **react:** fixes search bar focus on ic-dialog ([038c434](https://github.com/mi6/ic-ui-kit/commit/038c434da99f1771fb077745b6f4794cad207faa))
-- **react:** hide the compliance section when there is no logo, caption or copyright info ([9fb7405](https://github.com/mi6/ic-ui-kit/commit/9fb74057482653855eb101c6e45f3aa4240e4a6c)), closes [#1800](https://github.com/mi6/ic-ui-kit/issues/1800)
-- **react:** slotted content is focused when running .setFocus() ([6c40dd9](https://github.com/mi6/ic-ui-kit/commit/6c40dd9fde48ba38f24dafd694f80317f79add46))
-- **react:** toggle button displays correct high contrast colours when checked and unchecked ([5335c45](https://github.com/mi6/ic-ui-kit/commit/5335c452146751677cff0ab7e6075fcdb434c917))
-- **react:** update icon colours for dark mode badge ([ede2a04](https://github.com/mi6/ic-ui-kit/commit/ede2a04ffa9f6295f391283af1180e75a7c5a6e4))
-- **web-components:** bugfix: props passed correctly to child in group ([e4a4e41](https://github.com/mi6/ic-ui-kit/commit/e4a4e41178df8d6c150dba602bd86e16ee649cde))
-
-### Features
-
-- **react:** add tooltip placement prop on toggle button to match ic button ([04e9f59](https://github.com/mi6/ic-ui-kit/commit/04e9f59b2bf4ae509b5d8f0608026574f6b41b5a))
-- **react:** ic-theme component changes ([c2484c8](https://github.com/mi6/ic-ui-kit/commit/c2484c839655252de25d2654eec00faa64f7b325))
-- **react:** removed showState from IcSwitch ([19af8d4](https://github.com/mi6/ic-ui-kit/commit/19af8d4ce18b6a688a31bbc6bf00eb5f55d3f446))
-- **web-components:** Fix/able to select no options when select has empty options array ([cccf3fe](https://github.com/mi6/ic-ui-kit/commit/cccf3febc0edfa65474bda6ce08b2e8f8c895a6d))
-
-### Tests
-
-- **react:** updated cypress tests to include new native input element in IcSearchBar ([77d0af0](https://github.com/mi6/ic-ui-kit/commit/77d0af02699c4b647252dc6b89bb1cbb08bd9353))
-
-### BREAKING CHANGES
-
-- **react:** removed showState prop
-- **react:** removed IcTextField component, which may break tests
-- **react:** BREAKING CHANGE: color prop renamed to brandColor
-  icThemeChange event renamed to icBrandChange
-  changes to types:
-  IcThemeForegroundEnum now IcBrandForegroundEnum
-  IcThemeForeground now IcBrandForeground
-  IcThemeForegroundNoDefault now IcBrandForegroundNoDefault
-  IcTheme now IcBrand
-
-### Bug Fixes
-
-- **react:** add Cypress visual regression tests for ag grid wrapper ([7db1566](https://github.com/mi6/ic-ui-kit/commit/7db1566298164c180facb6f22fa26c08885a6f76))
-- **react:** adds a story for toggling hidden input on text field ([ed2b689](https://github.com/mi6/ic-ui-kit/commit/ed2b6897abe644f63e90f1ef3e04e5e6b0e8094a))
-- **react:** allow the IcTextField to be able to handle null or undefined values ([6712d6a](https://github.com/mi6/ic-ui-kit/commit/6712d6a2a0bbdfbb54592389df3c1e7f15e2ec43)), closes [#2813](https://github.com/mi6/ic-ui-kit/issues/2813)
-- **react:** enables test for search-icon in high contrast mode ([faa53fb](https://github.com/mi6/ic-ui-kit/commit/faa53fbd17c4b46596874c3f0a0ef177ebde0d62))
-- **react:** fix for items displayed on brand color background ([bfdc38c](https://github.com/mi6/ic-ui-kit/commit/bfdc38ced77380feb7c8b0324e71bdde3b16c2f3))
-- **react:** hide the compliance section when there is no logo, caption or copyright info ([9fb7405](https://github.com/mi6/ic-ui-kit/commit/9fb74057482653855eb101c6e45f3aa4240e4a6c)), closes [#1800](https://github.com/mi6/ic-ui-kit/issues/1800)
-- **react:** update icon colours for dark mode badge ([ede2a04](https://github.com/mi6/ic-ui-kit/commit/ede2a04ffa9f6295f391283af1180e75a7c5a6e4))
 - **web-components:** bugfix: props passed correctly to child in group ([e4a4e41](https://github.com/mi6/ic-ui-kit/commit/e4a4e41178df8d6c150dba602bd86e16ee649cde))
 - **react:** update story book for test to react horizontal ([849a69d](https://github.com/mi6/ic-ui-kit/commit/849a69d2b8aa90ec9b12450d6a51c21e0a0f4e5a))
 - **react:** updates test following component change ([7c85c95](https://github.com/mi6/ic-ui-kit/commit/7c85c95eebc36590a52bf503409a7186102bfbbb))
@@ -204,12 +45,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** side nav Cypress test changes - add externally controlled visual tests ([2070042](https://github.com/mi6/ic-ui-kit/commit/2070042406e4b2694e3fe41fa11674e9b738bbc0))
 - **react:** update Cypress tests after colour/colour token update ([58bf555](https://github.com/mi6/ic-ui-kit/commit/58bf555bac04f4cf8ddb6842e030396ce111d990))
 - **react:** updating cypress tests ([83ec801](https://github.com/mi6/ic-ui-kit/commit/83ec80173c94d1e4dbeaa44843b7041162e66b0c))
-
-### Code Refactoring
-
-- **react:** change the name of the data-entity component to data-list ([7ffe6ea](https://github.com/mi6/ic-ui-kit/commit/7ffe6ea26b41ac315c2c8a2956149a2d08127e45)), closes [#79](https://github.com/mi6/ic-ui-kit/issues/79)
-- **react:** icCard renamed to IcCardVertical ([88eeaeb](https://github.com/mi6/ic-ui-kit/commit/88eeaeb10b2b6c91d8b2ab96d4813878cb0247e2)), closes [#2216](https://github.com/mi6/ic-ui-kit/issues/2216)
-- **react:** component size prop options changed ([61b3921](https://github.com/mi6/ic-ui-kit/commit/61b39213f184e4fca002962fb7800be01fe7c867))
+- **react:** added cypress test for backBreadcrumbOnly when using react router ([a20c2d9](https://github.com/mi6/ic-ui-kit/commit/a20c2d9aef4b7952660bb937fd21c8254a3d4d23))
+- **react:** expose IcToolTip disableClick prop ([01fe9ed](https://github.com/mi6/ic-ui-kit/commit/01fe9ed2b12eef7428d74f4afc854a1de4981156)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
+- **react:** fixed docs tab for react storybook ([62bb763](https://github.com/mi6/ic-ui-kit/commit/62bb76307c75f38ec7c83144c2f8a2560fffd9e5))
+- **react:** fixes card button focus color in high contrast mode ([720b098](https://github.com/mi6/ic-ui-kit/commit/720b0984ea40c27d0229a7ffef6ba8a0d4474c9f))
+- **react:** update Cypress visual regression test baseline images ([1d06e25](https://github.com/mi6/ic-ui-kit/commit/1d06e2578abc649162b7f38aefdee5e979d2472a))
+- **react:** update IcTopNavigation visual regression image ([e7a94d1](https://github.com/mi6/ic-ui-kit/commit/e7a94d1caba7df2b75e6130f476224e40c0f8458))
+- **react:** update visual regression images in IcAlert and IcTheme, fix storybook example ([577af0f](https://github.com/mi6/ic-ui-kit/commit/577af0fbfcf668b22b8728658a3a3f29ae34b48e))
+- **react:** baseline image update ([e8f2040](https://github.com/mi6/ic-ui-kit/commit/e8f20407c9d3d1986dc0a3546caa0324930335e0))
+- **react:** update Cypress visual regression images after removing side nav shadow ([1d37c42](https://github.com/mi6/ic-ui-kit/commit/1d37c427e97daa8e70c94ab20667ccf239131c7e)), closes [#2624](https://github.com/mi6/ic-ui-kit/issues/2624)
+- **react:** updates dialog stories and tests after focus fix ([c6f8dc9](https://github.com/mi6/ic-ui-kit/commit/c6f8dc94708b227eb19758345c7b96bd37ea882c))
+- **react:** updates tests for select change ([4357eda](https://github.com/mi6/ic-ui-kit/commit/4357eda5bc46ad12acb9c4a675bd203757c3e779))
+- **react:** set the focus in the icpopovermenu when the open prop has been provided ([bc6fa9b](https://github.com/mi6/ic-ui-kit/commit/bc6fa9b1b56b9eff7f6cb6dd9f726dba77d1c57c))
+- **react:** update Cypress tests after button updates to show slotted content with router item slot ([1e53f9b](https://github.com/mi6/ic-ui-kit/commit/1e53f9b225d7b02edaf3db0c39417d266550edaf))
+- **react:** update side nav to append badge to iconWrapper when slotted nav item used ([0a0ba96](https://github.com/mi6/ic-ui-kit/commit/0a0ba961a39cdd1dc9e270b3d004ea5ad6f42fc1)), closes [#1701](https://github.com/mi6/ic-ui-kit/issues/1701)
 
 ### Features
 
@@ -219,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** improve component prop names ([268e75f](https://github.com/mi6/ic-ui-kit/commit/268e75f57cb953050283634171a9da2f1ace911b))
 - **react:** remove references to deprecated props ([cb4ade4](https://github.com/mi6/ic-ui-kit/commit/cb4ade45dce5f434685a85c6af6c6b694528d6ea)), closes [#230](https://github.com/mi6/ic-ui-kit/issues/230)
 - **react:** update Cypress visual regression test baseline images ([b641bb4](https://github.com/mi6/ic-ui-kit/commit/b641bb478351fa47f1757fd1c8752034d1365330))
-- **react:** update usage of sideNavExpanded and topNavResized events to use new names ([63b533c](https://github.com/mi6/ic-ui-kit/commit/63b533c3c55cc2c98bc132afc45a97dccaad95fd)), closes [.#1354](https://github.com/./issues/1354)
+- **react:** update usage of sideNavExpanded and topNavResized events to use new names ([63b533c](https://github.com/mi6/ic-ui-kit/commit/63b533c3c55cc2c98bc132afc45a97dccaad95fd)), closes [#1354](https://github.com/mi6/ic-ui-kit/issues/1354)
 - **react:** updated radio cypress tests to remove shadow reference ([9f8b426](https://github.com/mi6/ic-ui-kit/commit/9f8b4264c55072b260c3e88558df8c7b9d98a01f))
 - **react:** add Cypress tests for icon button variants with tooltip ([1b9daca](https://github.com/mi6/ic-ui-kit/commit/1b9dacaec94feaa9216d9b749e1e4bc7fd01436d))
 - **react:** add maxLengthMessage prop to text field ([edb89af](https://github.com/mi6/ic-ui-kit/commit/edb89af8471d9583528ba2f6e1911a6a9c9507d0))
@@ -264,6 +113,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** implement theme prop on top navigation ([2bcf8d6](https://github.com/mi6/ic-ui-kit/commit/2bcf8d6a780bcdce5d542cb4b33ed4b28c3b042b))
 - **react:** update toggle button and toggle button group to have theme prop ([6b9b8be](https://github.com/mi6/ic-ui-kit/commit/6b9b8be2da8279a2f96985b93a39569ecdf7166e))
 - **web-components:** dark mode work ([580ab3a](https://github.com/mi6/ic-ui-kit/commit/580ab3acf60889fd17c096ba340e9cb7b9207139))
+- **react:** update empty state to have theme prop ([c02a6c2](https://github.com/mi6/ic-ui-kit/commit/c02a6c244c27b288b2f5f6cc9ef0f5156e879fad))
+- **react:** add tooltip placement prop on toggle button to match ic button ([04e9f59](https://github.com/mi6/ic-ui-kit/commit/04e9f59b2bf4ae509b5d8f0608026574f6b41b5a))
+- **react:** removed showState from IcSwitch ([19af8d4](https://github.com/mi6/ic-ui-kit/commit/19af8d4ce18b6a688a31bbc6bf00eb5f55d3f446))
+- **web-components:** Fix/able to select no options when select has empty options array ([cccf3fe](https://github.com/mi6/ic-ui-kit/commit/cccf3febc0edfa65474bda6ce08b2e8f8c895a6d))
+- **react:** add Cypress test for slotting interactive content after first load ([868d75a](https://github.com/mi6/ic-ui-kit/commit/868d75a8f064b8c02aa44bad9a4797606f801122)), closes [#2773](https://github.com/mi6/ic-ui-kit/issues/2773)
+- **react:** add tests for footer and top nav fixes for slotted link colours ([7b1e3ef](https://github.com/mi6/ic-ui-kit/commit/7b1e3eff2b0116cc497edbe2b0011ea9dcd6b184)), closes [#3234](https://github.com/mi6/ic-ui-kit/issues/3234)
+- **react:** update empty state to have theme prop ([1d7925d](https://github.com/mi6/ic-ui-kit/commit/1d7925d56b42180abdd1b5d19776a923247922e4))
+- **react:** update visual test screenshots - scrollbar on dialog ([f2e3585](https://github.com/mi6/ic-ui-kit/commit/f2e358529696614c388af0e0fc9cdb4ba5379372)), closes [#2868](https://github.com/mi6/ic-ui-kit/issues/2868)
+- **react:** added new react component for ic-skip-link ([d00a04f](https://github.com/mi6/ic-ui-kit/commit/d00a04feb55e6de14bb5116f392e29068554a5ae))
+- **react:** remove hashtag from skip link's target prop following prefixing of hashtag in prop ([d13356f](https://github.com/mi6/ic-ui-kit/commit/d13356f1605972a03e078c91f318dcc2a9c47053))
+- **react:** update nav menu and top nav tests and stories following nav group focus fix ([825e392](https://github.com/mi6/ic-ui-kit/commit/825e392032df1d9e1c4c2a6919db6927dfa70425)), closes [#3261](https://github.com//mi6/ic-ui-kit/issues/3261)
 
 ### Tests
 
@@ -274,21 +134,27 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** tests altered for dark mode ([0d0f783](https://github.com/mi6/ic-ui-kit/commit/0d0f7836b3b69adaa138b99a931f1b78b844cfd4))
 - **react:** visual regression image change ([6dad47e](https://github.com/mi6/ic-ui-kit/commit/6dad47e185a692e4796a0af5568e28efc38240a1))
 
+### Code Refactoring
+
+- **react:** change the name of the data-entity component to data-list ([7ffe6ea](https://github.com/mi6/ic-ui-kit/commit/7ffe6ea26b41ac315c2c8a2956149a2d08127e45)), closes [#79](https://github.com/mi6/ic-ui-kit/issues/79)
+- **react:** icCard renamed to IcCardVertical ([88eeaeb](https://github.com/mi6/ic-ui-kit/commit/88eeaeb10b2b6c91d8b2ab96d4813878cb0247e2)), closes [#2216](https://github.com/mi6/ic-ui-kit/issues/2216)
+- **react:** component size prop options changed ([61b3921](https://github.com/mi6/ic-ui-kit/commit/61b39213f184e4fca002962fb7800be01fe7c867))
+
 ### Performance Improvements
 
 - **react:** add the ability to change between themes in Storybook toolbar ([2e60dd8](https://github.com/mi6/ic-ui-kit/commit/2e60dd83d9330f205edabc87667b3cff6984b465))
 
 ### BREAKING CHANGES
 
-- **react:** dark mode
-- **react:** removed IcTextField component, which may break tests
-- **react:** BREAKING CHANGE: color prop renamed to brandColor
+- **react:** removed showState prop from IcSwitch
+- **react:** removed IcTextField component from IcSearchBar, which may break tests
+- **react:** IcTheme component color prop renamed to brandColor
   icThemeChange event renamed to icBrandChange
   changes to types:
-  IcThemeForegroundEnum now IcBrandForegroundEnum
-  IcThemeForeground now IcBrandForeground
-  IcThemeForegroundNoDefault now IcBrandForegroundNoDefault
-  IcTheme now IcBrand
+   - IcThemeForegroundEnum now IcBrandForegroundEnum
+   - IcThemeForeground now IcBrandForeground
+   - IcThemeForegroundNoDefault now IcBrandForegroundNoDefault
+   - IcTheme now IcBrand
 - **react:** IcCard renamed to IcCardVertical, IcPagination adjacentCount and boundaryCount
   props renamed to adjacentPageCount and boundaryPageCount respectively, IcEmptyState bodyMaxLines
   prop renamed to maxLines, IcFooter groupTitle prop renamed to label, IcRadio disabled class renamed
@@ -296,7 +162,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** Renaming IcCard to IcCardVertical and IcDataEntity to IcDataList
 - **react:** Accordion group 'groupTitle' renamed to 'label' and badge 'textLabel' renamed to
   'label'
-- **react:** component now uses an ic-button under the covers, so internal structure has changed
+- **react:** IcBackToTop component now uses an ic-button under the covers, so internal structure has changed
 - **react:** Accordion group and footer link group “groupTitle” renamed to “label”, badge
   “textLabel” renamed to “label”, empty state “bodyMaxLines” renamed to “maxLines”, input label
   “error” renamed to “status” with error as an option, pagination “boundaryCount” and “adjacentCount”
@@ -315,6 +181,37 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **react:** Add default styling and props to IcDivider
 - **react:** For toggle button/toggle button group, the appearance prop has been replaced with
   theme and monochrome
+
+## [2.37.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.37.0...@ukic/react@2.37.2) (2025-04-16)
+
+### Bug Fixes
+
+- **react:** set the focus in the icpopovermenu when the open prop has been provided ([a2c1703](https://github.com/mi6/ic-ui-kit/commit/a2c1703f5a89ca033cdfe91eaab13aeba9b33c9c))
+
+## [2.37.1](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.37.0...@ukic/react@2.37.1) (2025-04-07)
+
+**Note:** Version bump only for package @ukic/react
+
+# [2.37.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.36.0...@ukic/react@2.37.0) (2025-03-19)
+
+### Features
+
+- **react:** update story name to have lowercase E ([16ebc85](https://github.com/mi6/ic-ui-kit/commit/16ebc859f66e31cd55da3e60e1320c8c8ea32be3))
+
+# [2.36.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.35.2...@ukic/react@2.36.0) (2025-03-05)
+
+### Bug Fixes
+
+- **react:** added storybook example and modified cypress test ([56c1e24](https://github.com/mi6/ic-ui-kit/commit/56c1e2422b5e4e03112b9b7afe560d4b9fb364d2))
+- **react:** adds visual test for long label fix ([1bd73b8](https://github.com/mi6/ic-ui-kit/commit/1bd73b82d2b0c69847c83e6f71309e2c378e8a79))
+- **react:** fixed docs tab for react storybook ([2e321f9](https://github.com/mi6/ic-ui-kit/commit/2e321f9d7f77e0856593bd8f77dc234723cafd02))
+- **react:** fixes card button focus color in high contrast mode ([8343041](https://github.com/mi6/ic-ui-kit/commit/8343041a7f127c4d814624f6b7e3802cf30f0bbb))
+
+### Features
+
+- **react:** add Cypress test for slotting interactive content after first load ([22c58a0](https://github.com/mi6/ic-ui-kit/commit/22c58a0b7fd179bb34e8990916019ca0cc74134f)), closes [#2773](https://github.com/mi6/ic-ui-kit/issues/2773)
+- **react:** update visual test screenshots - scrollbar on dialog ([41d49f5](https://github.com/mi6/ic-ui-kit/commit/41d49f5b49c30dc573d90d647cc284449ad3bf77)), closes [#2868](https://github.com/mi6/ic-ui-kit/issues/2868)
+
 
 ## [2.35.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.35.1...@ukic/react@2.35.2) (2025-02-19)
 
@@ -475,11 +372,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 - **react:** add a storybook playground for ic-pagination ([6e8758f](https://github.com/mi6/ic-ui-kit/commit/6e8758fc2381a46dde71de8503e1ad0e5bb13ebc))
-- **react:** add loading indicator props playground ([fbbf0b6](https://github.com/mi6/ic-ui-kit/commit/fbbf0b6af8de252e5131b7de508d39d94e764800)), closes [.#1970](https://github.com/./issues/1970)
+- **react:** add loading indicator props playground ([fbbf0b6](https://github.com/mi6/ic-ui-kit/commit/fbbf0b6af8de252e5131b7de508d39d94e764800)), closes [#1970](https://github.com/mi6/ic-ui-kit/issues/1970)
 - **react:** adds playground for back to top ([5c6d265](https://github.com/mi6/ic-ui-kit/commit/5c6d265327300881f3762c2a7b4f52558aa5a0a7))
 - **react:** tests updated and storybook playground added ([5a62361](https://github.com/mi6/ic-ui-kit/commit/5a62361c8d74c5e06e28093bab81f0c179edd118))
 - **react:** update Cypress visual regression test baseline images ([9baef99](https://github.com/mi6/ic-ui-kit/commit/9baef999e08000a7e40c6a16b5112eb7ce6ce827))
-- **react:** update select playground argType ([ee5adb4](https://github.com/mi6/ic-ui-kit/commit/ee5adb4a9089b2a7e94b5856867fc71fb29323de)), closes [.#1970](https://github.com/./issues/1970)
+- **react:** update select playground argType ([ee5adb4](https://github.com/mi6/ic-ui-kit/commit/ee5adb4a9089b2a7e94b5856867fc71fb29323de)), closes [#1970](https://github.com/mi6/ic-ui-kit/issues/1970)
 
 # [2.22.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.21.0...@ukic/react@2.22.0) (2024-06-12)
 
@@ -549,7 +446,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **react:** add examples of components with type="dot" badge ([3f5c4a7](https://github.com/mi6/ic-ui-kit/commit/3f5c4a781961d042b43162850fd1d9311ef58c9c)), closes [.#1391](https://github.com/./issues/1391)
+- **react:** add examples of components with type="dot" badge ([3f5c4a7](https://github.com/mi6/ic-ui-kit/commit/3f5c4a781961d042b43162850fd1d9311ef58c9c)), closes [#1391](https://github.com/mi6/ic-ui-kit/issues/1391)
 
 ## [2.15.1](https://github.com/mi6/ic-ui-kit/compare/@ukic/react@2.15.0...@ukic/react@2.15.1) (2024-03-28)
 
@@ -577,7 +474,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **react:** add router item slot for buttons ([1d3b09e](https://github.com/mi6/ic-ui-kit/commit/1d3b09e8e662f735465a6d23af56f9292190ddc4)), closes [#1500](https://github.com/mi6/ic-ui-kit/issues/1500)
 - **react:** ic-toggle-button-group ([ee879b0](https://github.com/mi6/ic-ui-kit/commit/ee879b0d3d1a6a80e9f55fcacf3eca49c4f9b446))
-- **react:** split single and searchable select stories out into separate files ([b62052f](https://github.com/mi6/ic-ui-kit/commit/b62052f9b831ce2b089b52052e3be2c93953dd84)), closes [.#257](https://github.com/./issues/257)
+- **react:** split single and searchable select stories out into separate files ([b62052f](https://github.com/mi6/ic-ui-kit/commit/b62052f9b831ce2b089b52052e3be2c93953dd84)), closes [#257](https://github.com/mi6/ic-ui-kit/issues/257)
 - **react:** update Cypress visual regression test baseline images ([de15548](https://github.com/mi6/ic-ui-kit/commit/de1554857d14f0723c3d44300921ca85ddedaf54))
 - **react:** update how react storybook displays stories title ([ec525df](https://github.com/mi6/ic-ui-kit/commit/ec525df0f280302c156eaca5d3bbad5c32201517))
 - **react:** updates stories for icOpen and icClose events ([104c3fb](https://github.com/mi6/ic-ui-kit/commit/104c3fb686e1cc8337c3d5f53421fc364a2d4589))
@@ -733,7 +630,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **react:** remove selected prop from radio story, add reset button ([5d0b96e](https://github.com/mi6/ic-ui-kit/commit/5d0b96e348d15de1fd4abd1d61b32fd7a80110e4)), closes [.#822](https://github.com/./issues/822)
+- **react:** remove selected prop from radio story, add reset button ([5d0b96e](https://github.com/mi6/ic-ui-kit/commit/5d0b96e348d15de1fd4abd1d61b32fd7a80110e4)), closes [#822](https://github.com/mi6/ic-ui-kit/issues/822)
 
 # 2.1.0-beta.16 (2023-06-26)
 
@@ -802,13 +699,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **react:** add option with space to ic-select 'Scroll behaviour' story ([e5cc132](https://github.com/mi6/ic-ui-kit/commit/e5cc1327a85dde0d69c923237fa4484ae4a16f50)), closes [.#158](https://github.com/./issues/158)
+- **react:** add option with space to ic-select 'Scroll behaviour' story ([e5cc132](https://github.com/mi6/ic-ui-kit/commit/e5cc1327a85dde0d69c923237fa4484ae4a16f50)), closes [#158](https://github.com/mi6/ic-ui-kit/issues/158)
 
 # 2.1.0-beta.9 (2023-03-21)
 
 ### Features
 
-- **react:** add more tabs / nav items to stories for scroll demonstration ([925602b](https://github.com/mi6/ic-ui-kit/commit/925602b046734a867ae1d74a4a4e7306c14068fe)), closes [.#242](https://github.com/./issues/242)
+- **react:** add more tabs / nav items to stories for scroll demonstration ([925602b](https://github.com/mi6/ic-ui-kit/commit/925602b046734a867ae1d74a4a4e7306c14068fe)), closes [#242](https://github.com/mi6/ic-ui-kit/issues/242)
 - **web-components:** implement toast component ([db455fb](https://github.com/mi6/ic-ui-kit/commit/db455fbb16a4e0415908b909a6d47cafe9f10912))
 
 # 2.1.0-beta.8 (2023-03-01)

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -3,176 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.0.0-alpha.14](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@3.0.0-alpha.13...@ukic/web-components@3.0.0-alpha.14) (2025-04-16)
-
-### Bug Fixes
-
-- **canary-web-components:** update data table row hover colours for dark mode ([85ac59e](https://github.com/mi6/ic-ui-kit/commit/85ac59efcd6683eb611261f3aa4235ba8ca4f397)), closes [#3022](https://github.com/mi6/ic-ui-kit/issues/3022)
-- **web-components:** [ic-button] remove 1px top and bottom margin from icon variant ([7d78fb0](https://github.com/mi6/ic-ui-kit/commit/7d78fb0d1f2ebc90c101297655f5735cbbe34b3b))
-- **web-components:** add check for selectedOption to prevent undefined error in radio group ([1e81c59](https://github.com/mi6/ic-ui-kit/commit/1e81c59793e00a6d5f0bfd970369d2865aed14d8))
-- **web-components:** add focus indicator, hover state and pressed state to footer logo links ([eb3fbfa](https://github.com/mi6/ic-ui-kit/commit/eb3fbfa2008162b137774b7ee4e5247adc81a66d))
-- **web-components:** added fix to prevent numeric text field being modified by scroll ([c256013](https://github.com/mi6/ic-ui-kit/commit/c256013ada80d668abdcd6e0fb096be8e5b0e69e))
-- **web-components:** added updated status colour tokens + dt token ([d15248f](https://github.com/mi6/ic-ui-kit/commit/d15248fa4928ddb99e73dfb640c9b38071154560))
-- **web-components:** adding description to ic-loading-indicator of auto-dismiss toast ([52fa5a4](https://github.com/mi6/ic-ui-kit/commit/52fa5a47a2471bd5c3006b7a4c11281fb4a042ea))
-- **web-components:** auto-dismiss toasts now read aloud to screenreaders ([3450955](https://github.com/mi6/ic-ui-kit/commit/345095549cd280a22eaddcf4b07caf259c090a32))
-- **web-components:** changes to ic-badge and ic-navigation-button to show notifications in mobile ([be1bc5a](https://github.com/mi6/ic-ui-kit/commit/be1bc5a0585ee7a09ea6c80bbe39e931d14258f1))
-- **web-components:** destructive prop description change ([cf3b94c](https://github.com/mi6/ic-ui-kit/commit/cf3b94c57e970996658392bc6266e86e7e49e53d))
-- **web-components:** expose IcToolTip disableClick prop ([3be054f](https://github.com/mi6/ic-ui-kit/commit/3be054f19b663de7d391eb2ded26b48c27cf9a4f)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **web-components:** fix circular loading indicator showing as complete circle ([dbcf528](https://github.com/mi6/ic-ui-kit/commit/dbcf5281b721e23b6a98d87f4851726149c23b33))
-- **web-components:** fix double focus indicator on selected slotted side nav item when dark ([8b41b1f](https://github.com/mi6/ic-ui-kit/commit/8b41b1fab8b06e5c23b1f97aaefebc81e21b80ec))
-- **web-components:** fix incorrect footer link and top nav items slotted link colours ([3c512ef](https://github.com/mi6/ic-ui-kit/commit/3c512ef38d781063373084cfa0d71dc8761196a0)), closes [.#3234](https://github.com/./issues/3234)
-- **web-components:** fix issue with items in last top nav group not receiving focus ([2634fa8](https://github.com/mi6/ic-ui-kit/commit/2634fa86b97e174920e8e9e3344f2450f4df45c0)), closes [.#3261](https://github.com/./issues/3261)
-- **web-components:** fixed displaying readme docs on storybook ([0f7c35a](https://github.com/mi6/ic-ui-kit/commit/0f7c35aa5405bebce25de4fb6ed5aee02d1dd875))
-- **web-components:** fixed the height of readonly select ([6d30df9](https://github.com/mi6/ic-ui-kit/commit/6d30df93b0e9d6dd0ddc840b2521575f4af82d91))
-- **web-components:** fixes card button focus color in high contrast mode ([9439a45](https://github.com/mi6/ic-ui-kit/commit/9439a45ea2bf0eb81556091760956f7558c13736))
-- **web-components:** fixes focus in high contrst mode ([b9098d7](https://github.com/mi6/ic-ui-kit/commit/b9098d7849e2fa41d0e5f856434f6b310e0d2480))
-- **web-components:** fixes focus issues with interactive components on dialog ([b3d40f8](https://github.com/mi6/ic-ui-kit/commit/b3d40f80128348a7155d41f1016e16e6664d6a63))
-- **web-components:** ic-alert fix - height compensation in different themes ([860b235](https://github.com/mi6/ic-ui-kit/commit/860b235a11afca2862ffbbd19bdb35c040dab81c))
-- **web-components:** ic-popover-menu close sub menus fix ([2b94f58](https://github.com/mi6/ic-ui-kit/commit/2b94f58bbb600833da04cb7d0994355cfaf2ea78))
-- **web-components:** ic-select no longer allows values that aren't in options ([b1ba8a7](https://github.com/mi6/ic-ui-kit/commit/b1ba8a7302474d4533f28717f65d00998a1ea8b2))
-- **web-components:** remove shadow from side navigation ([06d31d5](https://github.com/mi6/ic-ui-kit/commit/06d31d512c6a4e7ecfb9507cd4c9f97934537fa0)), closes [#2624](https://github.com/mi6/ic-ui-kit/issues/2624)
-- **web-components:** render only one collapsed breadcrumb when window is resized ([ea25f2d](https://github.com/mi6/ic-ui-kit/commit/ea25f2de5a1c11c8bd79c52130343afd641007fe))
-- **web-components:** selected items with hover state are lined up correctly in nav group ([45d483a](https://github.com/mi6/ic-ui-kit/commit/45d483ab61641b1289ea96c61e30924c9089113f))
-- **web-components:** set the focus in the icpopovermenu when the open prop has been provided ([84324bc](https://github.com/mi6/ic-ui-kit/commit/84324bcbcc7cdd311cc28f63c92a2c3a44729224))
-- **web-components:** update button to display icons/badges when router item slot is used ([c62c414](https://github.com/mi6/ic-ui-kit/commit/c62c414a7d15435b50f4c384b3bace480ec6a45d)), closes [#1814](https://github.com/mi6/ic-ui-kit/issues/1814)
-- **web-components:** update checkbox so that it works correctly on rtl pages ([8911b4f](https://github.com/mi6/ic-ui-kit/commit/8911b4fcd759197991be1cbd22b948300d3a2b30))
-- **web-components:** update dialog to make interactive slotted children content focussable ([7fe73dc](https://github.com/mi6/ic-ui-kit/commit/7fe73dc8ffb67fe497bbee514fa73644743bfc77)), closes [.#2773](https://github.com/./issues/2773)
-- **web-components:** update navigation group so that two nav groups can't be open simultaneously ([3b61e98](https://github.com/mi6/ic-ui-kit/commit/3b61e98c79846f074213620db0fe38fbf8c2fd53)), closes [#3117](https://github.com/mi6/ic-ui-kit/issues/3117)
-- **web-components:** update select to not display clear button when disabled ([a74bae2](https://github.com/mi6/ic-ui-kit/commit/a74bae201ca21d25677e21d5d8b58f4f024a422f)), closes [.#2322](https://github.com/./issues/2322)
-- **web-components:** update side nav to append badge to iconWrapper when slotted nav item used ([e2c79c9](https://github.com/mi6/ic-ui-kit/commit/e2c79c9cda05f28e43ca988f8bafe2d402faa5d6)), closes [#1701](https://github.com/mi6/ic-ui-kit/issues/1701)
-- **web-components:** update to ic-stepper colours to match figma designs ([7bb760d](https://github.com/mi6/ic-ui-kit/commit/7bb760dd454dc8b5428c8b6d811a21d9c267cfdf))
-- **web-components:** updated tree-view selected colour mode values ([8fca7d4](https://github.com/mi6/ic-ui-kit/commit/8fca7d4c8a9013bbc3691b2d20aa4f2074898f99))
-- **web-components:** updating inner border of focused toggle button ([7dd59b2](https://github.com/mi6/ic-ui-kit/commit/7dd59b2e51688e9ce10a175bc1cfd8935e7f9ca9))
-
-### Features
-
-- **web-components:** add styling for inline variant of skip link and prefix target with hashtag ([621993b](https://github.com/mi6/ic-ui-kit/commit/621993bda0a566e52b31686db09c913bb45821be))
-- **web-components:** added ic-skip-link component ([2e321df](https://github.com/mi6/ic-ui-kit/commit/2e321df4132caf24b05ce986130771e182830b80))
-- **web-components:** CSS props for x and y positions exposed on ic-back-to-top ([2ce1d92](https://github.com/mi6/ic-ui-kit/commit/2ce1d9277e3781376bae41ba1ec3eb44e9228b9b))
-- **web-components:** enable TypeScript strict mode (core web comps) and add last required changes ([cd77717](https://github.com/mi6/ic-ui-kit/commit/cd7771797665a29a53e60a9d469094f3da700e70)), closes [.#266](https://github.com/./issues/266)
-- **web-components:** icBackToTop 'position' prop added ([be9c00c](https://github.com/mi6/ic-ui-kit/commit/be9c00c864c652fcc6fdb7244893dd14f81957d5))
-- **web-components:** icBackToTop 'position' prop added ([a685b62](https://github.com/mi6/ic-ui-kit/commit/a685b628449df9d2c8ae0a4130f1550da1b2a2e1))
-- **web-components:** make changes to first half of web-components files to resolve strict mode errors ([53690d1](https://github.com/mi6/ic-ui-kit/commit/53690d188b8559b7e3820d0cb9601fc549a24bee)), closes [.#266](https://github.com/./issues/266)
-- **web-components:** styling for RTL characters in ic-radio-option ([18e453d](https://github.com/mi6/ic-ui-kit/commit/18e453d40094b9fd37d5331ef6fb1742067204a4))
-- **web-components:** update empty state to have theme prop ([216dbb6](https://github.com/mi6/ic-ui-kit/commit/216dbb677a572c2ed91453683a12b02daeb19ee3))
-- **web-components:** update second half of web-components files to resolve strict mode errors ([b939971](https://github.com/mi6/ic-ui-kit/commit/b9399713cc98798fcca669db083869b134f82ca1)), closes [.#266](https://github.com/./issues/266) [#3349](https://github.com/mi6/ic-ui-kit/issues/3349)
-
-### BREAKING CHANGES
-
-- **web-components:** Can no longer populate a select with a value not included in the array
-
-# [3.0.0-alpha.13](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@3.0.0-alpha.12...@ukic/web-components@3.0.0-alpha.13) (2025-04-08)
-
-### Bug Fixes
-
-- **web-components:** [ic-button] remove 1px top and bottom margin from icon variant ([7d78fb0](https://github.com/mi6/ic-ui-kit/commit/7d78fb0d1f2ebc90c101297655f5735cbbe34b3b))
-- **web-components:** add check for selectedOption to prevent undefined error in radio group ([1e81c59](https://github.com/mi6/ic-ui-kit/commit/1e81c59793e00a6d5f0bfd970369d2865aed14d8))
-- **web-components:** add focus indicator, hover state and pressed state to footer logo links ([eb3fbfa](https://github.com/mi6/ic-ui-kit/commit/eb3fbfa2008162b137774b7ee4e5247adc81a66d))
-- **web-components:** added fix to prevent numeric text field being modified by scroll ([c256013](https://github.com/mi6/ic-ui-kit/commit/c256013ada80d668abdcd6e0fb096be8e5b0e69e))
-- **web-components:** adding description to ic-loading-indicator of auto-dismiss toast ([52fa5a4](https://github.com/mi6/ic-ui-kit/commit/52fa5a47a2471bd5c3006b7a4c11281fb4a042ea))
-- **web-components:** auto-dismiss toasts now read aloud to screenreaders ([3450955](https://github.com/mi6/ic-ui-kit/commit/345095549cd280a22eaddcf4b07caf259c090a32))
-- **web-components:** changes to ic-badge and ic-navigation-button to show notifications in mobile ([be1bc5a](https://github.com/mi6/ic-ui-kit/commit/be1bc5a0585ee7a09ea6c80bbe39e931d14258f1))
-- **web-components:** destructive prop description change ([cf3b94c](https://github.com/mi6/ic-ui-kit/commit/cf3b94c57e970996658392bc6266e86e7e49e53d))
-- **web-components:** expose IcToolTip disableClick prop ([3be054f](https://github.com/mi6/ic-ui-kit/commit/3be054f19b663de7d391eb2ded26b48c27cf9a4f)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **web-components:** fix circular loading indicator showing as complete circle ([dbcf528](https://github.com/mi6/ic-ui-kit/commit/dbcf5281b721e23b6a98d87f4851726149c23b33))
-- **web-components:** fix double focus indicator on selected slotted side nav item when dark ([8b41b1f](https://github.com/mi6/ic-ui-kit/commit/8b41b1fab8b06e5c23b1f97aaefebc81e21b80ec))
-- **web-components:** fix incorrect footer link and top nav items slotted link colours ([3c512ef](https://github.com/mi6/ic-ui-kit/commit/3c512ef38d781063373084cfa0d71dc8761196a0)), closes [.#3234](https://github.com/./issues/3234)
-- **web-components:** fixed displaying readme docs on storybook ([0f7c35a](https://github.com/mi6/ic-ui-kit/commit/0f7c35aa5405bebce25de4fb6ed5aee02d1dd875))
-- **web-components:** fixed the height of readonly select ([6d30df9](https://github.com/mi6/ic-ui-kit/commit/6d30df93b0e9d6dd0ddc840b2521575f4af82d91))
-- **web-components:** fixes card button focus color in high contrast mode ([9439a45](https://github.com/mi6/ic-ui-kit/commit/9439a45ea2bf0eb81556091760956f7558c13736))
-- **web-components:** fixes focus in high contrst mode ([b9098d7](https://github.com/mi6/ic-ui-kit/commit/b9098d7849e2fa41d0e5f856434f6b310e0d2480))
-- **web-components:** fixes focus issues with interactive components on dialog ([b3d40f8](https://github.com/mi6/ic-ui-kit/commit/b3d40f80128348a7155d41f1016e16e6664d6a63))
-- **web-components:** ic-alert fix - height compensation in different themes ([860b235](https://github.com/mi6/ic-ui-kit/commit/860b235a11afca2862ffbbd19bdb35c040dab81c))
-- **web-components:** ic-popover-menu close sub menus fix ([2b94f58](https://github.com/mi6/ic-ui-kit/commit/2b94f58bbb600833da04cb7d0994355cfaf2ea78))
-- **web-components:** ic-select no longer allows values that aren't in options ([b1ba8a7](https://github.com/mi6/ic-ui-kit/commit/b1ba8a7302474d4533f28717f65d00998a1ea8b2))
-- **web-components:** remove shadow from side navigation ([06d31d5](https://github.com/mi6/ic-ui-kit/commit/06d31d512c6a4e7ecfb9507cd4c9f97934537fa0)), closes [#2624](https://github.com/mi6/ic-ui-kit/issues/2624)
-- **web-components:** render only one collapsed breadcrumb when window is resized ([ea25f2d](https://github.com/mi6/ic-ui-kit/commit/ea25f2de5a1c11c8bd79c52130343afd641007fe))
-- **web-components:** selected items with hover state are lined up correctly in nav group ([45d483a](https://github.com/mi6/ic-ui-kit/commit/45d483ab61641b1289ea96c61e30924c9089113f))
-- **web-components:** update checkbox so that it works correctly on rtl pages ([8911b4f](https://github.com/mi6/ic-ui-kit/commit/8911b4fcd759197991be1cbd22b948300d3a2b30))
-- **web-components:** update dialog to make interactive slotted children content focussable ([7fe73dc](https://github.com/mi6/ic-ui-kit/commit/7fe73dc8ffb67fe497bbee514fa73644743bfc77)), closes [.#2773](https://github.com/./issues/2773)
-- **web-components:** update hero to use --ic-hero-background token ([8c4fc68](https://github.com/mi6/ic-ui-kit/commit/8c4fc687a01c16b7fcdd695f3ccf99c041935008)), closes [#3369](https://github.com/mi6/ic-ui-kit/issues/3369)
-- **web-components:** update navigation group so that two nav groups can't be open simultaneously ([3b61e98](https://github.com/mi6/ic-ui-kit/commit/3b61e98c79846f074213620db0fe38fbf8c2fd53)), closes [#3117](https://github.com/mi6/ic-ui-kit/issues/3117)
-- **web-components:** updated tree-view selected colour mode values ([8fca7d4](https://github.com/mi6/ic-ui-kit/commit/8fca7d4c8a9013bbc3691b2d20aa4f2074898f99))
-- **web-components:** updating inner border of focused toggle button ([7dd59b2](https://github.com/mi6/ic-ui-kit/commit/7dd59b2e51688e9ce10a175bc1cfd8935e7f9ca9))
-
-### Features
-
-- **web-components:** added ic-skip-link component ([2e321df](https://github.com/mi6/ic-ui-kit/commit/2e321df4132caf24b05ce986130771e182830b80))
-- **web-components:** CSS props for x and y positions exposed on ic-back-to-top ([2ce1d92](https://github.com/mi6/ic-ui-kit/commit/2ce1d9277e3781376bae41ba1ec3eb44e9228b9b))
-- **web-components:** enable TypeScript strict mode (core web comps) and add last required changes ([cd77717](https://github.com/mi6/ic-ui-kit/commit/cd7771797665a29a53e60a9d469094f3da700e70)), closes [.#266](https://github.com/./issues/266)
-- **web-components:** icBackToTop 'position' prop added ([be9c00c](https://github.com/mi6/ic-ui-kit/commit/be9c00c864c652fcc6fdb7244893dd14f81957d5))
-- **web-components:** icBackToTop 'position' prop added ([a685b62](https://github.com/mi6/ic-ui-kit/commit/a685b628449df9d2c8ae0a4130f1550da1b2a2e1))
-- **web-components:** make changes to first half of web-components files to resolve strict mode errors ([53690d1](https://github.com/mi6/ic-ui-kit/commit/53690d188b8559b7e3820d0cb9601fc549a24bee)), closes [.#266](https://github.com/./issues/266)
-- **web-components:** styling for RTL characters in ic-radio-option ([18e453d](https://github.com/mi6/ic-ui-kit/commit/18e453d40094b9fd37d5331ef6fb1742067204a4))
-- **web-components:** update empty state to have theme prop ([216dbb6](https://github.com/mi6/ic-ui-kit/commit/216dbb677a572c2ed91453683a12b02daeb19ee3))
-- **web-components:** update second half of web-components files to resolve strict mode errors ([b939971](https://github.com/mi6/ic-ui-kit/commit/b9399713cc98798fcca669db083869b134f82ca1)), closes [.#266](https://github.com/./issues/266) [#3349](https://github.com/mi6/ic-ui-kit/issues/3349)
-
-### BREAKING CHANGES
-
-- **web-components:** Can no longer populate a select with a value not included in the array
-
-# [3.0.0-alpha.12](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@3.0.0-alpha.11...@ukic/web-components@3.0.0-alpha.12) (2025-03-19)
-
-### Bug Fixes
-
-- **web-components:** add check for selectedOption to prevent undefined error in radio group ([1e81c59](https://github.com/mi6/ic-ui-kit/commit/1e81c59793e00a6d5f0bfd970369d2865aed14d8))
-- **web-components:** add focus indicator, hover state and pressed state to footer logo links ([eb3fbfa](https://github.com/mi6/ic-ui-kit/commit/eb3fbfa2008162b137774b7ee4e5247adc81a66d))
-- **web-components:** adding description to ic-loading-indicator of auto-dismiss toast ([52fa5a4](https://github.com/mi6/ic-ui-kit/commit/52fa5a47a2471bd5c3006b7a4c11281fb4a042ea))
-- **web-components:** auto-dismiss toasts now read aloud to screenreaders ([3450955](https://github.com/mi6/ic-ui-kit/commit/345095549cd280a22eaddcf4b07caf259c090a32))
-- **web-components:** changes to ic-badge and ic-navigation-button to show notifications in mobile ([be1bc5a](https://github.com/mi6/ic-ui-kit/commit/be1bc5a0585ee7a09ea6c80bbe39e931d14258f1))
-- **web-components:** destructive prop description change ([cf3b94c](https://github.com/mi6/ic-ui-kit/commit/cf3b94c57e970996658392bc6266e86e7e49e53d))
-- **web-components:** expose IcToolTip disableClick prop ([3be054f](https://github.com/mi6/ic-ui-kit/commit/3be054f19b663de7d391eb2ded26b48c27cf9a4f)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **web-components:** fix double focus indicator on selected slotted side nav item when dark ([8b41b1f](https://github.com/mi6/ic-ui-kit/commit/8b41b1fab8b06e5c23b1f97aaefebc81e21b80ec))
-- **web-components:** fix incorrect footer link and top nav items slotted link colours ([3c512ef](https://github.com/mi6/ic-ui-kit/commit/3c512ef38d781063373084cfa0d71dc8761196a0)), closes [.#3234](https://github.com/./issues/3234)
-- **web-components:** fixed displaying readme docs on storybook ([0f7c35a](https://github.com/mi6/ic-ui-kit/commit/0f7c35aa5405bebce25de4fb6ed5aee02d1dd875))
-- **web-components:** fixes card button focus color in high contrast mode ([9439a45](https://github.com/mi6/ic-ui-kit/commit/9439a45ea2bf0eb81556091760956f7558c13736))
-- **web-components:** fixes focus in high contrst mode ([b9098d7](https://github.com/mi6/ic-ui-kit/commit/b9098d7849e2fa41d0e5f856434f6b310e0d2480))
-- **web-components:** ic-alert fix - height compensation in different themes ([860b235](https://github.com/mi6/ic-ui-kit/commit/860b235a11afca2862ffbbd19bdb35c040dab81c))
-- **web-components:** ic-popover-menu close sub menus fix ([2b94f58](https://github.com/mi6/ic-ui-kit/commit/2b94f58bbb600833da04cb7d0994355cfaf2ea78))
-- **web-components:** render only one collapsed breadcrumb when window is resized ([ea25f2d](https://github.com/mi6/ic-ui-kit/commit/ea25f2de5a1c11c8bd79c52130343afd641007fe))
-- **web-components:** selected items with hover state are lined up correctly in nav group ([45d483a](https://github.com/mi6/ic-ui-kit/commit/45d483ab61641b1289ea96c61e30924c9089113f))
-- **web-components:** update checkbox so that it works correctly on rtl pages ([8911b4f](https://github.com/mi6/ic-ui-kit/commit/8911b4fcd759197991be1cbd22b948300d3a2b30))
-- **web-components:** update dialog to make interactive slotted children content focussable ([7fe73dc](https://github.com/mi6/ic-ui-kit/commit/7fe73dc8ffb67fe497bbee514fa73644743bfc77)), closes [.#2773](https://github.com/./issues/2773)
-- **web-components:** updated tree-view selected colour mode values ([8fca7d4](https://github.com/mi6/ic-ui-kit/commit/8fca7d4c8a9013bbc3691b2d20aa4f2074898f99))
-- **web-components:** updating inner border of focused toggle button ([7dd59b2](https://github.com/mi6/ic-ui-kit/commit/7dd59b2e51688e9ce10a175bc1cfd8935e7f9ca9))
-
-### Features
-
-- **web-components:** CSS props for x and y positions exposed on ic-back-to-top ([2ce1d92](https://github.com/mi6/ic-ui-kit/commit/2ce1d9277e3781376bae41ba1ec3eb44e9228b9b))
-- **web-components:** icBackToTop 'position' prop added ([be9c00c](https://github.com/mi6/ic-ui-kit/commit/be9c00c864c652fcc6fdb7244893dd14f81957d5))
-- **web-components:** icBackToTop 'position' prop added ([a685b62](https://github.com/mi6/ic-ui-kit/commit/a685b628449df9d2c8ae0a4130f1550da1b2a2e1))
-- **web-components:** styling for RTL characters in ic-radio-option ([18e453d](https://github.com/mi6/ic-ui-kit/commit/18e453d40094b9fd37d5331ef6fb1742067204a4))
-- **web-components:** update empty state to have theme prop ([216dbb6](https://github.com/mi6/ic-ui-kit/commit/216dbb677a572c2ed91453683a12b02daeb19ee3))
-
-# [3.0.0-alpha.11](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@3.0.0-alpha.9...@ukic/web-components@3.0.0-alpha.11) (2025-03-05)
-
-### Bug Fixes
-
-- **web-components:** add check for selectedOption to prevent undefined error in radio group ([1e81c59](https://github.com/mi6/ic-ui-kit/commit/1e81c59793e00a6d5f0bfd970369d2865aed14d8))
-- **web-components:** add focus indicator, hover state and pressed state to footer logo links ([eb3fbfa](https://github.com/mi6/ic-ui-kit/commit/eb3fbfa2008162b137774b7ee4e5247adc81a66d))
-- **web-components:** add scrollbar to content area on dialog to make it easier to scroll ([fa869cf](https://github.com/mi6/ic-ui-kit/commit/fa869cf8cc67da2425b3abfb456a6a5242a55478)), closes [.#2868](https://github.com/./issues/2868)
-- **web-components:** adding description to ic-loading-indicator of auto-dismiss toast ([52fa5a4](https://github.com/mi6/ic-ui-kit/commit/52fa5a47a2471bd5c3006b7a4c11281fb4a042ea))
-- **web-components:** auto-dismiss toasts now read aloud to screenreaders ([3450955](https://github.com/mi6/ic-ui-kit/commit/345095549cd280a22eaddcf4b07caf259c090a32))
-- **web-components:** changes to ic-badge and ic-navigation-button to show notifications in mobile ([be1bc5a](https://github.com/mi6/ic-ui-kit/commit/be1bc5a0585ee7a09ea6c80bbe39e931d14258f1))
-- **web-components:** destructive prop description change ([cf3b94c](https://github.com/mi6/ic-ui-kit/commit/cf3b94c57e970996658392bc6266e86e7e49e53d))
-- **web-components:** expose IcToolTip disableClick prop ([3be054f](https://github.com/mi6/ic-ui-kit/commit/3be054f19b663de7d391eb2ded26b48c27cf9a4f)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
-- **web-components:** fix double focus indicator on selected slotted side nav item when dark ([8b41b1f](https://github.com/mi6/ic-ui-kit/commit/8b41b1fab8b06e5c23b1f97aaefebc81e21b80ec))
-- **web-components:** fix incorrect footer link and top nav items slotted link colours ([3c512ef](https://github.com/mi6/ic-ui-kit/commit/3c512ef38d781063373084cfa0d71dc8761196a0)), closes [.#3234](https://github.com/./issues/3234)
-- **web-components:** fixed displaying readme docs on storybook ([0f7c35a](https://github.com/mi6/ic-ui-kit/commit/0f7c35aa5405bebce25de4fb6ed5aee02d1dd875))
-- **web-components:** fixed open in new icon colour on certain browsers ([182d7f8](https://github.com/mi6/ic-ui-kit/commit/182d7f800228609560836287760da3dcd565daab))
-- **web-components:** fixes back arrow not displaying ([fd54222](https://github.com/mi6/ic-ui-kit/commit/fd542229c5246986f28c00b93193bf724f84f7b5))
-- **web-components:** fixes card button focus color in high contrast mode ([9439a45](https://github.com/mi6/ic-ui-kit/commit/9439a45ea2bf0eb81556091760956f7558c13736))
-- **web-components:** ic-alert fix - height compensation in different themes ([860b235](https://github.com/mi6/ic-ui-kit/commit/860b235a11afca2862ffbbd19bdb35c040dab81c))
-- **web-components:** ic-popover-menu close sub menus fix ([2b94f58](https://github.com/mi6/ic-ui-kit/commit/2b94f58bbb600833da04cb7d0994355cfaf2ea78))
-- **web-components:** selected items with hover state are lined up correctly in nav group ([45d483a](https://github.com/mi6/ic-ui-kit/commit/45d483ab61641b1289ea96c61e30924c9089113f))
-- **web-components:** update checkbox so that it works correctly on rtl pages ([8911b4f](https://github.com/mi6/ic-ui-kit/commit/8911b4fcd759197991be1cbd22b948300d3a2b30))
-- **web-components:** update dialog to make interactive slotted children content focussable ([7fe73dc](https://github.com/mi6/ic-ui-kit/commit/7fe73dc8ffb67fe497bbee514fa73644743bfc77)), closes [.#2773](https://github.com/./issues/2773)
-- **web-components:** updating inner border of focused toggle button ([7dd59b2](https://github.com/mi6/ic-ui-kit/commit/7dd59b2e51688e9ce10a175bc1cfd8935e7f9ca9))
-
-### Features
-
-- **web-components:** update empty state to have theme prop ([216dbb6](https://github.com/mi6/ic-ui-kit/commit/216dbb677a572c2ed91453683a12b02daeb19ee3))
-
 # [3.0.0]
 
 ### Bug Fixes
@@ -196,65 +26,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** slotted content is focused when running .setFocus ([873865a](https://github.com/mi6/ic-ui-kit/commit/873865a42c456fb9a2ac912a8a365cda2b4624ac))
 - **web-components:** update breadcrumbs to prevent focus on slotted current page link ([5231ff4](https://github.com/mi6/ic-ui-kit/commit/5231ff44371a9e88be8bf3c16bcb985a3000bfb7))
 - **web-components:** update search and select clear icon css ([5d35619](https://github.com/mi6/ic-ui-kit/commit/5d3561902e8c6d894a8a3119c135bbac08cfaca0)), closes [#2923](https://github.com/mi6/ic-ui-kit/issues/2923)
-
-### Features
-
-- **web-components:** add tooltip placement prop to match ic-button ([e8abe7c](https://github.com/mi6/ic-ui-kit/commit/e8abe7c56f92faa0c5b853eeaa146e772213c3d7))
-- **web-components:** added ability to slot different elements into the additional-field slot ([1b1396f](https://github.com/mi6/ic-ui-kit/commit/1b1396fd32d2f8cf74de315631ac66783c10c1cb))
-- **web-components:** removed showState prop from ic-switch ([b2571cb](https://github.com/mi6/ic-ui-kit/commit/b2571cb2f268b7a503d4c9164bc5df937c4ddc7a))
-- **web-components:** update empty state to have theme prop ([15cc33d](https://github.com/mi6/ic-ui-kit/commit/15cc33dc498beb33d682e52b3432b7c6641b042d))
-
-### BREAKING CHANGES
-
-- **web-components:** removed showState prop
-- **web-components:** By default buttons in ic-alert will be in colour. Use monochrome prop to conform to designs
-
-### Bug Fixes
-
-- **web-components:** added color-scheme css prop to ic-theme-dark classes ([827e993](https://github.com/mi6/ic-ui-kit/commit/827e9933a8323ba2e11921b61e7727f601304c06))
-- **web-components:** bugfix ([7c73a6b](https://github.com/mi6/ic-ui-kit/commit/7c73a6b22cc1ce9cef8105b8770f29d68c989770))
-- **web-components:** bugfix: props passed correctly to child in group ([e4a4e41](https://github.com/mi6/ic-ui-kit/commit/e4a4e41178df8d6c150dba602bd86e16ee649cde))
-- **web-components:** dark mode ic-alert actions fix ([92594ab](https://github.com/mi6/ic-ui-kit/commit/92594ab7f0d9a25c691ec12ff7199aa3b56776dd))
-- **web-components:** fixes search bar focus issues on ic-dialog ([ea9009f](https://github.com/mi6/ic-ui-kit/commit/ea9009fa6b96f9428fc5046da878e36b070ecb2f))
-- **web-components:** loading checked in highcontrast displays high contrast colour ([ec69743](https://github.com/mi6/ic-ui-kit/commit/ec697430d4296a039b26b052bef5a02efe50f96e))
-- **web-components:** slotted content is focused when running .setFocus ([873865a](https://github.com/mi6/ic-ui-kit/commit/873865a42c456fb9a2ac912a8a365cda2b4624ac))
-- **web-components:** update breadcrumbs to prevent focus on slotted current page link ([5231ff4](https://github.com/mi6/ic-ui-kit/commit/5231ff44371a9e88be8bf3c16bcb985a3000bfb7))
-- **web-components:** update search and select clear icon css ([5d35619](https://github.com/mi6/ic-ui-kit/commit/5d3561902e8c6d894a8a3119c135bbac08cfaca0)), closes [#2923](https://github.com/mi6/ic-ui-kit/issues/2923)
-
-### Features
-
-- **web-components:** add tooltip placement prop to match ic-button ([e8abe7c](https://github.com/mi6/ic-ui-kit/commit/e8abe7c56f92faa0c5b853eeaa146e772213c3d7))
-- **web-components:** added ability to slot different elements into the additional-field slot ([1b1396f](https://github.com/mi6/ic-ui-kit/commit/1b1396fd32d2f8cf74de315631ac66783c10c1cb))
-- **web-components:** removed showState prop from ic-switch ([b2571cb](https://github.com/mi6/ic-ui-kit/commit/b2571cb2f268b7a503d4c9164bc5df937c4ddc7a))
-
-### BREAKING CHANGES
-
-- **web-components:** removed showState prop
-- **web-components:** By default buttons in ic-alert will be in colour. Use monochrome prop to conform to designs
-
-### Bug Fixes
-
-- **web-components:** bugfix ([7c73a6b](https://github.com/mi6/ic-ui-kit/commit/7c73a6b22cc1ce9cef8105b8770f29d68c989770))
-- **web-components:** bugfix: props passed correctly to child in group ([e4a4e41](https://github.com/mi6/ic-ui-kit/commit/e4a4e41178df8d6c150dba602bd86e16ee649cde))
 - **web-components:** change <a> in ic-footer-link to <ic-link> ([d4685eb](https://github.com/mi6/ic-ui-kit/commit/d4685eb6e6dd35e829a7af085f65f44bffddc266)), closes [#265](https://github.com/mi6/ic-ui-kit/issues/265)
-- **web-components:** fix issue with IC Radio to override horizontal ([f27bf1a](https://github.com/mi6/ic-ui-kit/commit/f27bf1a851c7c218cd8b04aafbe172b728dd87a1))
 - **web-components:** fix radio-group rebase issue ([ef600c2](https://github.com/mi6/ic-ui-kit/commit/ef600c23fefe68ddf338fd3099c5d66104e35491))
 - **web-components:** fixes icon only variant positioning ([fc79597](https://github.com/mi6/ic-ui-kit/commit/fc795973e412f5fc4b3b6afdddd160dada929a05))
-- **web-components:** make radio group set disabled state on children ([17ebcd0](https://github.com/mi6/ic-ui-kit/commit/17ebcd020ec2c0a230efe0752accc99b1afe3107))
 - **web-components:** restore isSlotUsed after rebase ([3b0b3de](https://github.com/mi6/ic-ui-kit/commit/3b0b3de6f36dfb213d0450e9703d4e908fc626c5))
 - **web-components:** restore slotted-svg styles in footer link ([9a018a1](https://github.com/mi6/ic-ui-kit/commit/9a018a16314401f06cc0477474670309dcb3916a))
 - **web-components:** set heading levels on Hero component ([e32a0ad](https://github.com/mi6/ic-ui-kit/commit/e32a0adcd046fc71e05631532e615278a0ce1826)), closes [#1687](https://github.com/mi6/ic-ui-kit/issues/1687)
 - **web-components:** update auto dismiss toast to turn manual when hovered over ([ed51065](https://github.com/mi6/ic-ui-kit/commit/ed51065ba9ef9a0c459d92c1f0db778fac0279f6)), closes [#1291](https://github.com/mi6/ic-ui-kit/issues/1291)
-- **web-components:** adds check for undefined element in typography ([e79d281](https://github.com/mi6/ic-ui-kit/commit/e79d2810c26330173bc25f6cc4172e993b44afda))
-- **web-components:** changed conditional for applying aria-role to ic-search-bar ([cbe4be8](https://github.com/mi6/ic-ui-kit/commit/cbe4be8b2af87c7cdd151012d8882d2f2aee373f))
 - **web-components:** fix icpopoverclosed event not emitting when closed via submenu ([87010e7](https://github.com/mi6/ic-ui-kit/commit/87010e73d20713f09d544f1f47f6e466f1b149d1)), closes [#2297](https://github.com/mi6/ic-ui-kit/issues/2297)
 - **web-components:** fixed not autoselecting first tab during dynamic render ([e2140eb](https://github.com/mi6/ic-ui-kit/commit/e2140ebf734f4b36eb76cffb71b0b45caa76171c))
-- **web-components:** fixes issue with showDefaultIcon in gatsby ([84719d9](https://github.com/mi6/ic-ui-kit/commit/84719d93de2255cf76cf1cfb0d820c499ff95193))
-- **web-components:** fixes tooltips wrapping onto multiple lines ([28321f7](https://github.com/mi6/ic-ui-kit/commit/28321f73610fbdbb57e93b982375403315a32ac8))
-- **web-components:** restore radio orientation overrides after rebase ([a29a4d7](https://github.com/mi6/ic-ui-kit/commit/a29a4d72d6b300ee391d8d460a324229b0f42c50))
-- **web-components:** update auto dismiss toast to turn manual when hovered over ([a12ab96](https://github.com/mi6/ic-ui-kit/commit/a12ab9651088fc750593c7b87a83b52a219b5d37)), closes [#1291](https://github.com/mi6/ic-ui-kit/issues/1291)
-- **web-components:** update toast animation to only work when prefers reduced motion is off ([e99ffa8](https://github.com/mi6/ic-ui-kit/commit/e99ffa833842e6f798c202271f88fbcd24a0a162)), closes [#1926](https://github.com/mi6/ic-ui-kit/issues/1926)
-- **react:** add relevant storybook component to demostrate the onClick event ([f884e02](https://github.com/mi6/ic-ui-kit/commit/f884e02e1395c582391360d8c35b17612367bd92))
 - **web-components:** added styling to loading indicator ([e4bf5b5](https://github.com/mi6/ic-ui-kit/commit/e4bf5b506b2a0bb0da503a88ff348f542af583af))
 - **web-components:** added useLabelTag Prop ([4202f50](https://github.com/mi6/ic-ui-kit/commit/4202f50b61ce2876a48153a6af8216b927afe0ce))
 - **web-components:** adds check for undefined element in typography ([e79d281](https://github.com/mi6/ic-ui-kit/commit/e79d2810c26330173bc25f6cc4172e993b44afda))
@@ -288,13 +68,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** update icpopoverclosed event to include relevant information ([c134f2b](https://github.com/mi6/ic-ui-kit/commit/c134f2b53c7581f73a8a30c3e615c01299cf1090)), closes [#2665](https://github.com/mi6/ic-ui-kit/issues/2665)
 - **web-components:** update top nav tokens to be the same in light and dark mode ([168a7ad](https://github.com/mi6/ic-ui-kit/commit/168a7ad9a3b1b94895abff7ac6132a2ae5f7fc50))
 - **web-components:** updated ic-card border color to correct dark mode patterns ([dac04e3](https://github.com/mi6/ic-ui-kit/commit/dac04e3036fe00cab9fb6c1b20a5870237f22a7b))
-- **web-components:** add dependencies on react types to fix a build problem ([be4d353](https://github.com/mi6/ic-ui-kit/commit/be4d353a5b99b93402f2cc117ee63294834d1d63))
-- **web-components:** additional field fix ([d41761e](https://github.com/mi6/ic-ui-kit/commit/d41761ed6acddad90a7c2ca0b5ca1410c2812136))
-- **web-components:** fix for items displayed on brand color background ([a7bff90](https://github.com/mi6/ic-ui-kit/commit/a7bff90357fc8bd5cd1f2c700281b84a073659b4))
-- **web-components:** fix monochrome button css issue, and update stories to have dark background ([8931cf7](https://github.com/mi6/ic-ui-kit/commit/8931cf7f52285e0cc72d74a09df9d151268fc85e))
-- **web-components:** ic-text-field bug ([6ac9480](https://github.com/mi6/ic-ui-kit/commit/6ac9480c28ac4ecf7012df09b647f539a1fbfa02))
-- **web-components:** removed disabled attribute from components when set to false ([e37af84](https://github.com/mi6/ic-ui-kit/commit/e37af84bd6ec5739b69860c180dc0017de702368))
-- **web-components:** update icon colours for dark mode badge ([2ca3b77](https://github.com/mi6/ic-ui-kit/commit/2ca3b775c977f197f953f4c7e806b5572af68ca9)), closes [#2910](https://github.com/mi6/ic-ui-kit/issues/2910)
 - **web-components:** add css for search toggle icon in top nav so it appears in hcm ([b354d1a](https://github.com/mi6/ic-ui-kit/commit/b354d1a67c5cc11b6d0ca910c7f58810f6cc515c))
 - **web-components:** add dependencies on react types to fix a build problem ([be4d353](https://github.com/mi6/ic-ui-kit/commit/be4d353a5b99b93402f2cc117ee63294834d1d63))
 - **web-components:** additional field fix ([d41761e](https://github.com/mi6/ic-ui-kit/commit/d41761ed6acddad90a7c2ca0b5ca1410c2812136))
@@ -310,14 +83,51 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** update icon colours for dark mode badge ([2ca3b77](https://github.com/mi6/ic-ui-kit/commit/2ca3b775c977f197f953f4c7e806b5572af68ca9)), closes [#2910](https://github.com/mi6/ic-ui-kit/issues/2910)
 - **web-components:** updated menu.css disabled option colour for high contrast mode ([9cba277](https://github.com/mi6/ic-ui-kit/commit/9cba2778563645e77a1922545edb99d4003fc41c))
 - **web-components:** updates css tokens in ag-theme-icds so that it responds to light/dark mode ([e0244a0](https://github.com/mi6/ic-ui-kit/commit/e0244a049bff83e27d58f792296cc8b73e8a1f14))
-
-### Documentation
-
-- **docs:** docs update ([aa0f1d7](https://github.com/mi6/ic-ui-kit/commit/aa0f1d7620d3806ae9725fc488c97aac9e044d97))
-- **docs:** docs update ([aa0f1d7](https://github.com/mi6/ic-ui-kit/commit/aa0f1d7620d3806ae9725fc488c97aac9e044d97))
+- **web-components:** add check for selectedOption to prevent undefined error in radio group ([1e81c59](https://github.com/mi6/ic-ui-kit/commit/1e81c59793e00a6d5f0bfd970369d2865aed14d8))
+- **web-components:** add focus indicator, hover state and pressed state to footer logo links ([eb3fbfa](https://github.com/mi6/ic-ui-kit/commit/eb3fbfa2008162b137774b7ee4e5247adc81a66d))
+- **web-components:** add scrollbar to content area on dialog to make it easier to scroll ([fa869cf](https://github.com/mi6/ic-ui-kit/commit/fa869cf8cc67da2425b3abfb456a6a5242a55478)), closes [#2868](https://github.com/mi6/ic-ui-kit/issues/2868)
+- **web-components:** adding description to ic-loading-indicator of auto-dismiss toast ([52fa5a4](https://github.com/mi6/ic-ui-kit/commit/52fa5a47a2471bd5c3006b7a4c11281fb4a042ea))
+- **web-components:** auto-dismiss toasts now read aloud to screenreaders ([3450955](https://github.com/mi6/ic-ui-kit/commit/345095549cd280a22eaddcf4b07caf259c090a32))
+- **web-components:** changes to ic-badge and ic-navigation-button to show notifications in mobile ([be1bc5a](https://github.com/mi6/ic-ui-kit/commit/be1bc5a0585ee7a09ea6c80bbe39e931d14258f1))
+- **web-components:** destructive prop description change ([cf3b94c](https://github.com/mi6/ic-ui-kit/commit/cf3b94c57e970996658392bc6266e86e7e49e53d))
+- **web-components:** expose IcToolTip disableClick prop ([3be054f](https://github.com/mi6/ic-ui-kit/commit/3be054f19b663de7d391eb2ded26b48c27cf9a4f)), closes [#3129](https://github.com/mi6/ic-ui-kit/issues/3129)
+- **web-components:** fix double focus indicator on selected slotted side nav item when dark ([8b41b1f](https://github.com/mi6/ic-ui-kit/commit/8b41b1fab8b06e5c23b1f97aaefebc81e21b80ec))
+- **web-components:** fix incorrect footer link and top nav items slotted link colours ([3c512ef](https://github.com/mi6/ic-ui-kit/commit/3c512ef38d781063373084cfa0d71dc8761196a0)), closes [#3234](https://github.com/mi6/ic-ui-kit/issues/3234)
+- **web-components:** fixed displaying readme docs on storybook ([0f7c35a](https://github.com/mi6/ic-ui-kit/commit/0f7c35aa5405bebce25de4fb6ed5aee02d1dd875))
+- **web-components:** fixed open in new icon colour on certain browsers ([182d7f8](https://github.com/mi6/ic-ui-kit/commit/182d7f800228609560836287760da3dcd565daab))
+- **web-components:** fixes back arrow not displaying ([fd54222](https://github.com/mi6/ic-ui-kit/commit/fd542229c5246986f28c00b93193bf724f84f7b5))
+- **web-components:** fixes card button focus color in high contrast mode ([9439a45](https://github.com/mi6/ic-ui-kit/commit/9439a45ea2bf0eb81556091760956f7558c13736))
+- **web-components:** ic-alert fix - height compensation in different themes ([860b235](https://github.com/mi6/ic-ui-kit/commit/860b235a11afca2862ffbbd19bdb35c040dab81c))
+- **web-components:** ic-popover-menu close sub menus fix ([2b94f58](https://github.com/mi6/ic-ui-kit/commit/2b94f58bbb600833da04cb7d0994355cfaf2ea78))
+- **web-components:** selected items with hover state are lined up correctly in nav group ([45d483a](https://github.com/mi6/ic-ui-kit/commit/45d483ab61641b1289ea96c61e30924c9089113f))
+- **web-components:** update checkbox so that it works correctly on rtl pages ([8911b4f](https://github.com/mi6/ic-ui-kit/commit/8911b4fcd759197991be1cbd22b948300d3a2b30))
+- **web-components:** update dialog to make interactive slotted children content focussable ([7fe73dc](https://github.com/mi6/ic-ui-kit/commit/7fe73dc8ffb67fe497bbee514fa73644743bfc77)), closes [#2773](https://github.com/mi6/ic-ui-kit/issues/2773)
+- **web-components:** updating inner border of focused toggle button ([7dd59b2](https://github.com/mi6/ic-ui-kit/commit/7dd59b2e51688e9ce10a175bc1cfd8935e7f9ca9))
+- **web-components:** fixes focus in high contrst mode ([b9098d7](https://github.com/mi6/ic-ui-kit/commit/b9098d7849e2fa41d0e5f856434f6b310e0d2480))
+- **web-components:** render only one collapsed breadcrumb when window is resized ([ea25f2d](https://github.com/mi6/ic-ui-kit/commit/ea25f2de5a1c11c8bd79c52130343afd641007fe))
+- **web-components:** updated tree-view selected colour mode values ([8fca7d4](https://github.com/mi6/ic-ui-kit/commit/8fca7d4c8a9013bbc3691b2d20aa4f2074898f99))
+- **web-components:** [ic-button] remove 1px top and bottom margin from icon variant ([7d78fb0](https://github.com/mi6/ic-ui-kit/commit/7d78fb0d1f2ebc90c101297655f5735cbbe34b3b))
+- **web-components:** fix circular loading indicator showing as complete circle ([dbcf528](https://github.com/mi6/ic-ui-kit/commit/dbcf5281b721e23b6a98d87f4851726149c23b33))
+- **web-components:** fixed the height of readonly select ([6d30df9](https://github.com/mi6/ic-ui-kit/commit/6d30df93b0e9d6dd0ddc840b2521575f4af82d91))
+- **web-components:** fixes focus issues with interactive components on dialog ([b3d40f8](https://github.com/mi6/ic-ui-kit/commit/b3d40f80128348a7155d41f1016e16e6664d6a63))
+- **web-components:** ic-select no longer allows values that aren't in options ([b1ba8a7](https://github.com/mi6/ic-ui-kit/commit/b1ba8a7302474d4533f28717f65d00998a1ea8b2))
+- **web-components:** remove shadow from side navigation ([06d31d5](https://github.com/mi6/ic-ui-kit/commit/06d31d512c6a4e7ecfb9507cd4c9f97934537fa0)), closes [#2624](https://github.com/mi6/ic-ui-kit/issues/2624)
+- **web-components:** update hero to use --ic-hero-background token ([8c4fc68](https://github.com/mi6/ic-ui-kit/commit/8c4fc687a01c16b7fcdd695f3ccf99c041935008)), closes [#3369](https://github.com/mi6/ic-ui-kit/issues/3369)
+- **web-components:** update navigation group so that two nav groups can't be open simultaneously ([3b61e98](https://github.com/mi6/ic-ui-kit/commit/3b61e98c79846f074213620db0fe38fbf8c2fd53)), closes [#3117](https://github.com/mi6/ic-ui-kit/issues/3117)
+- **web-components:** added updated status colour tokens + dt token ([d15248f](https://github.com/mi6/ic-ui-kit/commit/d15248fa4928ddb99e73dfb640c9b38071154560))
+- **web-components:** fix issue with items in last top nav group not receiving focus ([2634fa8](https://github.com/mi6/ic-ui-kit/commit/2634fa86b97e174920e8e9e3344f2450f4df45c0)), closes [#3261](https://github.com/mi6/ic-ui-kit/issues/3261)
+- **web-components:** set the focus in the icpopovermenu when the open prop has been provided ([84324bc](https://github.com/mi6/ic-ui-kit/commit/84324bcbcc7cdd311cc28f63c92a2c3a44729224))
+- **web-components:** update button to display icons/badges when router item slot is used ([c62c414](https://github.com/mi6/ic-ui-kit/commit/c62c414a7d15435b50f4c384b3bace480ec6a45d)), closes [#1814](https://github.com/mi6/ic-ui-kit/issues/1814)
+- **web-components:** update select to not display clear button when disabled ([a74bae2](https://github.com/mi6/ic-ui-kit/commit/a74bae201ca21d25677e21d5d8b58f4f024a422f)), closes [#2322](https://github.com/mi6/ic-ui-kit/issues/2322)
+- **web-components:** update side nav to append badge to iconWrapper when slotted nav item used ([e2c79c9](https://github.com/mi6/ic-ui-kit/commit/e2c79c9cda05f28e43ca988f8bafe2d402faa5d6)), closes [#1701](https://github.com/mi6/ic-ui-kit/issues/1701)
+- **web-components:** update to ic-stepper colours to match figma designs ([7bb760d](https://github.com/mi6/ic-ui-kit/commit/7bb760dd454dc8b5428c8b6d811a21d9c267cfdf))
 
 ### Features
 
+- **web-components:** add tooltip placement prop to match ic-button ([e8abe7c](https://github.com/mi6/ic-ui-kit/commit/e8abe7c56f92faa0c5b853eeaa146e772213c3d7))
+- **web-components:** added ability to slot different elements into the additional-field slot ([1b1396f](https://github.com/mi6/ic-ui-kit/commit/1b1396fd32d2f8cf74de315631ac66783c10c1cb))
+- **web-components:** removed showState prop from ic-switch ([b2571cb](https://github.com/mi6/ic-ui-kit/commit/b2571cb2f268b7a503d4c9164bc5df937c4ddc7a))
+- **web-components:** update empty state to have theme prop ([15cc33d](https://github.com/mi6/ic-ui-kit/commit/15cc33dc498beb33d682e52b3432b7c6641b042d))
 - **web-components:** added mutationObserver to ic-footer ([1149408](https://github.com/mi6/ic-ui-kit/commit/1149408accf695d738a1cecb3875f20aa211c7f2))
 - **web-components:** adding data table loading background css property ([10179dc](https://github.com/mi6/ic-ui-kit/commit/10179dc3bdc25873ff256b937f3d00de578742b4))
 - **web-components:** adding icClear event to clear all button of multi-select ([56aa544](https://github.com/mi6/ic-ui-kit/commit/56aa544782be3b2e5610aeb973fc45489c5962eb))
@@ -326,17 +136,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** Fix/able to select no options when select has empty options array ([cccf3fe](https://github.com/mi6/ic-ui-kit/commit/cccf3febc0edfa65474bda6ce08b2e8f8c895a6d))
 - **web-components:** update searchable select to clear input on blur (when no option selected) ([db89c54](https://github.com/mi6/ic-ui-kit/commit/db89c54b80b8dd38823fe8cc36762cc25a7e5833))
 - **web-components:** update searchable select to de-select option when input edited ([d0513cf](https://github.com/mi6/ic-ui-kit/commit/d0513cf6fc29a1ec3387a9c58bdc1df661cc7fe6))
-- **web-components:** add aria-live region to announce current page on complex pagination ([4e47541](https://github.com/mi6/ic-ui-kit/commit/4e47541f652a560101ce4e2cbea24439de8ffe14))
-- **web-components:** add truncation styling for chip and typography when in an AG Grid ([d913a96](https://github.com/mi6/ic-ui-kit/commit/d913a964b6eeb01f97bb43b5a5756f2e530a6296))
 - **web-components:** changed ic-radio-option to not be shadow ([fa9725a](https://github.com/mi6/ic-ui-kit/commit/fa9725a16426b3d8ba05dc7a21adbac19c4f4aee))
 - **web-components:** improve component prop names ([79f4e6b](https://github.com/mi6/ic-ui-kit/commit/79f4e6bfaaf25e15254d1312bb073479a225bd0d)), closes [#662](https://github.com/mi6/ic-ui-kit/issues/662)
 - **web-components:** initial ic-theme changes for dark mode support ([0678c89](https://github.com/mi6/ic-ui-kit/commit/0678c89660232f0af26ea29fcbc01651d4cc7838))
 - **web-components:** remove deprecated props/slots/events/methods ([2e70f03](https://github.com/mi6/ic-ui-kit/commit/2e70f03a359974ead104e8afe238d6681dda5875)), closes [#230](https://github.com/mi6/ic-ui-kit/issues/230)
-- **web-components:** remove maxLength from text field, use maxCharacters instead, add hideCharCount ([172d139](https://github.com/mi6/ic-ui-kit/commit/172d139ebfbc3be09f968875656f901d3a9ce30f)), closes [.#1064](https://github.com/./issues/1064)
+- **web-components:** remove maxLength from text field, use maxCharacters instead, add hideCharCount ([172d139](https://github.com/mi6/ic-ui-kit/commit/172d139ebfbc3be09f968875656f901d3a9ce30f)), closes [#1064](https://github.com/mi6/ic-ui-kit/issues/1064)
 - **web-components:** removed deprecated colour tokens ([4bfa1e7](https://github.com/mi6/ic-ui-kit/commit/4bfa1e7dd7e1d8bc6e17ae13515cc766be382a1b))
 - **web-components:** removed hidden input from ic-radio-group ([ae09214](https://github.com/mi6/ic-ui-kit/commit/ae092144a7f07c8d6ee9b0287570672265550fbc))
-- **web-components:** update sideNavExpanded and topNavResized event names to have "ic" prefix ([14dd746](https://github.com/mi6/ic-ui-kit/commit/14dd7467f79baa77d20c043f916aebe0d182ed99)), closes [.#1354](https://github.com/./issues/1354)
-- **web-components:** updated ic-typography and ic-tooltip ([a545108](https://github.com/mi6/ic-ui-kit/commit/a545108de5fada884f6023d2e9507ee26ddb0d47))
+- **web-components:** update sideNavExpanded and topNavResized event names to have "ic" prefix ([14dd746](https://github.com/mi6/ic-ui-kit/commit/14dd7467f79baa77d20c043f916aebe0d182ed99)), closes [#1354](https://github.com/mi6/ic-ui-kit/issues/1354)
 - **web-components:** add maxLengthMessage prop to text field ([6d656ce](https://github.com/mi6/ic-ui-kit/commit/6d656ce70533cab7f283250d21c4443c09c09ac7)), closes [#2248](https://github.com/mi6/ic-ui-kit/issues/2248)
 - **web-components:** add showDefaultIcon prop and neutral-icon slot to alert ([cb8c2ea](https://github.com/mi6/ic-ui-kit/commit/cb8c2ea2d0a43d6027708790299981584e03b8d7))
 - **web-components:** adds ic-tooltip theme styling ([2566d0c](https://github.com/mi6/ic-ui-kit/commit/2566d0cea6e219dc8bd0c07fba939111cbcbb0cd))
@@ -353,16 +160,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** replaced appearance with theme prop on ic-skeleton ([b9e269f](https://github.com/mi6/ic-ui-kit/commit/b9e269f66833082e1e716e2c6bb2a7563e1e3200))
 - **web-components:** update stepper to use theme prop instead of appearance ([2164c9d](https://github.com/mi6/ic-ui-kit/commit/2164c9d99f6d687ccbb85cc7f806dc4cd7cf2be2))
 - **web-components:** add atoms css tokens to colors.css and color-mode.css ([3d7e6d8](https://github.com/mi6/ic-ui-kit/commit/3d7e6d84b215992e509dc36d5993c26fd3ced84e))
-- **web-components:** add global primitive and semantic CSS tokens to allow for use in dark mode ([d07633c](https://github.com/mi6/ic-ui-kit/commit/d07633c3535bd78f7ec9b7309d5cfe1712239a63)), closes [#2466](https://github.com/mi6/ic-ui-kit/issues/2466) [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
 - **web-components:** add multi-select functionality (moved from canary) ([cea50ef](https://github.com/mi6/ic-ui-kit/commit/cea50ef69f35ed27fd3bd4e668f006d3ac5280e3)), closes [#1966](https://github.com/mi6/ic-ui-kit/issues/1966) [#1652](https://github.com/mi6/ic-ui-kit/issues/1652) [#1658](https://github.com/mi6/ic-ui-kit/issues/1658) [#1816](https://github.com/mi6/ic-ui-kit/issues/1816) [#1917](https://github.com/mi6/ic-ui-kit/issues/1917) [#1767](https://github.com/mi6/ic-ui-kit/issues/1767) [#2071](https://github.com/mi6/ic-ui-kit/issues/2071)
 - **web-components:** add theme prop to switch to enable light and dark mode ([829c187](https://github.com/mi6/ic-ui-kit/commit/829c187f810d2ecbe1292bcf53e9236967979fc3))
 - **web-components:** added hidelabel to remove label specifically ([13f77d1](https://github.com/mi6/ic-ui-kit/commit/13f77d198927a8fff303f6cce8707e6c8395dd15)), closes [#1813](https://github.com/mi6/ic-ui-kit/issues/1813)
-- **web-components:** added theme and monochrome prop to ic-loading-indicator ([46868f2](https://github.com/mi6/ic-ui-kit/commit/46868f231e8927d97ce956a21bb3eeb69f1cf79d))
-- **web-components:** adds theme prop to ic-chip ([16bae57](https://github.com/mi6/ic-ui-kit/commit/16bae57c59ee2b5c4df8d9cbe8017a1e46e7e3bb))
 - **web-components:** dark mode popover ([09a636b](https://github.com/mi6/ic-ui-kit/commit/09a636b1f973c940763e89eee0fc7b5d35f9fc73))
-- **web-components:** replaced appearance with theme prop on ic-skeleton ([b9e269f](https://github.com/mi6/ic-ui-kit/commit/b9e269f66833082e1e716e2c6bb2a7563e1e3200))
-- **web-components:** update stepper to use theme prop instead of appearance ([2164c9d](https://github.com/mi6/ic-ui-kit/commit/2164c9d99f6d687ccbb85cc7f806dc4cd7cf2be2))
-- **react:** implement theme prop on dialog ([3c4edf0](https://github.com/mi6/ic-ui-kit/commit/3c4edf0fb5e4e1bb4bce6ae4b6eae16939c888ae))
+- **web-components:** implement theme prop on dialog ([3c4edf0](https://github.com/mi6/ic-ui-kit/commit/3c4edf0fb5e4e1bb4bce6ae4b6eae16939c888ae))
 - **web-components:** add additional functionality to existing ic-divider component ([d71bb97](https://github.com/mi6/ic-ui-kit/commit/d71bb97e00fd3c129f26c2a1e64a1b185fcd33ec)), closes [#1331](https://github.com/mi6/ic-ui-kit/issues/1331) [#1214](https://github.com/mi6/ic-ui-kit/issues/1214)
 - **web-components:** add theme prop to accordion component ([bd505d0](https://github.com/mi6/ic-ui-kit/commit/bd505d0c5e1bfe08198eb7e1ec55e573003b1e22))
 - **web-components:** add theme prop to radio group/radio option ([6ab3a0b](https://github.com/mi6/ic-ui-kit/commit/6ab3a0bb116c8a91b3b458cb6d663f75fd97d1cc))
@@ -391,9 +193,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** implement theme prop on top navigation ([880b1a9](https://github.com/mi6/ic-ui-kit/commit/880b1a9700a3ed66045f692f0f3024c52ac21a7f))
 - **web-components:** update searchable prop on select component ([0408d46](https://github.com/mi6/ic-ui-kit/commit/0408d46ce250b645cda693e6ae49506c8e90acfc))
 - **web-components:** update toggle button and toggle button group to have theme prop ([48d9e01](https://github.com/mi6/ic-ui-kit/commit/48d9e0183c86c6698fd08fdecc4e077f9cdfb252))
-- **web-components:** changes to ic-theme ([e8149bb](https://github.com/mi6/ic-ui-kit/commit/e8149bb48692538632e886f0ffd4b00308ac0b33))
-- **web-components:** dismiss label ([42618b2](https://github.com/mi6/ic-ui-kit/commit/42618b2f651b9dfa7257ebed5521492bdfb07ca7))
-- **web-components:** Fix/able to select no options when select has empty options array ([cccf3fe](https://github.com/mi6/ic-ui-kit/commit/cccf3febc0edfa65474bda6ce08b2e8f8c895a6d))
+- **web-components:** update empty state to have theme prop ([216dbb6](https://github.com/mi6/ic-ui-kit/commit/216dbb677a572c2ed91453683a12b02daeb19ee3))
+- **web-components:** CSS props for x and y positions exposed on ic-back-to-top ([2ce1d92](https://github.com/mi6/ic-ui-kit/commit/2ce1d9277e3781376bae41ba1ec3eb44e9228b9b))
+- **web-components:** icBackToTop 'position' prop added ([be9c00c](https://github.com/mi6/ic-ui-kit/commit/be9c00c864c652fcc6fdb7244893dd14f81957d5))
+- **web-components:** icBackToTop 'position' prop added ([a685b62](https://github.com/mi6/ic-ui-kit/commit/a685b628449df9d2c8ae0a4130f1550da1b2a2e1))
+- **web-components:** styling for RTL characters in ic-radio-option ([18e453d](https://github.com/mi6/ic-ui-kit/commit/18e453d40094b9fd37d5331ef6fb1742067204a4))
+- **web-components:** added ic-skip-link component ([2e321df](https://github.com/mi6/ic-ui-kit/commit/2e321df4132caf24b05ce986130771e182830b80))
+- **web-components:** enable TypeScript strict mode (core web comps) and add last required changes ([cd77717](https://github.com/mi6/ic-ui-kit/commit/cd7771797665a29a53e60a9d469094f3da700e70)), closes [#266](https://github.com/mi6/ic-ui-kit/issues/266)
+- **web-components:** make changes to first half of web-components files to resolve strict mode errors ([53690d1](https://github.com/mi6/ic-ui-kit/commit/53690d188b8559b7e3820d0cb9601fc549a24bee)), closes [#266](https://github.com/mi6/ic-ui-kit/issues/266)
+- **web-components:** update second half of web-components files to resolve strict mode errors ([b939971](https://github.com/mi6/ic-ui-kit/commit/b9399713cc98798fcca669db083869b134f82ca1)), closes [#266](https://github.com/mi6/ic-ui-kit/issues/266) [#3349](https://github.com/mi6/ic-ui-kit/issues/3349)
+- **web-components:** add styling for inline variant of skip link and prefix target with hashtag ([621993b](https://github.com/mi6/ic-ui-kit/commit/621993bda0a566e52b31686db09c913bb45821be))
 
 ### Performance Improvements
 
@@ -428,18 +237,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### BREAKING CHANGES
 
 - **web-components:** dark mode
-- **web-components:** removed ic-text-field element so tests may break
+- **web-components:** removed ic-text-field element from ic-search-bar so tests may break
 - **web-components:** The icChange event on the searchable select now emits only option values or 'null'
   to match how editing input de-selects the selected option. IcInput can be used to detect which
   characters are inputted - the 'debounce' prop now applies to this instead of icChange.
-- **docs:** prop rename to more closely align with native html attribute
-- **web-components:** color prop renamed to brandColor
+- **web-components:** prop rename to more closely align with native html attribute
+- **web-components:** IcTheme component color prop renamed to brandColor
   icThemeChange event renamed to icBrandChange
   changes to types:
-  IcThemeForegroundEnum now IcBrandForegroundEnum
-  IcThemeForeground now IcBrandForeground
-  IcThemeForegroundNoDefault now IcBrandForegroundNoDefault
-  IcTheme now IcBrand
+   - IcThemeForegroundEnum now IcBrandForegroundEnum
+   - IcThemeForeground now IcBrandForeground
+   - IcThemeForegroundNoDefault now IcBrandForegroundNoDefault
+   - IcTheme now IcBrand
 - **web-components:** disabled class renamed to ic-radio-option-disabled
 - **web-components:** Change <a> in ic-footer-link to <ic-link>
 - **web-components:** ic-card is now named ic-card-vertical
@@ -448,7 +257,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** Behaviour change to auto dismiss toasts to show dismiss button when toast is hovered
   over or focussed. May cause test breakages.
 - **web-components:** Deprecated props/slots/events/methods have been removed entirely.
-- **web-components:** component now uses an ic-button under the covers, so testing may be affected by
+- **web-components:** ic-back-to-top component now uses an ic-button under the covers, so testing may be affected by
   change in structure
 - **web-components:** Heading heirarchy of ic-hero has changed, which might affect accessibility
   compliance when integrated. Removed deprecated 'small' prop from ic-hero
@@ -494,6 +303,48 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **web-components:** tooltip wrapping change that may affect visual regression snapshots
 - **web-components:** Rename some of the existing CSS tokens following the move towards primitive, semantic and component tokens
 - **web-components:** prop rename from auto-focus to autofocus, more closely aligning with native html attribute
+- **web-components:** removed showState prop from IcSwitch
+- **web-components:** By default buttons in ic-alert will be in colour. Use monochrome prop to conform to designs
+- **web-components:** Can no longer populate a select with a value not included in the array
+
+## [2.37.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@2.37.0...@ukic/web-components@2.37.2) (2025-04-16)
+
+### Bug Fixes
+
+- **web-components:** correct formatting of OFFSEN in classification banner ([d5afb8f](https://github.com/mi6/ic-ui-kit/commit/d5afb8f634bc3fe5508e994cf93b436e195b6c70))
+- **web-components:** fix ic-page-header nav element aria label ([fd6ae26](https://github.com/mi6/ic-ui-kit/commit/fd6ae269b577224fd473279dbc537de4a5f3dbc1))
+- **web-components:** set the focus in the icpopovermenu when the open prop has been provided ([502e2b2](https://github.com/mi6/ic-ui-kit/commit/502e2b265699970b07014f04c1c97c82325849b4))
+- **web-components:** update navigation group so that two nav groups can't be open simultaneously ([7ab8b85](https://github.com/mi6/ic-ui-kit/commit/7ab8b85866ca5ad628fe3bf2bdc011f000facd8e)), closes [#3117](https://github.com/mi6/ic-ui-kit/issues/3117)
+
+## [2.37.1](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@2.37.0...@ukic/web-components@2.37.1) (2025-04-07)
+
+### Bug Fixes
+
+- **web-components:** update navigation group so that two nav groups can't be open simultaneously ([c89bafe](https://github.com/mi6/ic-ui-kit/commit/c89bafe6f1a39e662639ad2a393a19d507893dd7)), closes [#3117](https://github.com/mi6/ic-ui-kit/issues/3117)
+
+# [2.37.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@2.36.0...@ukic/web-components@2.37.0) (2025-03-19)
+
+### Features
+
+- **web-components:** styling for RTL characters in ic-radio-option ([818910f](https://github.com/mi6/ic-ui-kit/commit/818910f4d4024135949a2698ea567a4342851cc9))
+
+# [2.36.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@2.35.2...@ukic/web-components@2.36.0) (2025-03-05)
+
+### Bug Fixes
+
+- **web-components:** add check for selectedOption to prevent undefined error in radio group ([b44826e](https://github.com/mi6/ic-ui-kit/commit/b44826e6d49dcc219e2d700521b29876363944ad))
+- **web-components:** add scrollbar to content area on dialog to make it easier to scroll ([6e46379](https://github.com/mi6/ic-ui-kit/commit/6e46379d9679a3d32295c30d651afab93da21614)), closes [.#2868](https://github.com/./issues/2868)
+- **web-components:** added more accurate check for ids ([89ab8ec](https://github.com/mi6/ic-ui-kit/commit/89ab8ec4b9379401de132f4047bf208fa19bd5f9))
+- **web-components:** fixed displaying readme docs on storybook ([8ea1325](https://github.com/mi6/ic-ui-kit/commit/8ea1325322d036188ab521eddd095a63573972d1))
+- **web-components:** fixed icon colour on ic-link ([0ced098](https://github.com/mi6/ic-ui-kit/commit/0ced0983efb6822992b54465998e809b156e0c85))
+- **web-components:** fixes card button focus color in high contrast mode ([43e8693](https://github.com/mi6/ic-ui-kit/commit/43e8693b1b8eb0206a9ed26b7ed7ed623edfe9b0))
+- **web-components:** fixes issue with long options label in ic-select ([69af4cc](https://github.com/mi6/ic-ui-kit/commit/69af4ccb95976767ba173d93b350d189678d1a04))
+- **web-components:** update checkbox so that it works correctly on rtl pages ([527889a](https://github.com/mi6/ic-ui-kit/commit/527889af06fe6bd876349b3bebd3b9247f0f112b))
+- **web-components:** update dialog to make interactive slotted children content focussable ([6a7925a](https://github.com/mi6/ic-ui-kit/commit/6a7925aa531518bfbeaef8b5e5360e070125bd23)), closes [.#2773](https://github.com/./issues/2773)
+
+### Features
+
+- **web-components:** v2 web-comps release bump ([036b36e](https://github.com/mi6/ic-ui-kit/commit/036b36ea1a13cdc268eab486a8ac62fa3489d482))
 
 ## [2.35.2](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@2.35.1...@ukic/web-components@2.35.2) (2025-02-19)
 
@@ -715,9 +566,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **web-components:** add loading indicator props playground ([8e2cf2d](https://github.com/mi6/ic-ui-kit/commit/8e2cf2d9f804214016a8eff581c262a0137d9a12)), closes [.#1970](https://github.com/./issues/1970)
+- **web-components:** add loading indicator props playground ([8e2cf2d](https://github.com/mi6/ic-ui-kit/commit/8e2cf2d9f804214016a8eff581c262a0137d9a12)), closes [#1970](https://github.com/mi6/ic-ui-kit/issues/1970)
 - **web-components:** implements native indeterminate checkbox behaviour ([950d879](https://github.com/mi6/ic-ui-kit/commit/950d879a64595a4d1741389737a54e10bb7cecc1))
-- **web-components:** update select playground argType ([c36c63c](https://github.com/mi6/ic-ui-kit/commit/c36c63c44361bced1725f26a617e37a1d4e07790)), closes [.#1970](https://github.com/./issues/1970)
+- **web-components:** update select playground argType ([c36c63c](https://github.com/mi6/ic-ui-kit/commit/c36c63c44361bced1725f26a617e37a1d4e07790)), closes [#1970](https://github.com/mi6/ic-ui-kit/issues/1970)
 
 # [2.22.0](https://github.com/mi6/ic-ui-kit/compare/@ukic/web-components@2.21.0...@ukic/web-components@2.22.0) (2024-06-12)
 
@@ -761,7 +612,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **web-components:** add max-content to ic-tooltip to make size match child element ([3196b47](https://github.com/mi6/ic-ui-kit/commit/3196b4784af7733fe9c270f161817222b5592a31)), closes [.#1815](https://github.com/./issues/1815)
+- **web-components:** add max-content to ic-tooltip to make size match child element ([3196b47](https://github.com/mi6/ic-ui-kit/commit/3196b4784af7733fe9c270f161817222b5592a31)), closes [#1815](https://github.com/mi6/ic-ui-kit/issues/1815)
 - **web-components:** added watch handlers for accessibleLabel, customColor & variant ([9b3b674](https://github.com/mi6/ic-ui-kit/commit/9b3b674731b076311791329f16d4e1400d9d8950))
 - **web-components:** adjust focus underline display for Link ([7a89112](https://github.com/mi6/ic-ui-kit/commit/7a891129989d10be8ca550a998637ba5af758eb4))
 - **web-components:** changed chip disabled text colour ([f58d1f4](https://github.com/mi6/ic-ui-kit/commit/f58d1f445c3e3030092fd2b9c630e2fc40b1d84a))
@@ -810,7 +661,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **web-components:** adjust badge screen reader behaviour ([784a8aa](https://github.com/mi6/ic-ui-kit/commit/784a8aa24af45b91606679a524428780ed526612)), closes [.#1391](https://github.com/./issues/1391)
+- **web-components:** adjust badge screen reader behaviour ([784a8aa](https://github.com/mi6/ic-ui-kit/commit/784a8aa24af45b91606679a524428780ed526612)), closes [#1391](https://github.com/mi6/ic-ui-kit/issues/1391)
 - **web-components:** ic-dialog ([e108710](https://github.com/mi6/ic-ui-kit/commit/e1087102c8e79eccbb562088f1f8b651eace4395))
 
 ### Features
@@ -854,12 +705,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 - **web-components:** add accessible title prop to accordion group to improve accessibility ([6857755](https://github.com/mi6/ic-ui-kit/commit/6857755a3e5858200f8cbd74825026be2e0f3f61)), closes [#1488](https://github.com/mi6/ic-ui-kit/issues/1488)
-- **web-components:** add code to get large ic-select variant working ([befb115](https://github.com/mi6/ic-ui-kit/commit/befb11534959c3efb28b655337a7f572cecc9ed8)), closes [.#257](https://github.com/./issues/257)
+- **web-components:** add code to get large ic-select variant working ([befb115](https://github.com/mi6/ic-ui-kit/commit/befb11534959c3efb28b655337a7f572cecc9ed8)), closes [#257](https://github.com/mi6/ic-ui-kit/issues/257)
 - **web-components:** add router item slot for buttons ([261d419](https://github.com/mi6/ic-ui-kit/commit/261d419b63b72ff36b60642c591e3faaf412255d)), closes [#1500](https://github.com/mi6/ic-ui-kit/issues/1500)
 - **web-components:** added table-row-selected design token ([e1acfc4](https://github.com/mi6/ic-ui-kit/commit/e1acfc47ac7162ffc408ce047066ea5e1eaa9acd))
 - **web-components:** adds icOpen and icClose events to icSelect ([fdcc844](https://github.com/mi6/ic-ui-kit/commit/fdcc844a140c4fce55f4444387c4526bb5dfeb7d))
 - **web-components:** ic-toggle-button-group ([20f3319](https://github.com/mi6/ic-ui-kit/commit/20f33192a2e44d088433b77e1453446f16c77341))
-- **web-components:** make web-components changes to prepare for multi-select ([d6d51bb](https://github.com/mi6/ic-ui-kit/commit/d6d51bb3dedc533b77f95a294f895ca3d590404e)), closes [.#257](https://github.com/./issues/257)
+- **web-components:** make web-components changes to prepare for multi-select ([d6d51bb](https://github.com/mi6/ic-ui-kit/commit/d6d51bb3dedc533b77f95a294f895ca3d590404e)), closes [#257](https://github.com/mi6/ic-ui-kit/issues/257)
 
 ### Reverts
 
@@ -1088,7 +939,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **web-components:** add query selector for <div> to side nav if statement in paddingIconWidth func ([1574ec6](https://github.com/mi6/ic-ui-kit/commit/1574ec65a7aaa34e5454aa7a5853a7a7d0b4be4d)), closes [.#863](https://github.com/./issues/863)
+- **web-components:** add query selector for <div> to side nav if statement in paddingIconWidth func ([1574ec6](https://github.com/mi6/ic-ui-kit/commit/1574ec65a7aaa34e5454aa7a5853a7a7d0b4be4d)), closes [#863](https://github.com/mi6/ic-ui-kit/issues/863)
 - **web-components:** added prop to prevent auto highlighting first option ([9b4e755](https://github.com/mi6/ic-ui-kit/commit/9b4e755bf2011a9e735e551d6a8efadca20fc522))
 - **web-components:** added trigger to update enabled tabs when tab's disabled state changes ([bf85f01](https://github.com/mi6/ic-ui-kit/commit/bf85f01ffcbc6425420011416df31215a3439be0))
 - **web-components:** ic-card message rendering ([a5c0d02](https://github.com/mi6/ic-ui-kit/commit/a5c0d027854967ec1143ce1a274157d70a945777))
@@ -1107,12 +958,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **web-components:** add role tab to divs in horizontal scroll to stop axe issue ([9275490](https://github.com/mi6/ic-ui-kit/commit/92754900e82a5dbed114ea120e14f65ab458c49e)), closes [#721](https://github.com/mi6/ic-ui-kit/issues/721)
 - **web-components:** fix padding on static side navigation ([caaae78](https://github.com/mi6/ic-ui-kit/commit/caaae78a75a94c9b710ebc13e0ce76f77b39754c)), closes [.mi6/ic-ui-kit#885](https://github.com/.mi6/ic-ui-kit/issues/885)
-- **web-components:** fix vertical alignment of icons on side navigation ([f2e581e](https://github.com/mi6/ic-ui-kit/commit/f2e581e32e84b97bcd53f26855668d34bfc284c7)), closes [.#500](https://github.com/./issues/500)
+- **web-components:** fix vertical alignment of icons on side navigation ([f2e581e](https://github.com/mi6/ic-ui-kit/commit/f2e581e32e84b97bcd53f26855668d34bfc284c7)), closes [#500](https://github.com/mi6/ic-ui-kit/issues/500)
 - **web-components:** fixes ic-button aria-describedby not working ([048e603](https://github.com/mi6/ic-ui-kit/commit/048e60394383f9069480100c25ec31bbff763f75))
 - **web-components:** update search bar to correctly show no results found ([8ebb118](https://github.com/mi6/ic-ui-kit/commit/8ebb118cdb620f03b5dd70f28fb51945692dc39b)), closes [#849](https://github.com/mi6/ic-ui-kit/issues/849)
 - **web-components:** update short-title to short-app-title for top navigation ([fb2251f](https://github.com/mi6/ic-ui-kit/commit/fb2251fae3f07f825dd2c52c933c0f5c2c8417da)), closes [#853](https://github.com/mi6/ic-ui-kit/issues/853)
-- **web-components:** update side nav CSS to ensure visibility of menu content is correct ([a4619be](https://github.com/mi6/ic-ui-kit/commit/a4619be16453b2efac9faf71eff727a0acd33b55)), closes [.#739](https://github.com/./issues/739)
-- **web-components:** update side nav transition handlers to fix bug with collapsed labels variant ([5f3f9b0](https://github.com/mi6/ic-ui-kit/commit/5f3f9b085635aeac1d8603caa23a0c817b0e1e13)), closes [.#896](https://github.com/./issues/896)
+- **web-components:** update side nav CSS to ensure visibility of menu content is correct ([a4619be](https://github.com/mi6/ic-ui-kit/commit/a4619be16453b2efac9faf71eff727a0acd33b55)), closes [#739](https://github.com/mi6/ic-ui-kit/issues/739)
+- **web-components:** update side nav transition handlers to fix bug with collapsed labels variant ([5f3f9b0](https://github.com/mi6/ic-ui-kit/commit/5f3f9b085635aeac1d8603caa23a0c817b0e1e13)), closes [#896](https://github.com/mi6/ic-ui-kit/issues/896)
 - **web-components:** updated searchable select to clear input when value programatically set ([334446a](https://github.com/mi6/ic-ui-kit/commit/334446acc7d0e554034c154ee53c9d087b1e88f1))
 
 ### Features
@@ -1123,11 +974,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **web-components:** add event for selecting / deselecting radio option, update tab index ([86a5d4a](https://github.com/mi6/ic-ui-kit/commit/86a5d4a6544517a25b3bb38b2bf354bb35e59cc2)), closes [.#822](https://github.com/./issues/822)
+- **web-components:** add event for selecting / deselecting radio option, update tab index ([86a5d4a](https://github.com/mi6/ic-ui-kit/commit/86a5d4a6544517a25b3bb38b2bf354bb35e59cc2)), closes [#822](https://github.com/mi6/ic-ui-kit/issues/822)
 - **web-components:** add removeDisabledFalse helper to select ([8e76640](https://github.com/mi6/ic-ui-kit/commit/8e76640bcb99f5d358be7807aa332cfcce664858))
 - **web-components:** cSS styling updates after stylelint update ([18d21fc](https://github.com/mi6/ic-ui-kit/commit/18d21fcea43c17d948b5266176e59c04ef9b00bf))
 - **web-components:** duplicate a.link styles for div.link on nav items ([0ccc268](https://github.com/mi6/ic-ui-kit/commit/0ccc268e411666bce4b8fe2e9d8b24af9eabbd01)), closes [#726](https://github.com/mi6/ic-ui-kit/issues/726)
-- **web-components:** increase min-width of button when it has an icon and it is loading ([e314aa3](https://github.com/mi6/ic-ui-kit/commit/e314aa3484aada0e8611bc1933a01559a5d85d1f)), closes [.#838](https://github.com/./issues/838)
+- **web-components:** increase min-width of button when it has an icon and it is loading ([e314aa3](https://github.com/mi6/ic-ui-kit/commit/e314aa3484aada0e8611bc1933a01559a5d85d1f)), closes [#838](https://github.com/mi6/ic-ui-kit/issues/838)
 - **web-components:** remove event listeners ([58e42e0](https://github.com/mi6/ic-ui-kit/commit/58e42e09d9e01adad7c8b8eff0cd83158965af35)), closes [#791](https://github.com/mi6/ic-ui-kit/issues/791)
 - **web-components:** update navigation items to display slotted labels on menu open ([c7837ba](https://github.com/mi6/ic-ui-kit/commit/c7837ba1023a539f759cd48a49bebd7a454bc4c2)), closes [#775](https://github.com/mi6/ic-ui-kit/issues/775)
 
@@ -1135,9 +986,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-- **web-components:** add wait for changes and remove unnecessary test button from select test ([e56ee81](https://github.com/mi6/ic-ui-kit/commit/e56ee81386b5887c1f3b698ea137192e03f10ba3)), closes [.#694](https://github.com/./issues/694)
+- **web-components:** add wait for changes and remove unnecessary test button from select test ([e56ee81](https://github.com/mi6/ic-ui-kit/commit/e56ee81386b5887c1f3b698ea137192e03f10ba3)), closes [#694](https://github.com/mi6/ic-ui-kit/issues/694)
 - **web-components:** fix resizeObserver calculation for top nav height to remove extra padding ([780ce5e](https://github.com/mi6/ic-ui-kit/commit/780ce5e7e4867577db7fb257fbc4ab2d93046717)), closes [#785](https://github.com/mi6/ic-ui-kit/issues/785)
-- **web-components:** fix static side navigation falling off screen ([702582e](https://github.com/mi6/ic-ui-kit/commit/702582ec6489f34c660a7dd0df05f9cc75c4fa3a)), closes [.#700](https://github.com/./issues/700)
+- **web-components:** fix static side navigation falling off screen ([702582e](https://github.com/mi6/ic-ui-kit/commit/702582ec6489f34c660a7dd0df05f9cc75c4fa3a)), closes [#700](https://github.com/mi6/ic-ui-kit/issues/700)
 - **web-components:** fix suggestions after typing ([22e81c6](https://github.com/mi6/ic-ui-kit/commit/22e81c6a37d2897ccfaf2bb3829c73f49d556d1d))
 - **web-components:** fixes memory leak in ic-button\ic-tooltip ([a4aba85](https://github.com/mi6/ic-ui-kit/commit/a4aba8538e3cf11bbd45fcfca637de706b9fb25e))
 - **web-components:** fixes rendering of footer with no links ([0f62e3a](https://github.com/mi6/ic-ui-kit/commit/0f62e3ad2e33b0a632058c9a21a3ab942cfef511))
@@ -1275,13 +1126,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - **web-components:** add new window icon to navigation item ([791e8ca](https://github.com/mi6/ic-ui-kit/commit/791e8ca1c76e3846010f76cc1fbc38dd37afae53))
 - **web-components:** add open in new window functionality and icon to footer link ([cb36abe](https://github.com/mi6/ic-ui-kit/commit/cb36abe5b1de7e5cb0710f5bf3e95538613cfcab))
-- **web-components:** add quick keyboard navigation to select - selects option based on characters ([3d3927d](https://github.com/mi6/ic-ui-kit/commit/3d3927d62ae2a0aaca391dc88f00013baf51dc2d)), closes [.#158](https://github.com/./issues/158)
+- **web-components:** add quick keyboard navigation to select - selects option based on characters ([3d3927d](https://github.com/mi6/ic-ui-kit/commit/3d3927d62ae2a0aaca391dc88f00013baf51dc2d)), closes [#158](https://github.com/mi6/ic-ui-kit/issues/158)
 
 # 2.1.0-beta.9 (2023-03-21)
 
 ### Bug Fixes
 
-- **web-components:** add handleMouseDown, add css active selector, add spec test for handleMouseDown ([837e336](https://github.com/mi6/ic-ui-kit/commit/837e3366cc33a8a05fa300c1c641fa27cb0f5b7c)), closes [.#213](https://github.com/./issues/213)
+- **web-components:** add handleMouseDown, add css active selector, add spec test for handleMouseDown ([837e336](https://github.com/mi6/ic-ui-kit/commit/837e3366cc33a8a05fa300c1c641fa27cb0f5b7c)), closes [#213](https://github.com/mi6/ic-ui-kit/issues/213)
 - **web-components:** added func to allow default values for searchable variant ([6be8255](https://github.com/mi6/ic-ui-kit/commit/6be82554c1029719d1ec433f98e3b9d49ef45e89))
 - **web-components:** fix gap appearing under slotted nav items ([5e37d18](https://github.com/mi6/ic-ui-kit/commit/5e37d181806a98ef91dfb6d2dd5ec0e6b1832f74))
 - **web-components:** fixed placement issue in top nav ([95b9402](https://github.com/mi6/ic-ui-kit/commit/95b94027e5581cb0a9d8a13d0d52212ea0f22c27))
@@ -1294,7 +1145,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **web-components:** create horizontal scroll component and add to tabs and nav items ([1a88bd2](https://github.com/mi6/ic-ui-kit/commit/1a88bd2a45d41f04fcf9a0ab000617fdef0183aa)), closes [.#242](https://github.com/./issues/242)
+- **web-components:** create horizontal scroll component and add to tabs and nav items ([1a88bd2](https://github.com/mi6/ic-ui-kit/commit/1a88bd2a45d41f04fcf9a0ab000617fdef0183aa)), closes [#242](https://github.com/mi6/ic-ui-kit/issues/242)
 - **web-components:** implement toast component ([db455fb](https://github.com/mi6/ic-ui-kit/commit/db455fbb16a4e0415908b909a6d47cafe9f10912))
 
 # 2.1.0-beta.8 (2023-03-01)


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
- Updates changelogs to include recent v2 releases
- Merges recent v3 alpha releases under 3.0.0 section
- Canary changelogs reverted back to individual releases rather than a single 3.0.0, as there have been no alpha packages for canary
- Tried to improve some messages where they were particularly vague

## Related issue
#3462 

