### PR TITLE
feat(root): issue urgency changes - add workflow and update templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -8,34 +8,43 @@ type: 'Bug'
 
 ---
 
-## Summary of the bug 
+### Summary of the bug 
 Tell us, in a few words, what the problem is. 
 
-## 🪜 How to reproduce 
+### 🪜 How to reproduce 
 Tell us the steps to reproduce the problem: 
 1. Go to page: '...' 
 2. Click on: '....' 
 3. Type in: '....' 
 4. See the error 
 
-## 📸 Screenshots or code 
+### 📸 Screenshots or code 
 If you can, add screenshots to show the problem. If you need to show a code example, you can include a snippet or link to a repository with an example. 
 
-## 🖥 📱 Device 
+### 🖥 📱 Device 
 - Type: [e.g. Desktop, mobile] 
 - Device: [e.g. iPhone, MacBook, ThinkPad] 
 - OS version: [e.g. macOS13, iOS16, Android 13] 
 - Browser version: [e.g. Chrome 115, Safari 16] 
 
-## 🧐 Expected behaviour 
+### 🧐 Expected behaviour 
 Tell us, in enough detail, what you expected to happen instead. 
 
-## 📝 Acceptance Criteria  
+### 📝 Acceptance Criteria  
 If relevant, describe in full detail the different interactions and edge cases that the component or patterns needs to fulfil. 
 
 *Given* 
 *When*  
 *Then* 
 
-## Additional info 
+### 🚨 Urgency (low, medium or high)
+If applicable, tell us how urgent it is that this issue gets resolved, based on the impact it has on your team's work or project timeline.
+
+<!--
+- Low = Does not have significant impact and can be addressed at a convenient time without causing delays.
+- Medium = Has moderate impact and should be addressed soon to avoid potential delays or complications.
+- High = A critical issue which has significant impact and needs immediate attention to prevent major delays or blockers.
+-->
+
+### Additional info 
 Tell us anything else useful to help us fix or understand the problem.

--- a/.github/ISSUE_TEMPLATE/suggest-guidance.md
+++ b/.github/ISSUE_TEMPLATE/suggest-guidance.md
@@ -8,10 +8,19 @@ type: 'Guidance'
 
 ---
 
-## What component is this related to? 
+### What component is this related to? 
 E.g. Button, search results page, accessibility, etc 
 
-## Why do we need it? 
+### Why do we need it?
 
-## Related open issues  
+### 🚨 Urgency (low, medium or high)
+If applicable, tell us how urgent it is that this issue gets resolved, based on the impact it has on your team's work or project timeline.
+
+<!--
+- Low = Does not have significant impact and can be addressed at a convenient time without causing delays.
+- Medium = Has moderate impact and should be addressed soon to avoid potential delays or complications.
+- High = A critical issue which has significant impact and needs immediate attention to prevent major delays or blockers.
+-->
+
+### Related open issues  
 [Link to other GitHub issues] 

--- a/.github/ISSUE_TEMPLATE/suggest-improvement.md
+++ b/.github/ISSUE_TEMPLATE/suggest-improvement.md
@@ -8,27 +8,36 @@ type: 'Feature improvement'
 
 ---
 
-## Summary 
+### Summary 
 Tell us, in a few words, what the improvement is. 
 
-## 💬 Description 
+### 💬 Description 
 A full description of what the improvement should be and how it should work. 
 
-## 💰 Use value 
+### 💰 Use value 
 Describe why this is important and how it will help users (either developers, designers or the end-users). Think about how it makes people's lives easier, more accessible or quicker to build stuff. 
 
-## 📝 Acceptance Criteria  
+### 📝 Acceptance Criteria  
 If relevant, describe in full detail the different interactions and edge cases that the component or patterns needs to fulfil.  
 
 *Given* 
 *When*  
 *Then* 
 
-## ✏ Designs 
+### ✏ Designs 
 If there's a Figma design file (or other mock-up), include it here. 
 
-## 🧾 Guidance 
+### 🧾 Guidance 
 If there's written guidance or documentation, include a link to it here.  
 
-## Additional info 
+### 🚨 Urgency (low, medium or high)
+If applicable, tell us how urgent it is that this issue gets resolved, based on the impact it has on your team's work or project timeline.
+
+<!--
+- Low = Does not have significant impact and can be addressed at a convenient time without causing delays.
+- Medium = Has moderate impact and should be addressed soon to avoid potential delays or complications.
+- High = A critical issue which has significant impact and needs immediate attention to prevent major delays or blockers.
+-->
+
+### Additional info 
 Tell us anything else useful to help us understand your suggestion. 

--- a/.github/ISSUE_TEMPLATE/suggest-new-component-pattern.md
+++ b/.github/ISSUE_TEMPLATE/suggest-new-component-pattern.md
@@ -7,34 +7,43 @@ assignees: ''
 type: 'Feature'
 ---
 
-## Summary 
+### Summary 
 Tell us, in a few words, what the component or pattern would do. 
 
-## 💬 Description 
+### 💬 Description 
 A full description of what the component or pattern should be and how it should work. 
 
-## 💰 User value 
+### 💰 User value 
 Describe why this is important and how it will help users (either developers, designers or the end-users). Think about how it makes people's lives easier, more accessible or quicker to build stuff. 
 
-## 📚 User Stories 
+### 📚 User Stories 
 If relevant, describe the high-level functionality as user stories. 
 
 *As an* ICDS user:  
 *I need* 
 *So that*  
 
-## 📝 Acceptance Criteria  
+### 📝 Acceptance Criteria  
 If relevant, describe in full detail the different interactions and edge cases that the component or patterns needs to fulfil. 
 
 *Given* 
 *When*  
 *Then* 
 
-## ✏ Designs 
+### ✏ Designs 
 If there's a Figma design file (or other mock-up), include it here. 
 
-## 🧾 Guidance 
+### 🧾 Guidance 
 If there's written guidance or documentation, include a link to it here.  
 
-## Additional info 
+### 🚨 Urgency (low, medium or high)
+If applicable, tell us how urgent it is that this issue gets resolved, based on the impact it has on your team's work or project timeline.
+
+<!--
+- Low = Does not have significant impact and can be addressed at a convenient time without causing delays.
+- Medium = Has moderate impact and should be addressed soon to avoid potential delays or complications.
+- High = A critical issue which has significant impact and needs immediate attention to prevent major delays or blockers.
+-->
+
+### Additional info 
 Tell us anything else useful to help us understand your suggestion. 

--- a/.github/ISSUE_TEMPLATE/suggest-new-feature-existing-component.md
+++ b/.github/ISSUE_TEMPLATE/suggest-new-feature-existing-component.md
@@ -7,34 +7,43 @@ assignees: ''
 type: 'Feature'
 ---
 
-## Summary 
+### Summary 
 Tell us, in a few words, what the new feature would do. 
 
-## 💬 Description 
+### 💬 Description 
 A full description of what the feature should be and how it should work. 
 
-## 💰 User value 
+### 💰 User value 
 Describe why this is important and how it will help users (either developers, designers or the end-users). Think about how it makes people's lives easier, more accessible or quicker to build stuff. 
 
-## 📚 User Stories 
+### 📚 User Stories 
 If relevant, describe the high-level functionality as user stories. 
 
 *As an* ICDS user:  
 *I need* 
 *So that*  
 
-## 📝 Acceptance Criteria  
+### 📝 Acceptance Criteria  
 If relevant, describe in full detail the different interactions and edge cases that the component or patterns needs to fulfil. 
 
 *Given* 
 *When*  
 *Then* 
 
-## ✏ Designs 
+### ✏ Designs 
 If there's a Figma design file (or other mock-up), include it here. 
 
-## 🧾 Guidance 
+### 🧾 Guidance 
 If there's written guidance or documentation, include a link to it here.  
 
-## Additional info 
+### 🚨 Urgency (low, medium or high)
+If applicable, tell us how urgent it is that this issue gets resolved, based on the impact it has on your team's work or project timeline.
+
+<!--
+- Low = Does not have significant impact and can be addressed at a convenient time without causing delays.
+- Medium = Has moderate impact and should be addressed soon to avoid potential delays or complications.
+- High = A critical issue which has significant impact and needs immediate attention to prevent major delays or blockers.
+-->
+
+### Additional info 
 Tell us anything else useful to help us understand your suggestion. 

--- a/.github/ISSUE_TEMPLATE/suggest-process-improvement.md
+++ b/.github/ISSUE_TEMPLATE/suggest-process-improvement.md
@@ -8,10 +8,19 @@ type: 'Process improvement'
 
 ---
 
-## Summary
+### Summary
 Tell us, in a few words, what the improvement is. 
 
-## 💬 Description 
+### 💬 Description 
 A full description of what the improvement should be and how it should work. 
 
-## Why do we need it? 
+### 🚨 Urgency (low, medium or high)
+If applicable, tell us how urgent it is that this issue gets resolved, based on the impact it has on your team's work or project timeline.
+
+<!--
+- Low = Does not have significant impact and can be addressed at a convenient time without causing delays.
+- Medium = Has moderate impact and should be addressed soon to avoid potential delays or complications.
+- High = A critical issue which has significant impact and needs immediate attention to prevent major delays or blockers.
+-->
+
+### Why do we need it? 

--- a/.github/workflows/add-issue-urgency.yml
+++ b/.github/workflows/add-issue-urgency.yml
@@ -1,0 +1,50 @@
+name: Add issue urgency
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  add-issue-urgency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse issue body
+        id: parse
+        uses: zentered/issue-forms-body-parser@93bd9fdcb3679be1889d2006e9c2cf496899402e #v2.2.0
+
+      - name: Get issue urgency
+        env:
+          URGENCY_STRING: ${{ fromJSON(steps.parse.outputs.data).urgency-low-medium-or-high.text }}
+        if: env.URGENCY_STRING
+        run: |
+          urgencyLevels=("high" "medium" "low")
+          matchedUrgency="None"
+          urgencyString="${{ env.URGENCY_STRING }}"
+
+          for level in "${urgencyLevels[@]}"; do
+            if [[ "${urgencyString,,}" == *"$level"* ]]; then
+              matchedUrgency="${level^}"
+              break
+            fi
+          done
+
+          if [[ "$matchedUrgency" != "None" ]]; then
+            echo "MATCHED_URGENCY=$matchedUrgency" >> $GITHUB_ENV
+          fi
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        with:
+          app_id: ${{ secrets.ADD_ISSUE_URGENCY_APP_ID }}
+          private_key: ${{ secrets.ADD_ISSUE_URGENCY_APP_PEM }}
+
+      - name: Populate urgency field on issue
+        if: env.MATCHED_URGENCY
+        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b #v2.0.2
+        with:
+          project-url: https://github.com/orgs/mi6/projects/2
+          github-token: ${{ steps.generate_token.outputs.token }}
+          field-name: "Urgency"
+          field-value-script: |
+            return `${{ env.MATCHED_URGENCY }} urgency`;


### PR DESCRIPTION
## Summary of the changes

Updated issue templates to include a new “Urgency” section and added a workflow file. This workflow will run whenever an issue is created or edited, check what has been written in the “Urgency” section, and populate the urgency custom field with the appropriate value. (I will create the urgency custom field in our Project immediately after this PR has been merged).

Had to make the headings on the templates level 3 (###) because the issue parser only works with this heading level.

I will open an equivalent PR in the ic-design-system repo.

-----

See the [example issues I created in a test repo](https://github.com/GCHQ-Developer-847/test-repo/issues) ([associated actions](https://github.com/GCHQ-Developer-847/test-repo/actions)) which shows the urgency field, in the "Projects" section on the right on each issue, being populated correctly based on the issue body (e.g. not at all if the user doesn’t provide an urgency). (Although I had to [use a PAT](https://github.com/GCHQ-Developer-847/test-repo/blob/07f61224dcc6b0d84b65ebb36007848adb69bbb9/.github/workflows/add-issue-urgency.yml#L47) in the workflow due to [issues with giving Project permissions to a user-owned GitHub App](https://github.com/orgs/community/discussions/46681#discussioncomment-8774842) - hoping it should all be fine with an org-owned app).

## Related issue
#3130 