### PR TITLE
fix(web-components): update ariaExpanded from on ic-text-field to use correct type

### DIFF
--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -2070,7 +2070,7 @@ export namespace Components {
     interface IcTextField {
         "ariaActiveDescendant"?: string;
         "ariaAutocomplete"?: IcAriaAutocompleteTypes;
-        "ariaExpanded": string | undefined;
+        "ariaExpanded": string | null;
         "ariaOwns"?: string;
         /**
           * The automatic capitalisation of the text value as it is entered/edited by the user. Available options: "off", "none", "on", "sentences", "words", "characters".
@@ -2177,7 +2177,7 @@ export namespace Components {
           * If `true`, the multiline text area will be resizeable.
          */
         "resize": boolean;
-        "role": string | undefined;
+        "role": string | null;
         /**
           * The number of rows to transform the text field into a text area with a specific height.
          */
@@ -5602,7 +5602,7 @@ declare namespace LocalJSX {
     interface IcTextField {
         "ariaActiveDescendant"?: string;
         "ariaAutocomplete"?: IcAriaAutocompleteTypes;
-        "ariaExpanded"?: string | undefined;
+        "ariaExpanded"?: string | null;
         "ariaOwns"?: string;
         /**
           * The automatic capitalisation of the text value as it is entered/edited by the user. Available options: "off", "none", "on", "sentences", "words", "characters".
@@ -5734,7 +5734,7 @@ declare namespace LocalJSX {
           * If `true`, the multiline text area will be resizeable.
          */
         "resize"?: boolean;
-        "role"?: string | undefined;
+        "role"?: string | null;
         /**
           * The number of rows to transform the text field into a text area with a specific height.
          */

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -90,7 +90,7 @@ export class TextField {
   /**
    * @internal Used to identify if the slotted menu is rendered
    */
-  @Prop() ariaExpanded: string | undefined;
+  @Prop() ariaExpanded: string | null;
 
   /**
    * @internal Used to identify any related child component
@@ -240,7 +240,7 @@ export class TextField {
   /**
    * @internal Used to set the role if not default textbox;
    */
-  @Prop() role: string | undefined;
+  @Prop() role: string | null;
 
   /**
    * The number of rows to transform the text field into a text area with a specific height.
@@ -722,7 +722,7 @@ export class TextField {
                 autocapitalize={autocapitalize}
                 spellcheck={spellcheck}
                 inputmode={inputmode}
-                role={role}
+                role={role || undefined}
                 maxlength={maxCharactersReached ? maxCharacters : undefined}
                 minlength={minCharactersUnattained ? minCharacters : undefined}
                 {...inheritedAttributes}

--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -8,7 +8,6 @@
     "jsxFactory": "h",
     "strict": true,
     "strictPropertyInitialization": false,
-    "skipLibCheck": true
   },
   "include": ["src", "./node.d.ts"],
   "exclude": ["node_modules", "src/testa11y.setup.ts"]


### PR DESCRIPTION
## Summary of the changes
Updated `ariaExpanded` and `role` prop types on ic-text-field to match types of equivalent `HTMLElement` attributes.

Removed "skipLibCheck" from the tsconfig, which was added to suppress a TypeScript strict mode error regarding this issue - I wasn't sure how to resolve it originally (when I implemented strict mode)

Related to issue mentioned by a customer

## Related issue
N/A
