### PR TITLE
3358 ic tree view trying to arrow down doesn't move to the next item when a child in tree view is expanded

### DIFF
--- a/packages/canary-react/src/component-tests/IcTreeView/IcTreeView.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcTreeView/IcTreeView.cy.tsx
@@ -42,6 +42,32 @@ export const BasicTreeView = (
   </div>
 );
 
+export const BasicTreeViewWithCoffeeTypes = (
+  props?: object,
+  treeItemProps?: object
+): ReactElement => (
+  <div
+    style={{
+      width: "250px",
+      padding: "16px",
+    }}
+  >
+    <IcTreeView heading="Menu" {...props}>
+      <IcTreeItem label="Coffee" {...treeItemProps}>
+        <IcTreeItem label="Americano">
+          <IcTreeItem label="With milk" />
+        </IcTreeItem>
+        <IcTreeItem label="Latte" />
+      </IcTreeItem>
+      <IcTreeItem label="Tea">
+        <IcTreeItem label="Earl Grey" />
+        <IcTreeItem label="Chai" />
+      </IcTreeItem>
+      <IcTreeItem label="Hot Chocolate" />
+    </IcTreeView>
+  </div>
+);
+
 export const Icon = (): ReactElement => (
   <SlottedSVG
     slot="icon"
@@ -821,6 +847,33 @@ describe("IcTreeView", () => {
       .realPress("ArrowDown");
 
     cy.get(TREE_ITEM).eq(1).should(HAVE_FOCUS).realPress("ArrowDown");
+
+    cy.get(TREE_ITEM).eq(4).should(HAVE_FOCUS);
+  });
+
+  it("should navigate through tree items when expanded content is hidden using arrow keys", () => {
+    mount(<BasicTreeViewWithCoffeeTypes />);
+
+    cy.checkHydrated("ic-tree-view");
+
+    cy.findShadowEl(TREE_ITEM, TREE_ITEM_CONTENT)
+      .eq(0)
+      .focus()
+      .realPress("Enter");
+
+    cy.get(TREE_ITEM).eq(0).should(HAVE_FOCUS).realPress("ArrowDown");
+
+    cy.get(TREE_ITEM)
+      .eq(1)
+      .should(HAVE_FOCUS)
+      .realPress("Enter")
+      .realPress("ArrowUp");
+
+    cy.get(TREE_ITEM)
+      .eq(0)
+      .should(HAVE_FOCUS)
+      .realPress("Enter")
+      .realPress("ArrowDown");
 
     cy.get(TREE_ITEM).eq(4).should(HAVE_FOCUS);
   });

--- a/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.tsx
@@ -274,8 +274,9 @@ export class TreeView {
 
       if (
         this.treeItems[nextItem].parentElement?.tagName !== this.treeItemTag ||
-        (this.treeItems[nextItem].parentElement as HTMLIcTreeItemElement)
-          .expanded
+        ((this.treeItems[nextItem].parentElement as HTMLIcTreeItemElement)
+          .expanded &&
+          this.treeItems[nextItem].offsetHeight > 0)
       ) {
         return nextItem;
       }


### PR DESCRIPTION
fix: arrow down moves to the next item when a child in tree view is expanded