### PR TITLE
Updated breadcrumb group to not incorrectly apply hide class to last breadcrumb

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -1118,7 +1118,7 @@
           "mutable": false,
           "attr": "custom-color",
           "reflectToAttr": false,
-          "docs": "The custom badge colour. This will only style the badge component if variant=\"custom\".\nCan be a hex value e.g. \"#ff0000\", RGB e.g. \"rgb(255, 0, 0)\", or RGBA e.g. \"rgba(255, 0, 0, 1)\".",
+          "docs": "The custom badge colour. This will only style the badge component if variant=\"custom\".\r\nCan be a hex value e.g. \"#ff0000\", RGB e.g. \"rgb(255, 0, 0)\", or RGBA e.g. \"rgba(255, 0, 0, 1)\".",
           "docsTags": [],
           "values": [
             {
@@ -1176,7 +1176,7 @@
           "mutable": false,
           "attr": "max-number",
           "reflectToAttr": false,
-          "docs": "The maximum number shown on the badge appended with a +.\nThis will only be displayed if type=\"text\" and label is not empty.",
+          "docs": "The maximum number shown on the badge appended with a +.\r\nThis will only be displayed if type=\"text\" and label is not empty.",
           "docsTags": [],
           "values": [
             {
@@ -1495,10 +1495,10 @@
       "props": [
         {
           "name": "current",
-          "type": "boolean | undefined",
+          "type": "boolean",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean | undefined",
+            "resolved": "boolean",
             "references": {}
           },
           "mutable": false,
@@ -1510,12 +1510,9 @@
           "values": [
             {
               "type": "boolean"
-            },
-            {
-              "type": "undefined"
             }
           ],
-          "optional": true,
+          "optional": false,
           "required": false,
           "getter": false,
           "setter": false
@@ -1630,10 +1627,10 @@
       "props": [
         {
           "name": "backBreadcrumbOnly",
-          "type": "boolean | undefined",
+          "type": "boolean",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean | undefined",
+            "resolved": "boolean",
             "references": {}
           },
           "mutable": false,
@@ -1645,25 +1642,22 @@
           "values": [
             {
               "type": "boolean"
-            },
-            {
-              "type": "undefined"
             }
           ],
-          "optional": true,
+          "optional": false,
           "required": false,
           "getter": false,
           "setter": false
         },
         {
           "name": "collapsed",
-          "type": "boolean | undefined",
+          "type": "boolean",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean | undefined",
+            "resolved": "boolean",
             "references": {}
           },
-          "mutable": false,
+          "mutable": true,
           "attr": "collapsed",
           "reflectToAttr": false,
           "docs": "If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.",
@@ -1672,22 +1666,19 @@
           "values": [
             {
               "type": "boolean"
-            },
-            {
-              "type": "undefined"
             }
           ],
-          "optional": true,
+          "optional": false,
           "required": false,
           "getter": false,
           "setter": false
         },
         {
           "name": "monochrome",
-          "type": "boolean | undefined",
+          "type": "boolean",
           "complexType": {
             "original": "boolean",
-            "resolved": "boolean | undefined",
+            "resolved": "boolean",
             "references": {}
           },
           "mutable": false,
@@ -1699,22 +1690,19 @@
           "values": [
             {
               "type": "boolean"
-            },
-            {
-              "type": "undefined"
             }
           ],
-          "optional": true,
+          "optional": false,
           "required": false,
           "getter": false,
           "setter": false
         },
         {
           "name": "theme",
-          "type": "\"dark\" | \"inherit\" | \"light\" | undefined",
+          "type": "\"dark\" | \"inherit\" | \"light\"",
           "complexType": {
             "original": "IcThemeMode",
-            "resolved": "\"dark\" | \"inherit\" | \"light\" | undefined",
+            "resolved": "\"dark\" | \"inherit\" | \"light\"",
             "references": {
               "IcThemeMode": {
                 "location": "import",
@@ -1741,12 +1729,9 @@
             {
               "value": "light",
               "type": "string"
-            },
-            {
-              "type": "undefined"
             }
           ],
-          "optional": true,
+          "optional": false,
           "required": false,
           "getter": false,
           "setter": false
@@ -15395,7 +15380,7 @@
           "mutable": true,
           "attr": "value",
           "reflectToAttr": false,
-          "docs": "The value of the select, reflected by the value of the currently selected option.\nFor the searchable variant, the value is also reflected by the user input.\nFor the multi-select variant, the value must be an array of option values.",
+          "docs": "The value of the select, reflected by the value of the currently selected option.\r\nFor the searchable variant, the value is also reflected by the user input.\r\nFor the multi-select variant, the value must be an array of option values.",
           "docsTags": [],
           "values": [
             {
@@ -15589,7 +15574,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an option is selected.\nSelecting an option will also trigger an `icChange/onIcChange` due to the value being updated.",
+          "docs": "Emitted when an option is selected.\r\nSelecting an option will also trigger an `icChange/onIcChange` due to the value being updated.",
           "docsTags": []
         },
         {

--- a/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumb.cy.tsx
+++ b/packages/react/src/component-tests/IcBreadcrumb/IcBreadcrumb.cy.tsx
@@ -150,6 +150,18 @@ describe("IcBreadcrumb end-to-end tests", () => {
     cy.get("ic-button").click();
     cy.get(".collapsed-breadcrumb").should("have.length", 1);
   });
+
+  it("should expand collapsed state then render all breadcrumbs when narrowing the viewport", () => {
+    mount(<Collapsed />);
+
+    cy.checkHydrated(IC_BREADCRUMB_LABEL);
+    cy.get("#collapsed-ellipsis").click();
+    cy.get('[page-title="Beverages"]').should(BE_VISIBLE);
+
+    cy.viewport(768, 750);
+
+    cy.get('[page-title="Beverages"]').should(BE_VISIBLE);
+  });
 });
 
 describe("IcBreadcrumb visual regression and a11y tests", () => {

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -224,12 +224,12 @@ export namespace Components {
         /**
           * If `true`, aria-current will be set on the breadcrumb.
          */
-        "current"?: boolean;
+        "current": boolean;
         /**
           * The URL that the breadcrumb link points to.
          */
         "href"?: string;
-        "monochrome"?: boolean;
+        "monochrome": boolean;
         /**
           * The title of the breadcrumb.
          */
@@ -238,26 +238,26 @@ export namespace Components {
           * Sets focus on the breadcrumb.
          */
         "setFocus": () => Promise<void>;
-        "showBackIcon"?: boolean;
-        "theme"?: IcThemeMode;
+        "showBackIcon": boolean;
+        "theme": IcThemeMode;
     }
     interface IcBreadcrumbGroup {
         /**
           * If `true`, display only a single breadcrumb for the parent page with a back icon.
          */
-        "backBreadcrumbOnly"?: boolean;
+        "backBreadcrumbOnly": boolean;
         /**
           * If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.
          */
-        "collapsed"?: boolean;
+        "collapsed": boolean;
         /**
           * If `true`, the breadcrumb group will display as black in the light theme, and white in the dark theme.
          */
-        "monochrome"?: boolean;
+        "monochrome": boolean;
         /**
           * Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.
          */
-        "theme"?: IcThemeMode;
+        "theme": IcThemeMode;
     }
     interface IcButton {
         /**

--- a/packages/web-components/src/components/ic-breadcrumb-group/readme.md
+++ b/packages/web-components/src/components/ic-breadcrumb-group/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property             | Attribute              | Description                                                                                                                             | Type                                          | Default     |
-| -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
-| `backBreadcrumbOnly` | `back-breadcrumb-only` | If `true`, display only a single breadcrumb for the parent page with a back icon.                                                       | `boolean \| undefined`                        | `false`     |
-| `collapsed`          | `collapsed`            | If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.                                                     | `boolean \| undefined`                        | `false`     |
-| `monochrome`         | `monochrome`           | If `true`, the breadcrumb group will display as black in the light theme, and white in the dark theme.                                  | `boolean \| undefined`                        | `false`     |
-| `theme`              | `theme`                | Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component. | `"dark" \| "inherit" \| "light" \| undefined` | `"inherit"` |
+| Property             | Attribute              | Description                                                                                                                             | Type                             | Default     |
+| -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
+| `backBreadcrumbOnly` | `back-breadcrumb-only` | If `true`, display only a single breadcrumb for the parent page with a back icon.                                                       | `boolean`                        | `false`     |
+| `collapsed`          | `collapsed`            | If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.                                                     | `boolean`                        | `false`     |
+| `monochrome`         | `monochrome`           | If `true`, the breadcrumb group will display as black in the light theme, and white in the dark theme.                                  | `boolean`                        | `false`     |
+| `theme`              | `theme`                | Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component. | `"dark" \| "inherit" \| "light"` | `"inherit"` |
 
 
 ## Dependencies

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/__snapshots__/ic-breadcrumb-group.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ic-breadcrumb-group should handle the hidden collapsed breadcrumbs: should handle the hidden collapsed breadcrumbs 1`] = `
-<ic-breadcrumb-group class="ic-breadcrumb-group-collapsed" collapsed="true">
+<ic-breadcrumb-group collapsed="true">
   <template shadowrootmode="open">
     <nav aria-label="breadcrumbs">
       <ol>
@@ -21,7 +21,7 @@ exports[`ic-breadcrumb-group should handle the hidden collapsed breadcrumbs: sho
       </div>
     </template>
   </ic-breadcrumb>
-  <ic-breadcrumb class="visuallyhidden" href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
+  <ic-breadcrumb href="/breadcrumb-2" page-title="Breadcrumb 2" role="listitem">
     <template shadowrootmode="open">
       <div class="breadcrumb">
         <span aria-hidden="true" class="chevron">

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/ic-breadcrumb-group.spec.ts
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/ic-breadcrumb-group.spec.ts
@@ -184,14 +184,12 @@ describe("ic-breadcrumb-group", () => {
       </ic-breadcrumb-group>`,
     });
 
-    page.rootInstance.expandedBreadcrumbGroup = true;
     page.rootInstance.resizeObserverCallback(DEVICE_SIZES.S);
 
     page.rootInstance.resizeObserverCallback(DEVICE_SIZES.M);
 
     expect(page.rootInstance.backBreadcrumbOnly).toBe(false);
 
-    //call runResizeObserver
     await page.rootInstance.runResizeObserver();
   });
 
@@ -206,24 +204,22 @@ describe("ic-breadcrumb-group", () => {
       </ic-breadcrumb-group>`,
     });
 
-    // page.rootInstance.expandedBreadcrumbGroup = true;
     page.rootInstance.resizeObserverCallback(DEVICE_SIZES.S);
 
-    expect(page.rootInstance.expandedBreadcrumbs).toBe(false);
+    expect(page.rootInstance.collapsed).toBe(true);
 
     const button = document.querySelector(
       "#collapsed-ellipsis"
     ) as HTMLButtonElement;
     button.click();
     await page.waitForChanges();
-    //delay to test setTimeout in code
-    await waitForTimeout(100);
+    await waitForTimeout(100); // delay to test setTimeout in code
 
     page.rootInstance.resizeObserverCallback(DEVICE_SIZES.M);
 
     await page.waitForChanges();
 
-    expect(page.rootInstance.expandedBreadcrumbs).toBe(true);
+    expect(page.rootInstance.collapsed).toBe(false);
 
     //call runResizeObserver
     await page.rootInstance.runResizeObserver();
@@ -240,7 +236,6 @@ describe("ic-breadcrumb-group", () => {
       </ic-breadcrumb-group>`,
     });
 
-    // page.rootInstance.expandedBreadcrumbGroup = true;
     page.rootInstance.resizeObserverCallback(DEVICE_SIZES.S);
 
     await page.waitForChanges();
@@ -248,10 +243,7 @@ describe("ic-breadcrumb-group", () => {
 
     await page.waitForChanges();
 
-    // expect(true).toBeTruthy;
-
-    expect(page.rootInstance.expandedBreadcrumbs).toBe(false);
-    // expect(page.rootInstance.backBreadcrumbOnly).toBe(false);
+    expect(page.rootInstance.collapsed).toBe(false);
 
     //call runResizeObserver
     await page.rootInstance.runResizeObserver();

--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.tsx
@@ -7,15 +7,10 @@ import {
   Method,
   Watch,
 } from "@stencil/core";
-import { IcBreadcrumbDefault } from "./ic-breadcrumb.types";
 
 import chevronIcon from "../../assets/chevron-icon.svg";
 import backIcon from "../../assets/back-icon.svg";
-import {
-  getSlotElements,
-  isPropDefined,
-  isSlotUsed,
-} from "../../utils/helpers";
+import { getSlotElements, isSlotUsed } from "../../utils/helpers";
 import { IcThemeMode } from "../../utils/types";
 
 /**
@@ -30,16 +25,16 @@ import { IcThemeMode } from "../../utils/types";
 })
 export class Breadcrumb {
   private HREF_ATTR = "href";
-  private linkSlotContent: HTMLElement;
-  private slottedLinkEl: HTMLElement | null;
-  private slottedLinkHref: string | null | undefined;
+  private linkSlotContent: HTMLElement | null = null;
+  private slottedLinkEl: HTMLElement | null = null;
+  private slottedLinkHref: string | null = null;
 
   @Element() el: HTMLIcBreadcrumbElement;
 
   /**
    * If `true`, aria-current will be set on the breadcrumb.
    */
-  @Prop() current?: boolean = false;
+  @Prop() current = false;
   @Watch("current")
   watchCurrentHandler(): void {
     this.updatedSlottedLinkFocus();
@@ -54,7 +49,7 @@ export class Breadcrumb {
   /**
    * @internal If `true`, the breadcrumb will display as black in the light theme, and white in the dark theme.
    */
-  @Prop() monochrome?: boolean = false;
+  @Prop() monochrome = false;
 
   /**
    * The title of the breadcrumb.
@@ -64,40 +59,34 @@ export class Breadcrumb {
   /**
    * @internal If `true`, back icon will be displayed.
    */
-  @Prop({ reflect: true }) showBackIcon?: boolean = false;
+  @Prop({ reflect: true }) showBackIcon = false;
 
   /**
    * @internal Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.
    */
-  @Prop() theme?: IcThemeMode = "inherit";
+  @Prop() theme: IcThemeMode = "inherit";
 
   // Prevent focus on breadcrumb if current page and contains slotted link
-  private updatedSlottedLinkFocus = (): void => {
+  private updatedSlottedLinkFocus = () => {
     // Sets tabindex on wrong element in unit test snapshots
     // - related to known Jest issue: https://github.com/ionic-team/stencil/issues/2830
     if (this.linkSlotContent) {
       this.linkSlotContent.tabIndex = this.current ? -1 : 0; // Prevent focus
     }
 
-    if (this.slottedLinkEl) {
-      if (this.current) {
-        this.slottedLinkEl.removeAttribute(this.HREF_ATTR); // Prevent screen reader announcing breadcrumb as a link
-      } else {
-        this.slottedLinkHref &&
-          this.slottedLinkEl.setAttribute(this.HREF_ATTR, this.slottedLinkHref);
-      }
+    if (this.current) {
+      this.slottedLinkEl?.removeAttribute(this.HREF_ATTR); // Prevent screen reader announcing breadcrumb as a link
+    } else if (this.slottedLinkHref) {
+      this.slottedLinkEl?.setAttribute(this.HREF_ATTR, this.slottedLinkHref);
     }
   };
 
-  private getSlottedLinkEl = (): HTMLElement | null => {
-    const link = this.linkSlotContent;
-    if (link) {
-      const elWithHref = link.hasAttribute(this.HREF_ATTR)
-        ? link
-        : link.querySelector("[href]");
-      return elWithHref as HTMLElement;
-    }
-    return null;
+  private getSlottedLinkEl = () => {
+    if (!this.linkSlotContent) return null;
+
+    return this.linkSlotContent.hasAttribute(this.HREF_ATTR)
+      ? this.linkSlotContent
+      : this.linkSlotContent.querySelector<HTMLElement>("[href]");
   };
 
   componentDidLoad(): void {
@@ -108,15 +97,23 @@ export class Breadcrumb {
       const slotEls = getSlotElements(slottedLinkWrapper);
       if (slotEls) {
         this.linkSlotContent = slotEls[0] as HTMLElement;
+        this.slottedLinkEl = this.getSlottedLinkEl();
+        this.slottedLinkHref = this.slottedLinkEl?.getAttribute("href") || null;
       }
-      this.slottedLinkEl = this.getSlottedLinkEl();
-      this.slottedLinkHref = this.slottedLinkEl?.getAttribute("href");
       this.updatedSlottedLinkFocus();
     }
   }
 
   componentWillRender(): void {
-    this.setSlottedCurrentPageClass();
+    const icLink = this.el.querySelector("ic-link");
+    if (icLink) {
+      const CURRENT_PAGE = "current-page";
+      icLink.classList.remove(CURRENT_PAGE);
+
+      if (this.current && !icLink.classList.contains(CURRENT_PAGE)) {
+        icLink.classList.add("breadcrumb-link", CURRENT_PAGE);
+      }
+    }
   }
 
   /**
@@ -131,99 +128,54 @@ export class Breadcrumb {
     <div class="back-icon" innerHTML={backIcon}></div>
   );
 
-  private renderDefaultBreadcrumb = (
-    current: boolean,
-    pageTitle: string,
-    describedById: string,
-    href: string | undefined
-  ): IcBreadcrumbDefault => {
-    const hasPageTitle =
-      pageTitle !== null && isPropDefined(pageTitle) && pageTitle !== "";
-
-    if (current && hasPageTitle) {
-      return (
-        <span
-          class={{
-            "current-page-container": current,
-          }}
-        >
-          {isSlotUsed(this.el, "icon") && <slot name="icon"></slot>}
-          {pageTitle}
-        </span>
-      );
-    }
-
-    return (
-      <ic-link
-        theme={this.theme}
-        monochrome={this.monochrome}
-        href={href}
-        class="breadcrumb-link"
-        aria-describedby={this.showBackIcon && describedById && describedById}
-      >
-        {this.showBackIcon && this.renderBackIcon()}
-        {isSlotUsed(this.el, "icon") && <slot name="icon"></slot>}
-        {pageTitle}
-      </ic-link>
-    );
-  };
-
-  private setSlottedCurrentPageClass = () => {
-    const icLink = this.el.querySelector("ic-link");
-    const currentPage = "current-page";
-    if (icLink) {
-      icLink.classList.remove(currentPage);
-      if (this.current) {
-        const hasCurrentPageClass = icLink.classList.contains(currentPage);
-        if (!hasCurrentPageClass) {
-          icLink.classList.add("breadcrumb-link", currentPage);
-        }
-      }
-    }
-  };
-
   render() {
-    const { current, href, pageTitle } = this;
-    const describedById = `${
-      pageTitle && pageTitle.toLowerCase().replace(" ", "-")
-    }-describedby`;
-
-    const hasPageTitle =
-      pageTitle !== null && isPropDefined(pageTitle) && pageTitle !== "";
-    const hasHref = href !== null && isPropDefined(href) && href !== "";
+    const { current, href, monochrome, pageTitle, showBackIcon, theme } = this;
+    const describedById = `${pageTitle
+      ?.toLowerCase()
+      .replace(" ", "-")}-describedby`;
 
     return (
       <Host
         class={{
-          "ic-breadcrumb-back": !!this.showBackIcon,
-          [`ic-theme-${this.theme}`]: this.theme !== "inherit",
-          "ic-breadcrumb-monochrome": !!this.monochrome,
+          "ic-breadcrumb-back": showBackIcon,
+          "ic-breadcrumb-monochrome": monochrome,
+          [`ic-theme-${theme}`]: theme !== "inherit",
         }}
         aria-current={current && "page"}
         role="listitem"
       >
         <div class="breadcrumb">
           <span innerHTML={chevronIcon} class="chevron" aria-hidden="true" />
-          {this.showBackIcon && describedById && (
+          {showBackIcon && (
             <span
               id={describedById}
               class="hide"
             >{`Back to ${pageTitle}`}</span>
           )}
-          {hasPageTitle && hasHref ? (
-            this.renderDefaultBreadcrumb(
-              !!current,
-              pageTitle,
-              describedById,
-              href
-            )
-          ) : (
+          {!href ? (
             <div class="slotted-link-container">
-              {this.showBackIcon && this.renderBackIcon()}
+              {showBackIcon && this.renderBackIcon()}
               <span class="link-wrapper">
                 <slot />
               </span>
             </div>
+          ) : current ? (
+            <span class="current-page-container">
+              {isSlotUsed(this.el, "icon") && <slot name="icon"></slot>}
+              {pageTitle}
+            </span>
+          ) : (
+            <ic-link
+              theme={theme}
+              monochrome={monochrome}
+              href={href}
+              class="breadcrumb-link"
+              aria-describedby={showBackIcon && describedById}
+            >
+              {showBackIcon && this.renderBackIcon()}
+              {isSlotUsed(this.el, "icon") && <slot name="icon"></slot>}
+              {pageTitle}
+            </ic-link>
           )}
         </div>
       </Host>

--- a/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.types.ts
+++ b/packages/web-components/src/components/ic-breadcrumb/ic-breadcrumb.types.ts
@@ -1,1 +1,0 @@
-export type IcBreadcrumbDefault = string | HTMLIcLinkElement | null;

--- a/packages/web-components/src/components/ic-breadcrumb/readme.md
+++ b/packages/web-components/src/components/ic-breadcrumb/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property                 | Attribute    | Description                                            | Type                   | Default     |
-| ------------------------ | ------------ | ------------------------------------------------------ | ---------------------- | ----------- |
-| `current`                | `current`    | If `true`, aria-current will be set on the breadcrumb. | `boolean \| undefined` | `false`     |
-| `href`                   | `href`       | The URL that the breadcrumb link points to.            | `string \| undefined`  | `undefined` |
-| `pageTitle` _(required)_ | `page-title` | The title of the breadcrumb.                           | `string`               | `undefined` |
+| Property                 | Attribute    | Description                                            | Type                  | Default     |
+| ------------------------ | ------------ | ------------------------------------------------------ | --------------------- | ----------- |
+| `current`                | `current`    | If `true`, aria-current will be set on the breadcrumb. | `boolean`             | `false`     |
+| `href`                   | `href`       | The URL that the breadcrumb link points to.            | `string \| undefined` | `undefined` |
+| `pageTitle` _(required)_ | `page-title` | The title of the breadcrumb.                           | `string`              | `undefined` |
 
 
 ## Methods

--- a/packages/web-components/src/components/ic-breadcrumb/test/basic/ic-breadcrumb.spec.ts
+++ b/packages/web-components/src/components/ic-breadcrumb/test/basic/ic-breadcrumb.spec.ts
@@ -59,13 +59,22 @@ describe("ic-breadcrumb", () => {
       html: "<ic-breadcrumb id='ic-breadcrumb' current=true><ic-link href='/'>Link</ic-link></ic-breadcrumb>",
     });
 
-    await page.rootInstance.setSlottedCurrentPageClass();
+    page.rootInstance.componentWillRender();
 
     expect(
       document
         .querySelector("ic-breadcrumb")
         ?.classList.contains("current-page")
     ).toBeTruthy;
+
+    page.rootInstance.current = false;
+    await page.waitForChanges();
+
+    expect(
+      document
+        .querySelector("ic-breadcrumb")
+        ?.classList.contains("current-page")
+    ).toBeFalsy;
   });
 
   it("should call 'setFocus' when breadcrumb is focused", async () => {

--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -513,7 +513,7 @@ export class SideNavigation {
 
   private renderAppTitle = (isAppNameSubtitleVariant: boolean) => {
     const displayShortAppTitle =
-      this.deviceSize <= DEVICE_SIZES.S && !isEmptyString(this.shortAppTitle!);
+      this.deviceSize <= DEVICE_SIZES.S && !isEmptyString(this.shortAppTitle);
     return (
       <ic-typography
         variant={

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -754,8 +754,8 @@ export class TextField {
             )}
           </ic-input-component-container>
           {isSlotUsed(el, "menu") && <slot name="menu"></slot>}
-          {(!isEmptyString(validationStatus!) ||
-            !isEmptyString(validationText!) ||
+          {(!isEmptyString(validationStatus) ||
+            !isEmptyString(validationText) ||
             maxNumChars! > 0 ||
             maxValueExceeded ||
             maxCharactersWarning ||

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -358,7 +358,7 @@ export class TopNavigation {
                         </div>
                       )}
                       {deviceSize <= DEVICE_SIZES.S &&
-                      (!isEmptyString(shortAppTitle!) || shortAppTitleSlot) ? (
+                      (!isEmptyString(shortAppTitle) || shortAppTitleSlot) ? (
                         <ic-typography
                           variant="subtitle-small"
                           aria-label={

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -284,8 +284,8 @@ export const handleHiddenFormButtonClick = (
   hiddenFormButton.remove();
 };
 
-export const isEmptyString = (value: string): boolean =>
-  value ? value.trim().length === 0 : true;
+export const isEmptyString = (value?: string): boolean =>
+  !value || value.trim().length === 0;
 
 // A helper function that checks if a prop has been defined
 export const isPropDefined = (prop: string | undefined): string | undefined =>


### PR DESCRIPTION
## Summary of the changes
- Refactored ic-breadcrumb-group to set collapsed as mutable prop rather than relying on internal state.
- Now is able to accurately determine collapsed state and react accordingly when showing/hiding elements after clicking the expand button. (Was getting wrong value in `revertLastParentCollapsedBreadcrumb` so the hide class was being applied)
- Added test to cypress to cover this behaviour.

## Related issue
#3514 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge).

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.