### PR TITLE
V3 Fix appearance and non-appearance of length validation message in ic-textfield

### DIFF
--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -35,7 +35,10 @@ import {
   checkSlotInChildMutations,
   removeHiddenInput,
 } from "../../utils/helpers";
-import { IC_INHERITED_ARIA } from "../../utils/constants";
+import {
+  IC_INHERITED_ARIA,
+  IGNORED_KEYBOARD_CHARACTERS,
+} from "../../utils/constants";
 import {
   IcAriaAutocompleteTypes,
   IcTextFieldInputModes,
@@ -311,6 +314,9 @@ export class TextField {
 
     if (this.maxCharacters! > 0) {
       value = newValue.substring(0, this.maxCharacters);
+      if (value!.length < newValue!.length) {
+        this.maxCharactersWarning = true;
+      }
       this.value = value;
     } else {
       value = newValue;
@@ -422,7 +428,10 @@ export class TextField {
   @Listen("keydown", {})
   handleKeyDown(ev: KeyboardEvent): void {
     this.icKeydown.emit({ event: ev });
-    this.maxCharactersWarning = this.maxCharactersReached;
+
+    if (!ev.ctrlKey && !IGNORED_KEYBOARD_CHARACTERS.includes(ev.key)) {
+      this.maxCharactersWarning = this.maxCharactersReached;
+    }
   }
 
   /**

--- a/packages/web-components/src/utils/constants.ts
+++ b/packages/web-components/src/utils/constants.ts
@@ -91,3 +91,43 @@ export const IC_BLOCK_COLOR_EXCEPTIONS: IcColorExceptions = {
  */
 export const BLACK_MIN_COLOR_BRIGHTNESS = 136.701;
 export const WHITE_MAX_COLOR_BRIGHTNESS = 130;
+
+// Keyboard characters that do not affect the content of an input control when pressed
+export const IGNORED_KEYBOARD_CHARACTERS = [
+  "Alt",
+  "AltGraph",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "AudioVolumeDown",
+  "AudioVolumeMute",
+  "AudioVolumeUp",
+  "CapsLock",
+  "ContextMenu",
+  "Control",
+  "Delete",
+  "End",
+  "Enter",
+  "Escape",
+  "F1",
+  "F10",
+  "F11",
+  "F12",
+  "F2",
+  "F3",
+  "F4",
+  "F5",
+  "F6",
+  "F7",
+  "F8",
+  "F9",
+  "Home",
+  "Insert",
+  "Meta",
+  "NumLock",
+  "PageDown",
+  "PageUp",
+  "Shift",
+  "Tab",
+];


### PR DESCRIPTION
## Summary of the changes
There were three issues causing the max length validation message to not appear correctly.

1. The max length validation message was not appearing when pasting in more than maxLength characters. The validation message only appeared when another key was pressed (e.g. ArrowLeft) after the paste and data truncation had occurred.

2. The max length validation message was also appearing when it shouldn't have been, when maxLength chars had been entered into the textfield and then keyboard keys were pressed with don't affect the length of the input, e.g. ArrowLeft, Home, End, etc. If one of these keys has been pressed then then the keypress is ignored when working out whether to display the maxLength validation message.

3. Similar to 2. above, another case of the validation message appearing when it shouldn't have been, is when maxLength chars had been entered into the textfield and then the ctrl key along with another character, e.g. Ctrl-a (to select all the contents of the field). This is now prevented - if the ctrl key is pressed then the keypress is ignored when working out whether to display the maxLength validation message.

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.