### PR TITLE
fix(web-components): allow horizontal radio group inside checkbox and…

### DIFF
--- a/packages/react/src/stories/ic-checkbox.stories.js
+++ b/packages/react/src/stories/ic-checkbox.stories.js
@@ -6,6 +6,12 @@ import {
   IcCheckbox,
   IcTextField,
   IcButton,
+  IcRadioGroup,
+  IcRadioOption,
+  IcSelect,
+  IcSearchBar,
+  IcAlert,
+  IcChip,
 } from "../components";
 import { useForm } from "react-hook-form";
 import React, { useState, useRef } from "react";
@@ -479,11 +485,21 @@ export const ConditionalDynamic = {
         value="valueName3"
         label="option3"
       >
-        <IcTextField
-          slot="additional-field"
-          placeholder="Placeholder"
-          label="What's your favourite type of coffee?"
-        />
+        <IcRadioGroup slot="additional-field" label="Select an option" orientation="horizontal">
+          <IcRadioOption label="Caffeinated"/>
+          <IcRadioOption label="Decaf"/>
+        </IcRadioGroup>
+      </IcCheckbox>
+      <IcCheckbox
+        additionalFieldDisplay="dynamic"
+        value="valueName4"
+        label="option4"
+      >
+          <IcRadioGroup slot="additional-field" label="What's your favourite milk?">
+            <IcRadioOption label="Oat"/>
+            <IcRadioOption label="Almond"/>
+            <IcRadioOption label="Soy"/>
+          </IcRadioGroup>
       </IcCheckbox>
     </IcCheckboxGroup>
   ),
@@ -494,13 +510,47 @@ export const ConditionalDynamic = {
 export const ConditionalStatic = {
   render: () => (
     <IcCheckboxGroup label=" Conditional static " name="1">
-      <IcCheckbox value="valueName1" label="option1">
+      <IcCheckbox value="option1" label="Option one">
         <IcTextField
           slot="additional-field"
           label="What's your favourite type of coffee?"
         />
       </IcCheckbox>
-      <IcCheckbox value="valueName2" label="option2" />
+      <IcCheckbox value="option2" label="Option two">
+        <div slot="additional-field">
+          <IcTextField label="What's your favourite type of coffee?"/>
+          <IcTextField label="What's your second favourite type of coffee?"/>
+          <IcSelect
+            label="Select a coffee"
+            options={[
+            { label: "Espresso", value: "espresso"},
+            { label: "Flat white", value: "flat" },
+            { label: "Filter", value: "filter" }
+            ]}
+          />
+          <IcSearchBar
+            label="Search for a coffee"
+            options={[
+              { label: "Espresso", value: "espresso"},
+              { label: "Flat white", value: "flat" },
+              { label: "Filter", value: "filter" }
+              ]}
+          />
+        </div>
+      </IcCheckbox>
+      <IcCheckbox value="option3" label="Option three">
+        <IcRadioGroup slot="additional-field" label="What's your favourite milk">
+          <IcRadioOption label="Oat"/>
+          <IcRadioOption label="Almond"/>
+          <IcRadioOption label="Soy"/>
+        </IcRadioGroup>
+      </IcCheckbox>
+      <IcCheckbox value="option4" label="Option four">
+        <IcRadioGroup slot="additional-field" label="Select an option" orientation="horizontal">
+          <IcRadioOption label="Caffeinated"/>
+          <IcRadioOption label="Decaf"/>
+        </IcRadioGroup>
+      </IcCheckbox>
     </IcCheckboxGroup>
   ),
 

--- a/packages/web-components/src/components/ic-card-vertical/ic-card-vertical.css
+++ b/packages/web-components/src/components/ic-card-vertical/ic-card-vertical.css
@@ -65,6 +65,7 @@ button {
     &:active {
       background-color: var(--ic-card-background-pressed);
       box-shadow: var(--ic-border-focus);
+
       .card-title {
         text-decoration: none;
       }
@@ -72,11 +73,13 @@ button {
 
     .card-title {
       --ic-typography-color: var(--ic-card-clickable-text);
+
       color: var(--ic-card-clickable-text);
       text-decoration: underline;
       text-decoration-thickness: var(--ic-space-1px);
       margin-bottom: var(--ic-space-xxs);
     }
+
     .interaction-button,
     .icon {
       margin-bottom: var(--ic-space-xxs);

--- a/packages/web-components/src/components/ic-checkbox-group/test/basic/__snapshots__/ic-checkbox-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-checkbox-group/test/basic/__snapshots__/ic-checkbox-group.spec.ts.snap
@@ -78,59 +78,6 @@ exports[`ic-checkbox-group should prioritise the size on an individual checkbox 
 </ic-checkbox-group>
 `;
 
-exports[`ic-checkbox-group should remove disabled attribute from static additional field when checked: renders-with-disabled-attribute-removed-from-field 1`] = `
-<ic-checkbox-group class="ic-checkbox-group-medium" hide-label="" label="test label" name="test" validation-status="error">
-  <template shadowrootmode="open">
-    <span aria-hidden="true" class="screen-reader-only-text" id="screenReaderOnlyText">
-      test label invalid data
-    </span>
-    <fieldset aria-labelledby="screenReaderOnlyText test-validation-text" id="test">
-      <div class="checkboxes-container">
-        <slot></slot>
-      </div>
-    </fieldset>
-    <ic-input-validation arialivemode="polite" for="test" message="" status="error"></ic-input-validation>
-  </template>
-  <ic-checkbox additional-field-display="static" checked="" class="ic-checkbox-medium" label="test label" value="test">
-    <template shadowrootmode="open">
-      <div class="container">
-        <svg class="checkmark" clip-rule="evenodd" fill-rule="evenodd" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <title>
-            checkmark icon
-          </title>
-          <path d="M21 6.285l-11.16 12.733-6.84-6.018 1.319-1.49 5.341 4.686 9.865-11.196 1.475 1.285z"></path>
-        </svg>
-        <input checked="" class="checkbox checked" id="ic-checkbox-test-label-test-label" name="test" role="checkbox" type="checkbox" value="test">
-        <ic-typography class="checkbox-label" variant="body">
-          <label htmlfor="ic-checkbox-test-label-test-label">
-            test label
-          </label>
-        </ic-typography>
-      </div>
-      <div class="dynamic-container">
-        <div>
-          <div class="additional-field-wrapper">
-            <slot name="additional-field"></slot>
-          </div>
-        </div>
-      </div>
-    </template>
-    <ic-text-field label="Test label" placeholder="Placeholder" slot="additional-field" value="">
-      <template shadowrootmode="open">
-        <ic-input-container>
-          <ic-input-label for="ic-text-field-input-3" helpertext="" label="Test label"></ic-input-label>
-          <ic-input-component-container size="medium" validationstatus="">
-            <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-3" inputmode="text" name="ic-text-field-input-3" placeholder="Placeholder" type="text" value="">
-          </ic-input-component-container>
-        </ic-input-container>
-      </template>
-      <input class="ic-input" name="ic-text-field-input-3" type="hidden" value="">
-    </ic-text-field>
-    <input class="ic-input" name="test" type="hidden" value="test">
-  </ic-checkbox>
-</ic-checkbox-group>
-`;
-
 exports[`ic-checkbox-group should render an aria label when checkbox label hidden: renders-hidden-checkbox-label 1`] = `
 <ic-checkbox-group class="ic-checkbox-group-medium" label="test label" name="test">
   <template shadowrootmode="open">
@@ -378,14 +325,14 @@ exports[`ic-checkbox-group should render with disabled static additional field: 
         </ic-typography>
       </div>
       <div class="dynamic-container">
-        <div>
+        <div class="dynamic-field-container">
           <div class="additional-field-wrapper">
             <slot name="additional-field"></slot>
           </div>
         </div>
       </div>
     </template>
-    <ic-text-field class="ic-text-field-disabled" disabled="" label="Test label" placeholder="Placeholder" slot="additional-field" value="">
+    <ic-text-field class="ic-text-field-disabled" disabled="true" label="Test label" placeholder="Placeholder" slot="additional-field" value="">
       <template shadowrootmode="open">
         <ic-input-container disabled="">
           <ic-input-label disabled="" for="ic-text-field-input-2" helpertext="" label="Test label"></ic-input-label>
@@ -396,6 +343,49 @@ exports[`ic-checkbox-group should render with disabled static additional field: 
       </template>
       <input class="ic-input" disabled="" name="ic-text-field-input-2" type="hidden" value="">
     </ic-text-field>
+  </ic-checkbox>
+  <ic-checkbox additional-field-display="static" class="ic-checkbox-medium" label="test label" value="test2">
+    <template shadowrootmode="open">
+      <div class="container">
+        <input class="checkbox" id="ic-checkbox-test-label-test-label" name="test" role="checkbox" type="checkbox" value="test2">
+        <ic-typography class="checkbox-label" variant="body">
+          <label htmlfor="ic-checkbox-test-label-test-label">
+            test label
+          </label>
+        </ic-typography>
+      </div>
+      <div class="dynamic-container">
+        <div class="dynamic-field-container">
+          <div class="additional-field-wrapper">
+            <slot name="additional-field"></slot>
+          </div>
+        </div>
+      </div>
+    </template>
+    <div slot="additional-field">
+      <ic-text-field class="ic-text-field-disabled" disabled="true" label="Test label" placeholder="Placeholder" value="">
+        <template shadowrootmode="open">
+          <ic-input-container disabled="">
+            <ic-input-label disabled="" for="ic-text-field-input-3" helpertext="" label="Test label"></ic-input-label>
+            <ic-input-component-container disabled="" size="medium" validationstatus="">
+              <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-text-field-input-3" inputmode="text" name="ic-text-field-input-3" placeholder="Placeholder" type="text" value="">
+            </ic-input-component-container>
+          </ic-input-container>
+        </template>
+        <input class="ic-input" disabled="" name="ic-text-field-input-3" type="hidden" value="">
+      </ic-text-field>
+      <ic-text-field class="ic-text-field-disabled" disabled="true" label="Test label" placeholder="Placeholder" value="">
+        <template shadowrootmode="open">
+          <ic-input-container disabled="">
+            <ic-input-label disabled="" for="ic-text-field-input-4" helpertext="" label="Test label"></ic-input-label>
+            <ic-input-component-container disabled="" size="medium" validationstatus="">
+              <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-text-field-input-4" inputmode="text" name="ic-text-field-input-4" placeholder="Placeholder" type="text" value="">
+            </ic-input-component-container>
+          </ic-input-container>
+        </template>
+        <input class="ic-input" disabled="" name="ic-text-field-input-4" type="hidden" value="">
+      </ic-text-field>
+    </div>
   </ic-checkbox>
 </ic-checkbox-group>
 `;
@@ -431,7 +421,7 @@ exports[`ic-checkbox-group should render with dynamic additional field when chec
       </div>
       <div class="dynamic-container" style="display: flex;">
         <div class="branch-corner"></div>
-        <div>
+        <div class="dynamic-field-container">
           <ic-typography variant="caption">
             <p aria-live="polite" class="dynamic-text">
               This selection requires additional answers
@@ -484,7 +474,7 @@ exports[`ic-checkbox-group should render with hidden dynamic additional field: r
       </div>
       <div class="dynamic-container" style="display: none;">
         <div class="branch-corner"></div>
-        <div>
+        <div class="dynamic-field-container">
           <ic-typography variant="caption">
             <p aria-live="polite" class="dynamic-text">
               This selection requires additional answers
@@ -562,6 +552,109 @@ exports[`ic-checkbox-group should render: renders 1`] = `
         </ic-typography>
       </div>
     </template>
+  </ic-checkbox>
+</ic-checkbox-group>
+`;
+
+exports[`ic-checkbox-group should set disabled attribute to false on static additional field when checked: renders-with-disabled-attribute-removed-from-field 1`] = `
+<ic-checkbox-group class="ic-checkbox-group-medium" hide-label="" label="test label" name="test" validation-status="error">
+  <template shadowrootmode="open">
+    <span aria-hidden="true" class="screen-reader-only-text" id="screenReaderOnlyText">
+      test label invalid data
+    </span>
+    <fieldset aria-labelledby="screenReaderOnlyText test-validation-text" id="test">
+      <div class="checkboxes-container">
+        <slot></slot>
+      </div>
+    </fieldset>
+    <ic-input-validation arialivemode="polite" for="test" message="" status="error"></ic-input-validation>
+  </template>
+  <ic-checkbox additional-field-display="static" checked="" class="ic-checkbox-medium" label="test label" value="test">
+    <template shadowrootmode="open">
+      <div class="container">
+        <svg class="checkmark" clip-rule="evenodd" fill-rule="evenodd" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <title>
+            checkmark icon
+          </title>
+          <path d="M21 6.285l-11.16 12.733-6.84-6.018 1.319-1.49 5.341 4.686 9.865-11.196 1.475 1.285z"></path>
+        </svg>
+        <input checked="" class="checkbox checked" id="ic-checkbox-test-label-test-label" name="test" role="checkbox" type="checkbox" value="test">
+        <ic-typography class="checkbox-label" variant="body">
+          <label htmlfor="ic-checkbox-test-label-test-label">
+            test label
+          </label>
+        </ic-typography>
+      </div>
+      <div class="dynamic-container">
+        <div class="dynamic-field-container">
+          <div class="additional-field-wrapper">
+            <slot name="additional-field"></slot>
+          </div>
+        </div>
+      </div>
+    </template>
+    <ic-text-field disabled="false" label="Test label" placeholder="Placeholder" slot="additional-field" value="">
+      <template shadowrootmode="open">
+        <ic-input-container>
+          <ic-input-label for="ic-text-field-input-5" helpertext="" label="Test label"></ic-input-label>
+          <ic-input-component-container size="medium" validationstatus="">
+            <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-5" inputmode="text" name="ic-text-field-input-5" placeholder="Placeholder" type="text" value="">
+          </ic-input-component-container>
+        </ic-input-container>
+      </template>
+      <input class="ic-input" name="ic-text-field-input-5" type="hidden" value="">
+    </ic-text-field>
+    <input class="ic-input" name="test" type="hidden" value="test">
+  </ic-checkbox>
+  <ic-checkbox additional-field-display="static" checked="" class="ic-checkbox-medium" label="test label" value="test2">
+    <template shadowrootmode="open">
+      <div class="container">
+        <svg class="checkmark" clip-rule="evenodd" fill-rule="evenodd" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <title>
+            checkmark icon
+          </title>
+          <path d="M21 6.285l-11.16 12.733-6.84-6.018 1.319-1.49 5.341 4.686 9.865-11.196 1.475 1.285z"></path>
+        </svg>
+        <input checked="" class="checkbox checked" id="ic-checkbox-test-label-test-label" name="test" role="checkbox" type="checkbox" value="test2">
+        <ic-typography class="checkbox-label" variant="body">
+          <label htmlfor="ic-checkbox-test-label-test-label">
+            test label
+          </label>
+        </ic-typography>
+      </div>
+      <div class="dynamic-container">
+        <div class="dynamic-field-container">
+          <div class="additional-field-wrapper">
+            <slot name="additional-field"></slot>
+          </div>
+        </div>
+      </div>
+    </template>
+    <div slot="additional-field">
+      <ic-text-field disabled="false" label="Test label" placeholder="Placeholder" value="">
+        <template shadowrootmode="open">
+          <ic-input-container>
+            <ic-input-label for="ic-text-field-input-6" helpertext="" label="Test label"></ic-input-label>
+            <ic-input-component-container size="medium" validationstatus="">
+              <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-6" inputmode="text" name="ic-text-field-input-6" placeholder="Placeholder" type="text" value="">
+            </ic-input-component-container>
+          </ic-input-container>
+        </template>
+        <input class="ic-input" name="ic-text-field-input-6" type="hidden" value="">
+      </ic-text-field>
+      <ic-text-field disabled="false" label="Test label" placeholder="Placeholder" value="">
+        <template shadowrootmode="open">
+          <ic-input-container>
+            <ic-input-label for="ic-text-field-input-7" helpertext="" label="Test label"></ic-input-label>
+            <ic-input-component-container size="medium" validationstatus="">
+              <input aria-describedby="" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-7" inputmode="text" name="ic-text-field-input-7" placeholder="Placeholder" type="text" value="">
+            </ic-input-component-container>
+          </ic-input-container>
+        </template>
+        <input class="ic-input" name="ic-text-field-input-7" type="hidden" value="">
+      </ic-text-field>
+    </div>
+    <input class="ic-input" name="test" type="hidden" value="test2">
   </ic-checkbox>
 </ic-checkbox-group>
 `;

--- a/packages/web-components/src/components/ic-checkbox-group/test/basic/ic-checkbox-group.spec.ts
+++ b/packages/web-components/src/components/ic-checkbox-group/test/basic/ic-checkbox-group.spec.ts
@@ -150,20 +150,35 @@ describe("ic-checkbox-group", () => {
       components: [CheckboxGroup, Checkbox, TextField],
       html: `<ic-checkbox-group label="test label" hide-label name="test" validation-status="error">
         <ic-checkbox value="test" label="test label" additional-field-display="static">
-        <ic-text-field slot="additional-field" placeholder="Placeholder" label="Test label"></ic-text-field>
+          <ic-text-field slot="additional-field" placeholder="Placeholder" label="Test label"></ic-text-field>
+        </ic-checkbox>
+        <ic-checkbox value="test2" label="test label" additional-field-display="static">
+          <div slot="additional-field">
+          <ic-text-field placeholder="Placeholder" label="Test label"></ic-text-field>
+          <ic-text-field placeholder="Placeholder" label="Test label"></ic-text-field>
         </ic-checkbox>
       </ic-checkbox-group>`,
     });
 
     expect(page.root).toMatchSnapshot("renders-with-disabled-additional-field");
+
+    const textfieldElements = document.querySelectorAll("ic-text-field");
+    textfieldElements.forEach((textfield) => {
+      expect(textfield.disabled).toBe(true);
+    });
   });
 
-  it("should remove disabled attribute from static additional field when checked", async () => {
+  it("should set disabled attribute to false on static additional field when checked", async () => {
     const page = await newSpecPage({
       components: [CheckboxGroup, Checkbox, TextField],
       html: `<ic-checkbox-group label="test label" hide-label name="test" validation-status="error">
-        <ic-checkbox value="test" label="test label" additional-field-display="static" checked>
-        <ic-text-field slot="additional-field" placeholder="Placeholder" label="Test label"></ic-text-field>
+        <ic-checkbox value="test" label="test label" checked additional-field-display="static">
+          <ic-text-field slot="additional-field" placeholder="Placeholder" label="Test label"></ic-text-field>
+        </ic-checkbox>
+        <ic-checkbox value="test2" label="test label" checked additional-field-display="static">
+          <div slot="additional-field">
+          <ic-text-field placeholder="Placeholder" label="Test label"></ic-text-field>
+          <ic-text-field placeholder="Placeholder" label="Test label"></ic-text-field>
         </ic-checkbox>
       </ic-checkbox-group>`,
     });
@@ -171,6 +186,11 @@ describe("ic-checkbox-group", () => {
     expect(page.root).toMatchSnapshot(
       "renders-with-disabled-attribute-removed-from-field"
     );
+
+    const textfieldElements = document.querySelectorAll("ic-text-field");
+    textfieldElements.forEach((textfield) => {
+      expect(textfield.disabled).toBe(false);
+    });
   });
 
   it("should pass the size on the checkbox group to the child checkboxes when there's no size set on them individually", async () => {

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
@@ -214,9 +214,17 @@
   border-radius: 2%;
 }
 
+.dynamic-field-container {
+  flex: 100%;
+}
+
 @media (max-width: 576px) {
-  ::slotted(ic-text-field) {
+  ::slotted(*) {
     --input-width: 100%;
+  }
+
+  .dynamic-field-container {
+    flex: initial;
   }
 }
 

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -155,12 +155,10 @@ export class Checkbox {
 
   componentDidRender(): void {
     if (this.additionalFieldDisplay === "static") {
-      const textfield = this.el.querySelector("ic-text-field");
-      if (!this.checked) {
-        textfield?.setAttribute("disabled", "");
-      } else {
-        textfield?.removeAttribute("disabled");
-      }
+      const textfieldElements = this.el.querySelectorAll("ic-text-field");
+      textfieldElements.forEach((textfield) =>
+        textfield.setAttribute("disabled", this.checked ? "false" : "true")
+      );
     } else if (this.additionalFieldContainer) {
       this.additionalFieldContainer.style.display = !this.checked
         ? "none"
@@ -274,7 +272,7 @@ export class Checkbox {
             ref={(el) => (this.additionalFieldContainer = el)}
           >
             {isDynamicAdditionalField && <div class="branch-corner"></div>}
-            <div>
+            <div class="dynamic-field-container">
               {isDynamicAdditionalField && (
                 <ic-typography variant="caption">
                   <p class="dynamic-text" aria-live="polite">


### PR DESCRIPTION
… fix disabled textfield bug

Horizontal radio group variant displays correctly when nested inside a checkbox. Fix bug that causes only the first text field nested inside a checkbox to be in the disabled state when the checkbox is unchecked.

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

### Previous behaviour

- A nested radio always appears as the vertical variant
- If multiple textfields are nested under the same checkbox and the checkbox is unchecked, only the first is in the disabled state

![previous behaviour of checkboxes with nested radio groups and textfields at large viewport widths](https://github.com/user-attachments/assets/43751b4f-7846-4030-b848-5a35cc8e2fda)


### New behaviour

All nested textfields are disabled when the parent checkbox is unchecked
![All nested textfields are disabled when the parent checkbox is unchecked](https://github.com/user-attachments/assets/919370ff-643d-48e7-8e61-2714ded6dced)


#### Large viewport widths
![New behaviour at large viewport widths - radio groups in horizontal variant (conditional static)](https://github.com/user-attachments/assets/09354846-0fa7-4f60-a697-1261f8ca5d87)
![New behaviour at large viewport widths - radio groups in horizontal variant (conditional dynamic)](https://github.com/user-attachments/assets/9f2683f8-3df8-4748-8660-f5553c918f89)


#### Medium viewport widths
![New behaviour at medium viewport widths - radio groups with longer options in vertical variant (conditional static)](https://github.com/user-attachments/assets/4a9d50b5-e4c3-48a1-b1a2-7e5499ee3cb1)

#### Small viewport widths
![New behaviour at small viewport widths - all radio groups in vertical variant (conditional static)](https://github.com/user-attachments/assets/5ef67cbd-cc03-4cc2-bc7b-dbf941ab5492)
![New behaviour at small viewport widths - all radio groups in vertical variant (conditional dynamic) ](https://github.com/user-attachments/assets/01465bcf-52af-4f35-8120-2e81aed87387)





## Related issue
Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.