### PR TITLE
2184 link download prop not working as expected

### DIFF
--- a/packages/react/src/stories/ic-link.stories.js
+++ b/packages/react/src/stories/ic-link.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import React from 'react';
-import { IcLink, IcTypography, IcSectionContainer } from "../components";
+import React, { useRef } from 'react';
+import { IcLink, IcTypography, IcSectionContainer, IcButton } from "../components";
 import { NavLink, MemoryRouter, Route, Routes } from "react-router-dom";
 
 const HomePage = () => (
@@ -48,6 +48,37 @@ export const WithIcon = {
   ),
 
   name: "With icon",
+};
+
+const Download = () => {
+  const linkEl = useRef();
+  const handleTrue = () => {
+    linkEl.current.download = true;
+  };
+  const handleFalse = () => {
+    linkEl.current.download = false;
+  };
+  const handleReset = () => {
+    linkEl.current.download = "downloaded-file";
+  };
+  return (
+    <>
+      <IcLink href="/" download="downloaded-file" ref={linkEl}>
+        Download File
+      </IcLink>
+      <br />
+      <br />
+      <IcButton onClick={() => handleTrue()}>Set to true</IcButton>
+      <IcButton onClick={() => handleFalse()}>Set to false</IcButton>
+      <IcButton onClick={() => handleReset()}>Set to normal</IcButton>
+    </>
+  );
+};
+
+export const DownloadLink = {
+  render: () => <Download />,
+
+  name: "Download Link",
 };
 
 export const WithReactRouter = {

--- a/packages/web-components/src/components/ic-link/ic-link.stories.js
+++ b/packages/web-components/src/components/ic-link/ic-link.stories.js
@@ -43,12 +43,35 @@ export const WithIcon = {
 };
 
 export const DownloadLink = {
-  render: () => html`<ic-link href="/" download>Download File</ic-link>`,
-  name: "Download link",
+  render: () =>
+    html`<div>
+        <ic-link href="/" download="downloaded-file">Download File</ic-link>
+        <br />
+        <br />
+        <ic-button variant="primary" onclick="handleTrue()"
+          >Set to true</ic-button
+        >
+        <ic-button variant="primary" onclick="handleFalse()"
+          >Set to false</ic-button
+        >
+        <ic-button variant="primary" onclick="handleReset()"
+          >Set to normal</ic-button
+        >
+      </div>
+      <script>
+        var link = document.querySelector("ic-link");
+        function handleTrue() {
+          link.download = true;
+        }
+        function handleFalse() {
+          link.download = false;
+        }
+        function handleReset() {
+          link.download = "downloaded-file";
+        }
+      </script>`,
 
-  parameters: {
-    layout: "fullscreen",
-  },
+  name: "Download link",
 };
 
 export const Playground = {

--- a/packages/web-components/src/components/ic-link/ic-link.tsx
+++ b/packages/web-components/src/components/ic-link/ic-link.tsx
@@ -7,6 +7,7 @@ import {
   Listen,
   Method,
   forceUpdate,
+  Watch,
 } from "@stencil/core";
 
 import OpenInNew from "../../assets/OpenInNew.svg";
@@ -41,6 +42,10 @@ export class Link {
    * If `true`, the user can save the linked URL instead of navigating to it.
    */
   @Prop() download?: string | boolean = false;
+  @Watch("download")
+  watchDownloadHandler(): void {
+    this.updateDownload();
+  }
 
   /**
    * The URL that the link points to.
@@ -119,6 +124,20 @@ export class Link {
     }
   }
 
+  private updateDownload(): void {
+    const element = this.el.shadowRoot?.querySelector("a");
+    if (element) {
+      if (this.download) {
+        element.setAttribute(
+          "download",
+          this.download === true ? "" : this.download
+        );
+      } else {
+        element.removeAttribute("download");
+      }
+    }
+  }
+
   private hasRouterSlot(): boolean {
     this.routerSlot = this.el.querySelector('[slot="router-item"]');
     if (this.routerSlot) {
@@ -171,7 +190,7 @@ export class Link {
             class={{
               ["link"]: !!href,
             }}
-            download={download !== false ? download : null}
+            download={download !== true ? download : ""}
             href={href}
             hrefLang={hreflang}
             referrerPolicy={referrerpolicy}

--- a/packages/web-components/src/components/ic-link/test/basic/__snapshots__/ic-link.spec.ts.snap
+++ b/packages/web-components/src/components/ic-link/test/basic/__snapshots__/ic-link.spec.ts.snap
@@ -22,6 +22,28 @@ exports[`ic-link component should apply the 'download' attribute to the anchor e
 </ic-link>
 `;
 
+exports[`ic-link component should apply the 'download' attribute to the anchor element: download-link-false 1`] = `
+<ic-link class="ic-link" download="test-download" exportparts="link">
+  <template shadowrootmode="open">
+    <a part="link" tabindex="-1">
+      <slot></slot>
+    </a>
+  </template>
+  IC Link Test
+</ic-link>
+`;
+
+exports[`ic-link component should apply the 'download' attribute to the anchor element: download-link-true 1`] = `
+<ic-link class="ic-link" download="test-download" exportparts="link">
+  <template shadowrootmode="open">
+    <a download="" part="link" tabindex="-1">
+      <slot></slot>
+    </a>
+  </template>
+  IC Link Test
+</ic-link>
+`;
+
 exports[`ic-link component should apply the 'href' attribute and ic-link styling to the anchor element: default-link-href 1`] = `
 <ic-link class="ic-link" exportparts="link" href="test-href">
   <template shadowrootmode="open">

--- a/packages/web-components/src/components/ic-link/test/basic/ic-link.spec.ts
+++ b/packages/web-components/src/components/ic-link/test/basic/ic-link.spec.ts
@@ -19,6 +19,18 @@ describe("ic-link component", () => {
     });
 
     expect(page.root).toMatchSnapshot("download-link");
+
+    if (page.root) {
+      page.root.download = false;
+    }
+
+    expect(page.root).toMatchSnapshot("download-link-false");
+
+    if (page.root) {
+      page.root.download = true;
+    }
+
+    expect(page.root).toMatchSnapshot("download-link-true");
   });
 
   it("should apply the 'href' attribute and ic-link styling to the anchor element", async () => {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update link download prop to handle boolean values correctly - remove download from <a> completely if download is false, and set download to "" if download is true

## Related issue
#2184 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.