### PR TITLE
fix(web-components): improve Hero right-content display at small screen widths

### DIFF
--- a/packages/react/src/stories/ic-hero.stories.js
+++ b/packages/react/src/stories/ic-hero.stories.js
@@ -36,6 +36,7 @@ const Controlled = () => {
             placeholder="Filter display"
             label="Filter display"
             hide-label
+            full-width="true"
           />
           <IcButton
             variant="primary"

--- a/packages/web-components/src/components/ic-hero/ic-hero.css
+++ b/packages/web-components/src/components/ic-hero/ic-hero.css
@@ -179,6 +179,18 @@ ic-typography.heading-bottom-spacing {
     background-image: none !important;
   }
 
+  :host(.has-right-content) .section-container {
+    flex-wrap: wrap;
+  }
+  :host(.has-right-content) .left-container {
+    flex-basis: 100%;
+  }
+
+  :host(.has-right-content) .right-container {
+    flex-basis: 100%;
+    margin-bottom: 2.5rem;
+  }
+
   :host,
   .section-container {
     min-height: 16rem;
@@ -205,10 +217,6 @@ ic-typography.heading-bottom-spacing {
   .secondary-heading,
   .secondary-subheading {
     margin-left: 2.125rem;
-  }
-
-  .right-container {
-    margin-left: 3.125rem;
   }
 }
 

--- a/packages/web-components/src/components/ic-hero/ic-hero.stories.js
+++ b/packages/web-components/src/components/ic-hero/ic-hero.stories.js
@@ -279,6 +279,7 @@ export const Brand = {
             placeholder="Filter display"
             label="Filter display"
             hide-label
+            full-width="true"
           ></ic-text-field>
           <ic-button variant="primary" style="margin-left: var(--ic-space-md)"
             >Filter</ic-button

--- a/packages/web-components/src/components/ic-hero/ic-hero.tsx
+++ b/packages/web-components/src/components/ic-hero/ic-hero.tsx
@@ -167,6 +167,7 @@ export class Hero {
           [`ic-hero-${IcBrandForegroundEnum.Dark}`]:
             foregroundColor === IcBrandForegroundEnum.Dark,
           ["has-background-image"]: backgroundImage !== undefined,
+          ["has-right-content"]: this.rightContent,
           ["ic-hero-small"]: size === "small",
           ["secondary-heading"]: !!secondaryHeading,
         }}

--- a/packages/web-components/src/components/ic-hero/test/basic/__snapshots__/ic-hero.spec.ts.snap
+++ b/packages/web-components/src/components/ic-hero/test/basic/__snapshots__/ic-hero.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`ic-hero component should render at size small: renders-small-variant 1`
 `;
 
 exports[`ic-hero component should render with a background image when given: renders-with-background-image 1`] = `
-<ic-hero background-image="test.png" class="has-background-image" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -100px;">
+<ic-hero background-image="test.png" class="has-background-image has-right-content" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -100px;">
   <template shadowrootmode="open">
     <ic-section-container aligned="left" class="section-container" fullheight="">
       <div class="left-container left-container-full-width">
@@ -146,7 +146,7 @@ exports[`ic-hero component should render with interaction content: renders-with-
 `;
 
 exports[`ic-hero component should render with secondary content: renders-with-secondary-content 1`] = `
-<ic-hero heading="Test title" subheading="Test text">
+<ic-hero class="has-right-content" heading="Test title" subheading="Test text">
   <template shadowrootmode="open">
     <ic-section-container aligned="left" class="section-container" fullheight="">
       <div class="left-container left-container-full-width">
@@ -210,7 +210,7 @@ exports[`ic-hero component should render: renders 1`] = `
 `;
 
 exports[`ic-hero component should test rendering secondary slot after initial render 1`] = `
-<ic-hero heading="Test title" subheading="Test text">
+<ic-hero class="has-right-content" heading="Test title" subheading="Test text">
   <template shadowrootmode="open">
     <ic-section-container aligned="left" class="section-container" fullheight="">
       <div class="left-container left-container-full-width">
@@ -244,7 +244,7 @@ exports[`ic-hero component should test rendering secondary slot after initial re
 `;
 
 exports[`ic-hero component should use not parallax on scroll when a background image is given, but parallax disabled: renders-with-parallax-on-scroll-disabled 1`] = `
-<ic-hero background-image="test.png" class="has-background-image" disable-background-parallax="" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -100px;">
+<ic-hero background-image="test.png" class="has-background-image has-right-content" disable-background-parallax="" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -100px;">
   <template shadowrootmode="open">
     <ic-section-container aligned="left" class="section-container" fullheight="">
       <div class="left-container left-container-full-width">
@@ -278,7 +278,7 @@ exports[`ic-hero component should use not parallax on scroll when a background i
 `;
 
 exports[`ic-hero component should use parallax on scroll when a background image is given: renders-with-parallax-on-scroll 1`] = `
-<ic-hero background-image="test.png" class="has-background-image" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -80px;">
+<ic-hero background-image="test.png" class="has-background-image has-right-content" heading="Test title" subheading="Test text" style="background-image: url(test.png); background-position: right -80px;">
   <template shadowrootmode="open">
     <ic-section-container aligned="left" class="section-container" fullheight="">
       <div class="left-container left-container-full-width">


### PR DESCRIPTION
## Summary of the changes
Add conditional styles to improve Hero component display when right-content is present on smaller screen widths.

The best comparison for this is the [develop Hero Brand story](https://mi6.github.io/ic-ui-kit/branches/develop/web-components/?path=/story/web-components-hero--brand) where if you shrink the screen width, the right-content overflows to the right. This PR modifies should address that 

## Related issue
#274 

## Checklist

### General 

### Testing

- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.