### PR TITLE
fix(web-components): dialogs at narrow width/high zoom fix

### DIFF
--- a/packages/web-components/src/components/ic-dialog/ic-dialog.css
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.css
@@ -58,7 +58,9 @@
 .dialog {
   background-color: var(--ic-dialog-background);
   color: var(--ic-dialog-text-primary);
+
   --ic-typography-color: var(--ic-dialog-text-primary);
+
   border: var(--ic-space-1px) solid var(--ic-dialog-border);
   border-radius: var(--ic-border-radius);
   padding: var(--ic-space-xs) 0 var(--ic-space-md);
@@ -168,7 +170,6 @@
   .dialog {
     width: 100vw;
     height: 100vh;
-    transform: translateY(-5rem);
     max-width: none;
     max-height: none;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary of the changes
Removed a translate Y line in the ic-dialog.css that was forcing the dialog up off the screen on narrow widths and high zoom levels. See the ticket linked below for an example of the behaviour occuring, which I was able to replicate on Storybook and Stackblitz on Windows.

By removing this line, dialogs on narrow / zoomed in screens now fill the screen properly. 

Additionally `npm lint:fix` was run and added some linebreaks further up the file. 

##How to replicate

Compare [develop](https://mi6.github.io/ic-ui-kit/branches/develop/web-components/?path=/story/web-components-dialog--sizes) and [this branch](https://mi6.github.io/ic-ui-kit/branches/3432-zoom-icdialogs-are-cut-off-at-the-top/web-components/?path=/story/web-components-dialog--sizes)

1. click Launch Medium Dialog
2. Shrink the canvas window horizontally
3. You'll see on develop that past a certain width, the dialog goes fullscreen
  i. On develop it's spilling off the top of the screen
  ii. On this branch, it fits the screen happily

## Related issue
#3432 

## Checklist

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 