### PR TITLE
feat(react): add type exports to react library

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist/"
   ],

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitAny": true,
     "jsx": "react",
     "allowJs": true,
-    "types": ["cypress", "node", "cypress-axe", "cypress-file-upload", "cypress-real-events"]
+    "types": ["cypress", "node", "cypress-axe", "cypress-file-upload", "cypress-real-events"],
+    "declarationDir": "./dist/types"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["**/__tests__/**", "cypress/**", "src/component-tests/**/*", "**/*.cy.tsx"],


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

This PR does add a types folder for the react package, however it doesn't make the types from web-components any more available, instead this exposes the types that the react package uses (in the cypress tests for example)
<img width="397" alt="Screenshot 2025-05-06 at 14 14 11" src="https://github.com/user-attachments/assets/a6dafc8c-afd3-41b4-b201-fa9629c35f5f" />

I don't think this is going to be a solution at all, but i'm creating this PR in draft for dev team discussion.


## Related issue
ref #1395