### PR TITLE
2722 popover menu toggle variant menu items

### DIFF
--- a/packages/react/src/component-tests/IcPopoverMenu/IcPopoverMenu.cy.tsx
+++ b/packages/react/src/component-tests/IcPopoverMenu/IcPopoverMenu.cy.tsx
@@ -21,10 +21,18 @@ import {
   PopoverWithMenuGroups,
 } from "./IcPopoverMenuData";
 import { IcTheme } from "../../components";
+import { CYPRESS_AXE_OPTIONS } from "../../../cypress/utils/a11y";
 
 const BUTTON_SELECTOR = "ic-button";
 const MENU_ITEM_SELECTOR = "ic-menu-item";
 const POPOVER_SELECTOR = "ic-popover-menu";
+
+const DISABLED_POPOVER_AXE_OPTIONS = {
+  rules: {
+    ...CYPRESS_AXE_OPTIONS.rules,
+    "nested-interactive": { enabled: false },
+  },
+};
 
 const DEFAULT_TEST_THRESHOLD = 0.015;
 
@@ -96,7 +104,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.checkHydrated(POPOVER_SELECTOR);
     cy.get(BUTTON_SELECTOR).click().wait(500);
 
-    // cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "/description",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.027),
@@ -128,7 +136,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.get("@handleMenuItemClick").should(NOT_HAVE_BEEN_CALLED);
     cy.get("@triggerPopoverMenuInstance").should(NOT_BE_CALLED_ONCE);
 
-    // cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "/disabled",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
@@ -143,7 +151,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.get(BUTTON_SELECTOR).click();
     cy.realPress("ArrowDown").wait(250);
 
-    //cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "/disabled-focused",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.001),
@@ -156,7 +164,9 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.checkHydrated(POPOVER_SELECTOR);
     cy.get(BUTTON_SELECTOR).click().wait(500);
 
-    // cy.checkA11yWithWait();
+    // this accessibility check had to be modified, as the 'toggle' variant ic-menu-item triggers the nested-interactive rule
+    // but in manual testing the menu items read okay to NVDA and Voiceover
+    cy.checkA11yWithWait(undefined, undefined, DISABLED_POPOVER_AXE_OPTIONS);
     cy.compareSnapshot({
       name: "/variants",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.034),
@@ -169,7 +179,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.checkHydrated(POPOVER_SELECTOR);
     cy.get(BUTTON_SELECTOR).click().wait(500);
 
-    // cy.checkA11yWithWait(undefined, 500);
+    cy.checkA11yWithWait(undefined, 500);
     cy.compareSnapshot({
       name: "/menu-group",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.016),
@@ -182,7 +192,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.checkHydrated(POPOVER_SELECTOR);
     cy.get(BUTTON_SELECTOR).click().wait(500);
 
-    // cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "/max-height",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.028),
@@ -197,7 +207,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     cy.get(BUTTON_SELECTOR).click();
     cy.get("#submenu-trigger-actions").click().wait(250);
 
-    //checkA11yWithWait();
+    cy.checkA11yWithWait();
     cy.compareSnapshot({
       name: "/submenu-focused",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.01),
@@ -208,7 +218,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     mount(<PopoverDropdown />);
 
     cy.checkHydrated(POPOVER_SELECTOR);
-    // cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
 
     cy.get(POPOVER_SELECTOR).invoke(
       "on",
@@ -226,7 +236,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     mount(<PopoverDropdown />);
 
     cy.checkHydrated(POPOVER_SELECTOR);
-    // cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
 
     cy.get(POPOVER_SELECTOR).invoke(
       "on",
@@ -299,7 +309,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     mount(<PopoverDropdown />);
 
     cy.checkHydrated(POPOVER_SELECTOR);
-    // cy.checkA11yWithWait()
+    cy.checkA11yWithWait();
 
     cy.get(POPOVER_SELECTOR).invoke(
       "on",
@@ -323,7 +333,7 @@ describe("IcPopoverMenu end-to-end, visual regression and a11y tests", () => {
     mount(<PopoverMenuDescription />);
 
     cy.checkHydrated(POPOVER_SELECTOR);
-    // cy.checkA11yWithWait();
+    cy.checkA11yWithWait();
 
     cy.get(POPOVER_SELECTOR).invoke(
       "on",

--- a/packages/web-components/src/components/ic-menu-group/test/basic/__snapshots__/ic-menu-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-menu-group/test/basic/__snapshots__/ic-menu-group.spec.ts.snap
@@ -13,22 +13,20 @@ exports[`menu group should render a menu group with a label 1`] = `
   </template>
   <ic-menu-item label="Button" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, Menu item label menu group" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <span class="icon">
-              <slot name="icon"></slot>
-            </span>
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button, Menu item label menu group" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <span class="icon">
+            <slot name="icon"></slot>
+          </span>
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
     <svg height="24px" slot="icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
       <path d="M0 0h24v24H0V0z" fill="none"></path>
@@ -37,22 +35,20 @@ exports[`menu group should render a menu group with a label 1`] = `
   </ic-menu-item>
   <ic-menu-item label="Button" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, Menu item label menu group" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <span class="icon">
-              <slot name="icon"></slot>
-            </span>
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button, Menu item label menu group" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <span class="icon">
+            <slot name="icon"></slot>
+          </span>
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
     <svg height="24px" slot="icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
       <path d="M0 0h24v24H0V0z" fill="none"></path>
@@ -61,22 +57,20 @@ exports[`menu group should render a menu group with a label 1`] = `
   </ic-menu-item>
   <ic-menu-item description="This button has a href and so it behaves like a link" href="#" label="Button" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, This button has a href and so it behaves like a link, Menu item label menu group" fullwidth="" href="#" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button
-                </ic-typography>
-              </div>
-              <ic-typography class="menu-item-description" variant="caption">
-                This button has a href and so it behaves like a link
+      <ic-button aria-disabled="false" aria-label="Button, This button has a href and so it behaves like a link, Menu item label menu group" fullwidth="" href="#" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button
               </ic-typography>
             </div>
+            <ic-typography class="menu-item-description" variant="caption">
+              This button has a href and so it behaves like a link
+            </ic-typography>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
 </ic-menu-group>
@@ -92,22 +86,20 @@ exports[`menu group should render a menu group without a label 1`] = `
   </template>
   <ic-menu-item label="Button" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <span class="icon">
-              <slot name="icon"></slot>
-            </span>
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <span class="icon">
+            <slot name="icon"></slot>
+          </span>
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
     <svg height="24px" slot="icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
       <path d="M0 0h24v24H0V0z" fill="none"></path>
@@ -116,22 +108,20 @@ exports[`menu group should render a menu group without a label 1`] = `
   </ic-menu-item>
   <ic-menu-item label="Button" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <span class="icon">
-              <slot name="icon"></slot>
-            </span>
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <span class="icon">
+            <slot name="icon"></slot>
+          </span>
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
     <svg height="24px" slot="icon" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
       <path d="M0 0h24v24H0V0z" fill="none"></path>
@@ -140,22 +130,20 @@ exports[`menu group should render a menu group without a label 1`] = `
   </ic-menu-item>
   <ic-menu-item description="This button has a href and so it behaves like a link" href="#" label="Button" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button, This button has a href and so it behaves like a link" fullwidth="" href="#" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button
-                </ic-typography>
-              </div>
-              <ic-typography class="menu-item-description" variant="caption">
-                This button has a href and so it behaves like a link
+      <ic-button aria-disabled="false" aria-label="Button, This button has a href and so it behaves like a link" fullwidth="" href="#" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button
               </ic-typography>
             </div>
+            <ic-typography class="menu-item-description" variant="caption">
+              This button has a href and so it behaves like a link
+            </ic-typography>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
 </ic-menu-group>

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.css
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.css
@@ -1,10 +1,5 @@
 @import "../../global/normalize.css";
 
-li {
-  list-style: none;
-  padding: 0;
-}
-
 :host ::part(button) {
   color: var(--ic-popover-menu-item-check);
 

--- a/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
+++ b/packages/web-components/src/components/ic-menu-item/ic-menu-item.tsx
@@ -220,7 +220,15 @@ export class MenuItem {
           ["ic-menu-item-disabled"]: !!this.disabled,
         }}
       >
-        <li
+        <ic-button
+          fullWidth
+          variant="tertiary"
+          onClick={this.handleClick}
+          href={isPropDefined(this.href)}
+          hreflang={isPropDefined(this.hreflang)}
+          target={isPropDefined(this.target)}
+          rel={isPropDefined(this.rel)}
+          referrerpolicy={this.referrerpolicy}
           role={this.variant === "toggle" ? "menuitemcheckbox" : "menuitem"}
           aria-disabled={`${this.disabled}`}
           aria-checked={
@@ -230,52 +238,40 @@ export class MenuItem {
                 : "false"
               : undefined
           }
+          aria-label={this.getMenuItemAriaLabel()}
+          aria-haspopup={
+            isPropDefined(this.submenuTriggerFor) ||
+            this.el.classList.contains("ic-popover-submenu-back-button")
+              ? "menu"
+              : false
+          }
         >
-          <ic-button
-            fullWidth
-            variant="tertiary"
-            onClick={this.handleClick}
-            href={isPropDefined(this.href)}
-            hreflang={isPropDefined(this.hreflang)}
-            target={isPropDefined(this.target)}
-            rel={isPropDefined(this.rel)}
-            referrerpolicy={this.referrerpolicy}
-            aria-disabled={`${this.disabled}`}
-            aria-label={this.getMenuItemAriaLabel()}
-            aria-haspopup={
-              isPropDefined(this.submenuTriggerFor) ||
-              this.el.classList.contains("ic-popover-submenu-back-button")
-                ? "menu"
-                : false
-            }
-          >
-            <div class="focus-border">
-              {isSlotUsed(this.el, "icon") && (
-                <span class="icon">
-                  <slot name="icon"></slot>
-                </span>
-              )}
-              <MenuItemInformation />
-              {this.variant === "toggle" && (
-                <span
-                  class={{
-                    ["check-icon"]: true,
-                    ["hide"]: !this.checked,
-                  }}
-                  aria-hidden="true"
-                  innerHTML={Check}
-                />
-              )}
-              {isPropDefined(this.submenuTriggerFor) && (
-                <span
-                  class={{ ["submenu-icon"]: true }}
-                  aria-hidden="true"
-                  innerHTML={Chevron}
-                />
-              )}
-            </div>
-          </ic-button>
-        </li>
+          <div class="focus-border">
+            {isSlotUsed(this.el, "icon") && (
+              <span class="icon">
+                <slot name="icon"></slot>
+              </span>
+            )}
+            <MenuItemInformation />
+            {this.variant === "toggle" && (
+              <span
+                class={{
+                  ["check-icon"]: true,
+                  ["hide"]: !this.checked,
+                }}
+                aria-hidden="true"
+                innerHTML={Check}
+              />
+            )}
+            {isPropDefined(this.submenuTriggerFor) && (
+              <span
+                class={{ ["submenu-icon"]: true }}
+                aria-hidden="true"
+                innerHTML={Chevron}
+              />
+            )}
+          </div>
+        </ic-button>
       </Host>
     );
   }

--- a/packages/web-components/src/components/ic-menu-item/test/basic/__snapshots__/ic-menu-item.spec.ts.snap
+++ b/packages/web-components/src/components/ic-menu-item/test/basic/__snapshots__/ic-menu-item.spec.ts.snap
@@ -3,22 +3,20 @@
 exports[`menu item variants should render a menu item with a description 1`] = `
 <ic-menu-item description="This is the default variant of the menu item with a description" label="Default variant" variant="default">
   <template shadowrootmode="open">
-    <li aria-disabled="false" role="menuitem">
-      <ic-button aria-disabled="false" aria-label="Default variant, This is the default variant of the menu item with a description" fullwidth="" variant="tertiary">
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Default variant
-              </ic-typography>
-            </div>
-            <ic-typography class="menu-item-description" variant="caption">
-              This is the default variant of the menu item with a description
+    <ic-button aria-disabled="false" aria-label="Default variant, This is the default variant of the menu item with a description" fullwidth="" role="menuitem" variant="tertiary">
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Default variant
             </ic-typography>
           </div>
+          <ic-typography class="menu-item-description" variant="caption">
+            This is the default variant of the menu item with a description
+          </ic-typography>
         </div>
-      </ic-button>
-    </li>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;
@@ -26,19 +24,17 @@ exports[`menu item variants should render a menu item with a description 1`] = `
 exports[`menu item variants should render the default variant 1`] = `
 <ic-menu-item label="Default variant" variant="default">
   <template shadowrootmode="open">
-    <li aria-disabled="false" role="menuitem">
-      <ic-button aria-disabled="false" aria-label="Default variant" fullwidth="" variant="tertiary">
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Default variant
-              </ic-typography>
-            </div>
+    <ic-button aria-disabled="false" aria-label="Default variant" fullwidth="" role="menuitem" variant="tertiary">
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Default variant
+            </ic-typography>
           </div>
         </div>
-      </ic-button>
-    </li>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;
@@ -46,19 +42,17 @@ exports[`menu item variants should render the default variant 1`] = `
 exports[`menu item variants should render the destructive variant 1`] = `
 <ic-menu-item label="Destructive variant" variant="destructive">
   <template shadowrootmode="open">
-    <li aria-disabled="false" role="menuitem">
-      <ic-button aria-disabled="false" aria-label="Destructive variant, destructive" fullwidth="" variant="tertiary">
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Destructive variant
-              </ic-typography>
-            </div>
+    <ic-button aria-disabled="false" aria-label="Destructive variant, destructive" fullwidth="" role="menuitem" variant="tertiary">
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Destructive variant
+            </ic-typography>
           </div>
         </div>
-      </ic-button>
-    </li>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;
@@ -66,19 +60,17 @@ exports[`menu item variants should render the destructive variant 1`] = `
 exports[`menu item variants should render the disabled variant 1`] = `
 <ic-menu-item class="ic-menu-item-disabled" disabled="" label="Default variant" variant="default">
   <template shadowrootmode="open">
-    <li aria-disabled="true" role="menuitem">
-      <ic-button aria-disabled="true" aria-label="Default variant" fullwidth="" variant="tertiary">
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Default variant
-              </ic-typography>
-            </div>
+    <ic-button aria-disabled="true" aria-label="Default variant" fullwidth="" role="menuitem" variant="tertiary">
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Default variant
+            </ic-typography>
           </div>
         </div>
-      </ic-button>
-    </li>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;
@@ -86,19 +78,17 @@ exports[`menu item variants should render the disabled variant 1`] = `
 exports[`menu item variants should render the disabled variant: disabled-removed 1`] = `
 <ic-menu-item label="Default variant" variant="default">
   <template shadowrootmode="open">
-    <li aria-disabled="false" role="menuitem">
-      <ic-button aria-disabled="false" aria-label="Default variant" fullwidth="" variant="tertiary">
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Default variant
-              </ic-typography>
-            </div>
+    <ic-button aria-disabled="false" aria-label="Default variant" fullwidth="" role="menuitem" variant="tertiary">
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Default variant
+            </ic-typography>
           </div>
         </div>
-      </ic-button>
-    </li>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;
@@ -106,27 +96,25 @@ exports[`menu item variants should render the disabled variant: disabled-removed
 exports[`menu item variants should render the toggle variant 1`] = `
 <ic-menu-item id="test-menu-item" label="Toggle variant" variant="toggle">
   <template shadowrootmode="open">
-    <li aria-checked="false" aria-disabled="false" role="menuitemcheckbox">
-      <ic-button class="ic-button-full-width ic-button-size-medium ic-button-variant-tertiary" exportparts="button">
-        <template shadowrootmode="open">
-          <button aria-disabled="false" aria-label="Toggle variant" class="button" part="button" type="button">
-            <slot></slot>
-          </button>
-        </template>
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Toggle variant
-              </ic-typography>
-            </div>
+    <ic-button aria-checked="false" class="ic-button-full-width ic-button-size-medium ic-button-variant-tertiary" exportparts="button" role="menuitemcheckbox">
+      <template shadowrootmode="open">
+        <button aria-disabled="false" aria-label="Toggle variant" class="button" part="button" type="button">
+          <slot></slot>
+        </button>
+      </template>
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Toggle variant
+            </ic-typography>
           </div>
-          <span aria-hidden="true" class="check-icon hide">
-            svg
-          </span>
         </div>
-      </ic-button>
-    </li>
+        <span aria-hidden="true" class="check-icon hide">
+          svg
+        </span>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;
@@ -134,22 +122,20 @@ exports[`menu item variants should render the toggle variant 1`] = `
 exports[`menu item variants should render with keyboard shortcut 1`] = `
 <ic-menu-item keyboard-shortcut-label="Cmd+" label="Toggle variant" variant="default">
   <template shadowrootmode="open">
-    <li aria-disabled="false" role="menuitem">
-      <ic-button aria-disabled="false" aria-label="Toggle variant, Cmd+" fullwidth="" variant="tertiary">
-        <div class="focus-border">
-          <div class="menu-item-info">
-            <div class="menu-labels">
-              <ic-typography class="menu-item-label">
-                Toggle variant
-              </ic-typography>
-              <ic-typography class="shortcut" variant="caption">
-                Cmd+
-              </ic-typography>
-            </div>
+    <ic-button aria-disabled="false" aria-label="Toggle variant, Cmd+" fullwidth="" role="menuitem" variant="tertiary">
+      <div class="focus-border">
+        <div class="menu-item-info">
+          <div class="menu-labels">
+            <ic-typography class="menu-item-label">
+              Toggle variant
+            </ic-typography>
+            <ic-typography class="shortcut" variant="caption">
+              Cmd+
+            </ic-typography>
           </div>
         </div>
-      </ic-button>
-    </li>
+      </div>
+    </ic-button>
   </template>
 </ic-menu-item>
 `;

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.css
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.css
@@ -50,11 +50,6 @@
   height: 0;
 }
 
-.button {
-  text-decoration: none;
-  list-style-type: none;
-}
-
 :host(:focus-within) {
   box-shadow: var(--ic-border-focus);
 }

--- a/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
+++ b/packages/web-components/src/components/ic-popover-menu/ic-popover-menu.tsx
@@ -15,6 +15,8 @@ import { getSlotElements, isPropDefined } from "../../utils/helpers";
 import { createPopper, Instance as PopperInstance } from "@popperjs/core";
 import { IcThemeMode } from "../../utils/types";
 
+const MENU_SELECTOR = "div.menu-body";
+
 @Component({
   tag: "ic-popover-menu",
   styleUrl: "ic-popover-menu.css",
@@ -120,7 +122,7 @@ export class PopoverMenu {
   }
 
   componentDidLoad(): void {
-    const slotWrapper = this.el.shadowRoot?.querySelector("ul.button");
+    const slotWrapper = this.el.shadowRoot?.querySelector(MENU_SELECTOR);
     if (slotWrapper) {
       const popoverMenuElements = getSlotElements(slotWrapper);
 
@@ -424,9 +426,13 @@ export class PopoverMenu {
                 </ic-typography>
               </span>
             )}
-            <ul class="button" aria-label={this.getMenuAriaLabel()} role="menu">
+            <div
+              class="menu-body"
+              aria-label={this.getMenuAriaLabel()}
+              role="menu"
+            >
               <slot></slot>
-            </ul>
+            </div>
           </span>
         </div>
       </Host>

--- a/packages/web-components/src/components/ic-popover-menu/test/basic/__snapshots__/ic-popover-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-popover-menu/test/basic/__snapshots__/ic-popover-menu.spec.ts.snap
@@ -9,22 +9,20 @@ exports[`ic-popover-menu should render a back button when submenu-id is set: sho
           <span role="menu">
             <ic-menu-item class="ic-popover-submenu-back-button" id="ic-popover-submenu-back-button-1" variant="default">
               <template shadowrootmode="open">
-                <li aria-disabled="false" role="menuitem">
-                  <ic-button aria-disabled="false" aria-haspopup="menu" aria-label="Go back to parent menu" fullwidth="" variant="tertiary">
-                    <div class="focus-border">
-                      <span class="icon">
-                        <slot name="icon"></slot>
-                      </span>
-                      <div class="menu-item-info">
-                        <div class="menu-labels">
-                          <ic-typography class="menu-item-label">
-                            Back
-                          </ic-typography>
-                        </div>
+                <ic-button aria-disabled="false" aria-haspopup="menu" aria-label="Go back to parent menu" fullwidth="" role="menuitem" variant="tertiary">
+                  <div class="focus-border">
+                    <span class="icon">
+                      <slot name="icon"></slot>
+                    </span>
+                    <div class="menu-item-info">
+                      <div class="menu-labels">
+                        <ic-typography class="menu-item-label">
+                          Back
+                        </ic-typography>
                       </div>
                     </div>
-                  </ic-button>
-                </li>
+                  </div>
+                </ic-button>
               </template>
               <svg class="submenu-back-icon" fill="none" slot="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z" fill="currentColor"></path>
@@ -33,44 +31,40 @@ exports[`ic-popover-menu should render a back button when submenu-id is set: sho
           </span>
           <ic-typography class="parent-label" variant="subtitle-small"></ic-typography>
         </span>
-        <ul aria-label="popover-menu, within nested level 1 undefined submenu," class="button" role="menu">
+        <div aria-label="popover-menu, within nested level 1 undefined submenu," class="menu-body" role="menu">
           <slot></slot>
-        </ul>
+        </div>
       </span>
     </div>
   </template>
   <ic-menu-item label="Button 1" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button 1
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button 1
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
   <ic-menu-item label="Button 2" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button 2" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button 2
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button 2" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button 2
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
 </ic-popover-menu>
@@ -81,27 +75,25 @@ exports[`ic-popover-menu should render a menu item and menu group: should render
   <template shadowrootmode="open">
     <div class="menu" id="ic-popover-submenu-undefined">
       <span>
-        <ul aria-label="popover-menu" class="button" role="menu">
+        <div aria-label="popover-menu" class="menu-body" role="menu">
           <slot></slot>
-        </ul>
+        </div>
       </span>
     </div>
   </template>
   <ic-menu-item label="Button 1" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button 1
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button 1
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
   <ic-menu-group aria-label="Button group" label="Button group" role="group">
@@ -115,36 +107,32 @@ exports[`ic-popover-menu should render a menu item and menu group: should render
     </template>
     <ic-menu-item label="Group button 1" variant="destructive">
       <template shadowrootmode="open">
-        <li aria-disabled="false" role="menuitem">
-          <ic-button aria-disabled="false" aria-label="Group button 1, destructive, Button group menu group" fullwidth="" variant="tertiary">
-            <div class="focus-border">
-              <div class="menu-item-info">
-                <div class="menu-labels">
-                  <ic-typography class="menu-item-label">
-                    Group button 1
-                  </ic-typography>
-                </div>
+        <ic-button aria-disabled="false" aria-label="Group button 1, destructive, Button group menu group" fullwidth="" role="menuitem" variant="tertiary">
+          <div class="focus-border">
+            <div class="menu-item-info">
+              <div class="menu-labels">
+                <ic-typography class="menu-item-label">
+                  Group button 1
+                </ic-typography>
               </div>
             </div>
-          </ic-button>
-        </li>
+          </div>
+        </ic-button>
       </template>
     </ic-menu-item>
     <ic-menu-item label="Group button 2" variant="default">
       <template shadowrootmode="open">
-        <li aria-disabled="false" role="menuitem">
-          <ic-button aria-disabled="false" aria-label="Group button 2, Button group menu group" fullwidth="" variant="tertiary">
-            <div class="focus-border">
-              <div class="menu-item-info">
-                <div class="menu-labels">
-                  <ic-typography class="menu-item-label">
-                    Group button 2
-                  </ic-typography>
-                </div>
+        <ic-button aria-disabled="false" aria-label="Group button 2, Button group menu group" fullwidth="" role="menuitem" variant="tertiary">
+          <div class="focus-border">
+            <div class="menu-item-info">
+              <div class="menu-labels">
+                <ic-typography class="menu-item-label">
+                  Group button 2
+                </ic-typography>
               </div>
             </div>
-          </ic-button>
-        </li>
+          </div>
+        </ic-button>
       </template>
     </ic-menu-item>
   </ic-menu-group>
@@ -192,44 +180,40 @@ exports[`ic-popover-menu should render on a dialog 1`] = `
     <template shadowrootmode="open">
       <div class="menu" id="ic-popover-submenu-undefined">
         <span>
-          <ul aria-label="popover-menu" class="button" role="menu">
+          <div aria-label="popover-menu" class="menu-body" role="menu">
             <slot></slot>
-          </ul>
+          </div>
         </span>
       </div>
     </template>
     <ic-menu-item label="Button 1" variant="default">
       <template shadowrootmode="open">
-        <li aria-disabled="false" role="menuitem">
-          <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" variant="tertiary">
-            <div class="focus-border">
-              <div class="menu-item-info">
-                <div class="menu-labels">
-                  <ic-typography class="menu-item-label">
-                    Button 1
-                  </ic-typography>
-                </div>
+        <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" role="menuitem" variant="tertiary">
+          <div class="focus-border">
+            <div class="menu-item-info">
+              <div class="menu-labels">
+                <ic-typography class="menu-item-label">
+                  Button 1
+                </ic-typography>
               </div>
             </div>
-          </ic-button>
-        </li>
+          </div>
+        </ic-button>
       </template>
     </ic-menu-item>
     <ic-menu-item label="Button 2" variant="default">
       <template shadowrootmode="open">
-        <li aria-disabled="false" role="menuitem">
-          <ic-button aria-disabled="false" aria-label="Button 2" fullwidth="" variant="tertiary">
-            <div class="focus-border">
-              <div class="menu-item-info">
-                <div class="menu-labels">
-                  <ic-typography class="menu-item-label">
-                    Button 2
-                  </ic-typography>
-                </div>
+        <ic-button aria-disabled="false" aria-label="Button 2" fullwidth="" role="menuitem" variant="tertiary">
+          <div class="focus-border">
+            <div class="menu-item-info">
+              <div class="menu-labels">
+                <ic-typography class="menu-item-label">
+                  Button 2
+                </ic-typography>
               </div>
             </div>
-          </ic-button>
-        </li>
+          </div>
+        </ic-button>
       </template>
     </ic-menu-item>
   </ic-popover-menu>
@@ -241,27 +225,25 @@ exports[`ic-popover-menu should render when anchor starts with #: should render 
   <template shadowrootmode="open">
     <div class="menu" id="ic-popover-submenu-undefined">
       <span>
-        <ul aria-label="popover-menu" class="button" role="menu">
+        <div aria-label="popover-menu" class="menu-body" role="menu">
           <slot></slot>
-        </ul>
+        </div>
       </span>
     </div>
   </template>
   <ic-menu-item label="Button 1" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button 1
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button 1
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
 </ic-popover-menu>
@@ -272,27 +254,25 @@ exports[`ic-popover-menu should render with anchor: should render with anchor 1`
   <template shadowrootmode="open">
     <div class="menu" id="ic-popover-submenu-undefined">
       <span>
-        <ul aria-label="popover-menu" class="button" role="menu">
+        <div aria-label="popover-menu" class="menu-body" role="menu">
           <slot></slot>
-        </ul>
+        </div>
       </span>
     </div>
   </template>
   <ic-menu-item label="Button 1" variant="default">
     <template shadowrootmode="open">
-      <li aria-disabled="false" role="menuitem">
-        <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" variant="tertiary">
-          <div class="focus-border">
-            <div class="menu-item-info">
-              <div class="menu-labels">
-                <ic-typography class="menu-item-label">
-                  Button 1
-                </ic-typography>
-              </div>
+      <ic-button aria-disabled="false" aria-label="Button 1" fullwidth="" role="menuitem" variant="tertiary">
+        <div class="focus-border">
+          <div class="menu-item-info">
+            <div class="menu-labels">
+              <ic-typography class="menu-item-label">
+                Button 1
+              </ic-typography>
             </div>
           </div>
-        </ic-button>
-      </li>
+        </div>
+      </ic-button>
     </template>
   </ic-menu-item>
 </ic-popover-menu>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

- Refactor ic-menu-item to remove redundant `<li>` element
- Refactor ic-popover-menu to replace `<ul>` element with a `<div>`, allowing us to remove redundant styles that suppressed the normal list display behaviour. Renamed element's class selector too to be more readible. 
- Re-enable .checkA11y() calls in IcPopoverMenu.cy.tsx, and add an exception to the one that failed for 'nested-interactive' rule

This pull request doesn't resolve the accessibility failure reported by Accessibility Insights, my reasoning being that when manually testing with NVDA and Voiceover, the toggle variant menu items read out fine. My understanding is that we'd need to remove the ic-button from inside ic-menu-item altogether and that's a lot of bespoke code for a fix that, IMO, isn't necessary. Please do disagree though!

## Related issue
#2722 

## Checklist

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 