### PR TITLE
2541 icselect dropdown not visible in expanded accordion

### DIFF
--- a/packages/react/src/stories/ic-accordion.stories.js
+++ b/packages/react/src/stories/ic-accordion.stories.js
@@ -451,7 +451,7 @@ export const Disabled = {
 export const WithPopoverContent = {
   render: () => (
     <>
-      <IcAccordion heading="With Select">
+      <IcAccordion expanded heading="With Select">
       <IcSelect
         label="What is your favourite coffee?"
         options={[

--- a/packages/web-components/src/components/ic-accordion/ic-accordion.stories.js
+++ b/packages/web-components/src/components/ic-accordion/ic-accordion.stories.js
@@ -346,7 +346,7 @@ export const Disabled = {
 
 export const WithPopoverContent = {
   render: () => html`
-    <ic-accordion heading="With Select">
+    <ic-accordion expanded="true" heading="With Select">
       <ic-select
         id="select-1"
         label="What is your favourite coffee?"

--- a/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
+++ b/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
@@ -14,6 +14,7 @@ import chevronIcon from "../../assets/chevron-icon.svg";
 import { IcSizes, IcThemeMode } from "../../utils/types";
 
 let accordionIds = 0;
+const EXPANDED_CONTENT_OPENED_CLASS = "expanded-content-opened";
 
 /**
  * @slot heading - Content is placed as the accordion heading.
@@ -114,6 +115,7 @@ export class Accordion {
         this.CONTENT_VISIBILITY_PROPERTY,
         "visible"
       );
+      this.expandedContentEl.classList.add(EXPANDED_CONTENT_OPENED_CLASS);
     }
   }
 
@@ -139,7 +141,7 @@ export class Accordion {
     expandedContent: HTMLDivElement
   ) => {
     if (ev.propertyName === "height" && expandedContent.clientHeight > 0) {
-      expandedContent.classList.add("expanded-content-opened");
+      expandedContent.classList.add(EXPANDED_CONTENT_OPENED_CLASS);
       expandedContent.style.height = "auto";
     }
   };
@@ -190,7 +192,7 @@ export class Accordion {
             "height",
             "ease-in"
           );
-          expandedContentEl.classList.remove("expanded-content-opened");
+          expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
         }
         expandedContentEl.addEventListener("transitionend", (e) => {
           this.hideExpandedContent(e, expandedContentEl);


### PR DESCRIPTION
## Summary of the changes
I've modified the Accordion Popover Content stories in Web Components and React to have their first accordion expanded on first render, where you can test that the popover (in this case an Ic-Select) does render outside the accordion. 

## Related issue
#2541 

## Checklist

### Testing

- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

