### PR TITLE
fix(web-components): ensure ic-text-field remaining characters only a…

### DIFF
--- a/packages/web-components/src/components/ic-hero/ic-hero.css
+++ b/packages/web-components/src/components/ic-hero/ic-hero.css
@@ -182,6 +182,7 @@ ic-typography.heading-bottom-spacing {
   :host(.has-right-content) .section-container {
     flex-wrap: wrap;
   }
+
   :host(.has-right-content) .left-container {
     flex-basis: 100%;
   }

--- a/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
+++ b/packages/web-components/src/components/ic-text-field/ic-text-field.tsx
@@ -70,6 +70,7 @@ export class TextField {
   @State() minCharactersUnattained: boolean = false;
   @State() maxValueExceeded: boolean = false;
   @State() minValueUnattained: boolean = false;
+  @State() isFocussed: boolean = false;
 
   /**
    * @slot clear-button - an ic-button clear component will render as an end adornment to the input.
@@ -486,12 +487,14 @@ export class TextField {
     this.minCharactersUnattained =
       this.minCharacters > 0 && this.numChars < this.minCharacters;
     this.icBlur.emit({ value });
+    this.isFocussed = false;
   };
 
   private onFocus = (ev: Event) => {
     const target = ev.target as HTMLInputElement;
     target.addEventListener("wheel", this.onWheel);
     this.icFocus.emit({ value: target.value });
+    this.isFocussed = true;
   };
 
   private onTextAreaScroll = () => {
@@ -588,6 +591,7 @@ export class TextField {
       ariaOwns,
       autocomplete,
       role,
+      isFocussed,
     } = this;
 
     const el = this.el as HTMLElement;
@@ -630,11 +634,19 @@ export class TextField {
 
     const multiline = rows > 1;
 
-    const charsRemaining = maxNumChars - numChars;
     const hiddenCharCountDescId =
       maxCharacters > 0 ? `${inputId}-char-count-desc` : "";
 
-    const describedBy = `${hiddenCharCountDescId} ${getInputDescribedByText(
+    const charsRemaining = maxNumChars - numChars;
+    const remainingCharCountDescId =
+      maxCharacters > 0 ? `${inputId}-remaining-char-count-desc` : "";
+    const remainingCharCountDesc = `${charsRemaining} character${
+      charsRemaining === 1 ? "" : "s"
+    } remaining.`;
+
+    const describedBy = `${hiddenCharCountDescId} ${
+      numChars > 0 ? remainingCharCountDescId : ""
+    } ${getInputDescribedByText(
       inputId,
       helperText !== "",
       showStatusText
@@ -797,10 +809,13 @@ export class TextField {
                         </span>
                       </ic-typography>
                     )}
-                    <span class="remaining-char-count-desc" aria-live="polite">
-                      {`${charsRemaining} character${
-                        charsRemaining === 1 ? "" : "s"
-                      } remaining.`}
+                    <span
+                      class="remaining-char-count-desc"
+                      aria-live="polite"
+                      hidden={!isFocussed}
+                      id={remainingCharCountDescId}
+                    >
+                      {remainingCharCountDesc}
                     </span>
                     <span hidden={true} id={hiddenCharCountDescId}>
                       Field can contain a maximum of {maxNumChars} characters.

--- a/packages/web-components/src/components/ic-text-field/test/basic/__snapshots__/ic-text-field.input.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-text-field/test/basic/__snapshots__/ic-text-field.input.spec.tsx.snap
@@ -170,7 +170,7 @@ exports[`ic-text-field should render with max characters and a value set which e
     <ic-input-container>
       <ic-input-label for="ic-text-field-input-11" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container size="medium" validationstatus="">
-        <input aria-describedby="ic-text-field-input-11-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-11" inputmode="text" maxlength="25" name="ic-text-field-input-11" placeholder="" type="text" value="A long value which exceed">
+        <input aria-describedby="ic-text-field-input-11-char-count-desc ic-text-field-input-11-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-11" inputmode="text" maxlength="25" name="ic-text-field-input-11" placeholder="" type="text" value="A long value which exceed">
       </ic-input-component-container>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-11" message="" status="">
         <div slot="validation-message-adornment">
@@ -179,7 +179,7 @@ exports[`ic-text-field should render with max characters and a value set which e
               25/25
             </span>
           </ic-typography>
-          <span aria-live="polite" class="remaining-char-count-desc">
+          <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-11-remaining-char-count-desc">
             0 characters remaining.
           </span>
           <span hidden="" id="ic-text-field-input-11-char-count-desc">
@@ -199,7 +199,7 @@ exports[`ic-text-field should render with max characters and a value set which e
     <ic-input-container>
       <ic-input-label for="ic-text-field-input-13" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container size="medium" validationstatus="">
-        <input aria-describedby="ic-text-field-input-13-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-13" inputmode="text" maxlength="25" name="ic-text-field-input-13" placeholder="" type="text" value="A long value which exceed">
+        <input aria-describedby="ic-text-field-input-13-char-count-desc ic-text-field-input-13-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-13" inputmode="text" maxlength="25" name="ic-text-field-input-13" placeholder="" type="text" value="A long value which exceed">
       </ic-input-component-container>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-13" message="" status="">
         <div slot="validation-message-adornment">
@@ -208,7 +208,7 @@ exports[`ic-text-field should render with max characters and a value set which e
               25/25
             </span>
           </ic-typography>
-          <span aria-live="polite" class="remaining-char-count-desc">
+          <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-13-remaining-char-count-desc">
             0 characters remaining.
           </span>
           <span hidden="" id="ic-text-field-input-13-char-count-desc">
@@ -228,11 +228,11 @@ exports[`ic-text-field should render with max characters and hidden character co
     <ic-input-container>
       <ic-input-label for="ic-text-field-input-10" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container size="medium" validationstatus="">
-        <input aria-describedby="ic-text-field-input-10-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-10" inputmode="text" name="ic-text-field-input-10" placeholder="" type="text" value="Test value">
+        <input aria-describedby="ic-text-field-input-10-char-count-desc ic-text-field-input-10-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-10" inputmode="text" name="ic-text-field-input-10" placeholder="" type="text" value="Test value">
       </ic-input-component-container>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-10" message="" status="">
         <div slot="validation-message-adornment">
-          <span aria-live="polite" class="remaining-char-count-desc">
+          <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-10-remaining-char-count-desc">
             15 characters remaining.
           </span>
           <span hidden="" id="ic-text-field-input-10-char-count-desc">
@@ -252,11 +252,11 @@ exports[`ic-text-field should render with max characters and hidden character co
     <ic-input-container>
       <ic-input-label for="ic-text-field-input-12" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container size="medium" validationstatus="">
-        <input aria-describedby="ic-text-field-input-12-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-12" inputmode="text" name="ic-text-field-input-12" placeholder="" type="text" value="Test value">
+        <input aria-describedby="ic-text-field-input-12-char-count-desc ic-text-field-input-12-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-12" inputmode="text" name="ic-text-field-input-12" placeholder="" type="text" value="Test value">
       </ic-input-component-container>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-12" message="" status="">
         <div slot="validation-message-adornment">
-          <span aria-live="polite" class="remaining-char-count-desc">
+          <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-12-remaining-char-count-desc">
             15 characters remaining.
           </span>
           <span hidden="" id="ic-text-field-input-12-char-count-desc">
@@ -276,7 +276,7 @@ exports[`ic-text-field should render with max characters: renders-with-max-chara
     <ic-input-container>
       <ic-input-label for="ic-text-field-input-9" helpertext="" label="Test label"></ic-input-label>
       <ic-input-component-container size="medium" validationstatus="">
-        <input aria-describedby="ic-text-field-input-9-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-9" inputmode="text" name="ic-text-field-input-9" placeholder="" type="text" value="Test value">
+        <input aria-describedby="ic-text-field-input-9-char-count-desc ic-text-field-input-9-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-text-field-input-9" inputmode="text" name="ic-text-field-input-9" placeholder="" type="text" value="Test value">
       </ic-input-component-container>
       <ic-input-validation arialivemode="polite" for="ic-text-field-input-9" message="" status="">
         <div slot="validation-message-adornment">
@@ -285,7 +285,7 @@ exports[`ic-text-field should render with max characters: renders-with-max-chara
               10/25
             </span>
           </ic-typography>
-          <span aria-live="polite" class="remaining-char-count-desc">
+          <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-9-remaining-char-count-desc">
             15 characters remaining.
           </span>
           <span hidden="" id="ic-text-field-input-9-char-count-desc">

--- a/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.textarea.spec.tsx
+++ b/packages/web-components/src/components/ic-text-field/test/basic/ic-text-field.textarea.spec.tsx
@@ -213,7 +213,7 @@ describe("ic-text-field", () => {
         <mock:shadow-root>
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-9" helpertext="" label="Test label"></ic-input-label>
-            <ic-input-component-container multiline="" size="medium" validationstatus=""><textarea aria-describedby="ic-text-field-input-9-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-9" inputmode="text" name="ic-text-field-input-9" placeholder="" rows="6" value="Test value"></textarea>
+            <ic-input-component-container multiline="" size="medium" validationstatus=""><textarea aria-describedby="ic-text-field-input-9-char-count-desc ic-text-field-input-9-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-9" inputmode="text" name="ic-text-field-input-9" placeholder="" rows="6" value="Test value"></textarea>
             </ic-input-component-container>
             <ic-input-validation arialivemode="polite" for="ic-text-field-input-9" message="" status="">
               <div slot="validation-message-adornment">
@@ -222,7 +222,7 @@ describe("ic-text-field", () => {
                     10/25
                   </span>
                 </ic-typography>
-                <span aria-live="polite" class="remaining-char-count-desc">
+                <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-9-remaining-char-count-desc">
                   15 characters remaining.
                 </span>
                 <span hidden="" id="ic-text-field-input-9-char-count-desc">
@@ -248,11 +248,11 @@ describe("ic-text-field", () => {
         <mock:shadow-root>
           <ic-input-container>
             <ic-input-label for="ic-text-field-input-10" helpertext="" label="Test label"></ic-input-label>
-            <ic-input-component-container multiline="" size="medium" validationstatus=""><textarea aria-describedby="ic-text-field-input-10-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-10" inputmode="text" name="ic-text-field-input-10" placeholder="" rows="6" value="Test value"></textarea>
+            <ic-input-component-container multiline="" size="medium" validationstatus=""><textarea aria-describedby="ic-text-field-input-10-char-count-desc ic-text-field-input-10-remaining-char-count-desc" aria-invalid="false" aria-label="Test label" autocapitalize="off" class="no-resize" id="ic-text-field-input-10" inputmode="text" name="ic-text-field-input-10" placeholder="" rows="6" value="Test value"></textarea>
             </ic-input-component-container>
             <ic-input-validation arialivemode="polite" for="ic-text-field-input-10" message="" status="">
               <div slot="validation-message-adornment">
-                <span aria-live="polite" class="remaining-char-count-desc">
+                <span aria-live="polite" class="remaining-char-count-desc" hidden="" id="ic-text-field-input-10-remaining-char-count-desc">
                   15 characters remaining.
                 </span>
                 <span hidden="" id="ic-text-field-input-10-char-count-desc">


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
See [v2 pr](https://github.com/mi6/ic-ui-kit/pull/3575).

Fix and improve text field character limit screen reader announcements.

## Related issue
#3354 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.