### PR TITLE
Tooltip hover fix

### DIFF
--- a/packages/react/src/component-tests/IcTooltip/IcTooltip.cy.tsx
+++ b/packages/react/src/component-tests/IcTooltip/IcTooltip.cy.tsx
@@ -216,6 +216,72 @@ describe("IcTooltip end-to-end tests", () => {
       NOT_BE_VISIBLE
     );
   });
+
+  it("should update hover display when disableHover prop changes", () => {
+    mount(<Default />);
+
+    cy.checkHydrated(TOOLTIP_SELECTOR);
+
+    cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+      NOT_BE_VISIBLE
+    );
+    cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+      NOT_HAVE_ATTR,
+      "data-show"
+    );
+
+    cy.get("button").realHover("mouse");
+    cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+      BE_VISIBLE
+    );
+    cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+      HAVE_ATTR,
+      "data-show"
+    );
+
+    cy.get(TOOLTIP_SELECTOR)
+      .invoke("prop", "disableHover", "true")
+      .then(() => {
+        cy.get("button").realHover("mouse");
+        cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+          NOT_BE_VISIBLE
+        );
+        cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+          NOT_HAVE_ATTR,
+          "data-show"
+        );
+      });
+  });
+
+  it("should update click display when disableClick prop changes", () => {
+    mount(<Default />);
+
+    cy.checkHydrated(TOOLTIP_SELECTOR);
+
+    cy.get("button").click();
+
+    cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+      BE_VISIBLE
+    );
+
+    cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+      HAVE_ATTR,
+      "data-show"
+    );
+
+    cy.get(TOOLTIP_SELECTOR)
+      .invoke("prop", "disableClick", "true")
+      .then(() => {
+        cy.get("button").click();
+        cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+          NOT_BE_VISIBLE
+        );
+        cy.findShadowEl(TOOLTIP_SELECTOR, ".ic-tooltip-container").should(
+          NOT_HAVE_ATTR,
+          "data-show"
+        );
+      });
+  });
 });
 
 describe("IcTooltip visual regression and a11y tests", () => {

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -6,6 +6,7 @@ import {
   h,
   Method,
   State,
+  Watch,
 } from "@stencil/core";
 import { Instance, Options, createPopper } from "@popperjs/core";
 import { IcTooltipPlacements } from "./ic-tooltip.types";
@@ -41,10 +42,26 @@ export class Tooltip {
    */
   @Prop() disableClick?: boolean = false;
 
+  @Watch("disableClick")
+  watchDisableClickHandler(): void {
+    if (this.disableClick) {
+      this.hide();
+    }
+    this.updateTooltipEvents();
+  }
+
   /**
    * If `true`, the tooltip will not be displayed on hover, it will require a click.
    */
   @Prop() disableHover?: boolean = false;
+
+  @Watch("disableHover")
+  watchDisableHoverHandler(): void {
+    if (this.disableHover) {
+      this.hide();
+    }
+    this.updateTooltipEvents();
+  }
 
   /**
    * The number of lines to display before truncating the text.
@@ -306,6 +323,16 @@ export class Tooltip {
     });
 
     document[method]("keydown", this.handleKeyDown as EventListener);
+  };
+
+  private updateTooltipEvents = () => {
+    this.manageEventListeners("remove");
+    this.showEvents = [
+      !this.disableHover && "mouseenter",
+      !this.disableHover && "focusin",
+      !this.disableClick && "click",
+    ];
+    this.manageEventListeners("add");
   };
 
   render() {

--- a/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
@@ -479,4 +479,34 @@ describe("ic-tooltip component", () => {
       )
     ).toBe("-200px");
   });
+
+  it("should no longer display when disableClick changed from false to true", async () => {
+    const page = await newSpecPage({
+      components: [Tooltip],
+      html: `<ic-tooltip target="test-button" label="tooltip"><button id="test-button">Click</button></ic-tooltip>`,
+    });
+
+    jest.spyOn(page.rootInstance, "updateTooltipEvents").mockImplementation();
+
+    page.root!.disableClick = true;
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.updateTooltipEvents).toHaveBeenCalled();
+  });
+
+  it("should no longer display when disableHover changed from false to true", async () => {
+    const page = await newSpecPage({
+      components: [Tooltip],
+      html: `<ic-tooltip target="test-button" label="tooltip"><button id="test-button">Click</button></ic-tooltip>`,
+    });
+
+    jest.spyOn(page.rootInstance, "updateTooltipEvents").mockImplementation();
+
+    page.root!.disableHover = true;
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.updateTooltipEvents).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes issue where updating `disableClick` or `disableHover` props would not affect when tooltips are displayed

## Related issue
#1990 

## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [ ] All acceptance criteria reviewed and met. 

### Testing

- [ ] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [ ] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] All prop combinations work without issue. 
- [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [ ] Controlled and uncontrolled input components tested.
- [ ] Props/slots can be updated after initial render.