### PR TITLE
fix(web-components): manually focus ic-button on click

### DIFF
--- a/packages/web-components/src/components/ic-back-to-top/test/basic/__snapshots__/ic-back-to-top.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-back-to-top/test/basic/__snapshots__/ic-back-to-top.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`ic-back-to-top should render positioned in the centre 1`] = `
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>
@@ -23,7 +23,7 @@ exports[`ic-back-to-top should render positioned on the left 1`] = `
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>
@@ -41,7 +41,7 @@ exports[`ic-back-to-top should render when target starts with #: should render w
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>
@@ -60,7 +60,7 @@ exports[`ic-back-to-top should render with an icon only: should render with an i
     <ic-button class="ic-button-size-large ic-button-variant-icon-secondary icon-only" exportparts="button">
       <template shadowrootmode="open">
         <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-12" label="Back to top" placement="bottom" silent="" target="ic-button-with-tooltip-12">
-          <button aria-describedby="ic-tooltip-ic-button-with-tooltip-12" aria-label="Back to top" class="button" part="button" type="button">
+          <button aria-describedby="ic-tooltip-ic-button-with-tooltip-12" aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </ic-tooltip>
@@ -78,7 +78,7 @@ exports[`ic-back-to-top should render with dark theme: should render with dark t
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary ic-theme-dark" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>
@@ -99,7 +99,7 @@ exports[`ic-back-to-top should render with footer: should render with footer 1`]
       <template shadowrootmode="open">
         <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
           <template shadowrootmode="open">
-            <button aria-label="Back to top" class="button" part="button" type="button">
+            <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -136,7 +136,7 @@ exports[`ic-back-to-top should render with light theme: should render with light
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary ic-theme-light" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>
@@ -154,7 +154,7 @@ exports[`ic-back-to-top should render with no targetId set: should render with n
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>
@@ -172,7 +172,7 @@ exports[`ic-back-to-top should render: should render 1`] = `
   <template shadowrootmode="open">
     <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
       <template shadowrootmode="open">
-        <button aria-label="Back to top" class="button" part="button" type="button">
+        <button aria-label="Back to top" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>

--- a/packages/web-components/src/components/ic-badge/test/basic/__snapshots__/ic-badge.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-badge/test/basic/__snapshots__/ic-badge.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`ic-badge should render custom variant with custom colour in hex: should
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -23,7 +23,7 @@ exports[`ic-badge should render custom variant with custom colour in rgb: should
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -42,7 +42,7 @@ exports[`ic-badge should render error variant: should render error variant 1`] =
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -61,7 +61,7 @@ exports[`ic-badge should render info variant: should render info variant 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -80,7 +80,7 @@ exports[`ic-badge should render light variant: should render light variant 1`] =
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -99,7 +99,7 @@ exports[`ic-badge should render size large: should render size large 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -118,7 +118,7 @@ exports[`ic-badge should render size small: should render size small 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -343,7 +343,7 @@ exports[`ic-badge should render success variant: should render success variant 1
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -362,7 +362,7 @@ exports[`ic-badge should render type dot: should render type dot 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -381,7 +381,7 @@ exports[`ic-badge should render type icon: should render type icon 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -402,7 +402,7 @@ exports[`ic-badge should render warning variant: should render warning variant 1
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -421,7 +421,7 @@ exports[`ic-badge should render with accessible label: should render with access
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -440,7 +440,7 @@ exports[`ic-badge should render with id set: should render with id 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -459,7 +459,7 @@ exports[`ic-badge should render with max number prop set: should render with max
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -478,7 +478,7 @@ exports[`ic-badge should render with text slotted in a button: should render wit
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -497,7 +497,7 @@ exports[`ic-badge should render with visible false: should render with visible f
 <ic-button class="ic-button-size-medium ic-button-variant-primary with-badge" exportparts="button">
   <template shadowrootmode="open">
     <slot name="badge"></slot>
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>

--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -610,6 +610,7 @@ export class Button {
       ) : (
         <TagType
           class="button"
+          tabindex={0}
           aria-disabled={loading || disabled ? "true" : null}
           aria-label={loading ? "Loading" : ariaLabel}
           aria-expanded={dropdown && `${dropdownExpanded}`}

--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`button component render with correct button type when defined 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button" type="reset">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="reset">
+    <button class="button" part="button" tabindex="0" type="reset">
       <slot></slot>
     </button>
   </template>
@@ -14,7 +14,7 @@ exports[`button component render with correct button type when defined 1`] = `
 exports[`button component should correctly render with custom text 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -25,7 +25,7 @@ exports[`button component should correctly render with custom text 1`] = `
 exports[`button component should correctly render with text 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -36,7 +36,7 @@ exports[`button component should correctly render with text 1`] = `
 exports[`button component should disable tooltip when prop set 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-icon" disable-tooltip="" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
-    <button aria-label="Tooltip text" class="button" part="button" type="button">
+    <button aria-label="Tooltip text" class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -47,7 +47,7 @@ exports[`button component should disable tooltip when prop set 1`] = `
 exports[`button component should render a 'file' type input when fileUpload prop is enabled 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button" file-upload="">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -59,7 +59,7 @@ exports[`button component should render a 'file' type input when fileUpload prop
 exports[`button component should render correct HTML for destructive variant 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-destructive" exportparts="button" variant="destructive">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -70,7 +70,7 @@ exports[`button component should render correct HTML for destructive variant 1`]
 exports[`button component should render correct HTML for secondary variant 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-secondary" exportparts="button" variant="secondary">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -81,7 +81,7 @@ exports[`button component should render correct HTML for secondary variant 1`] =
 exports[`button component should render correct HTML for tertiary variant 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-tertiary" exportparts="button" variant="tertiary">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -92,7 +92,7 @@ exports[`button component should render correct HTML for tertiary variant 1`] = 
 exports[`button component should render correct HTML when loading - destructive 1`] = `
 <ic-button class="ic-button-loading ic-button-size-medium ic-button-variant-destructive" exportparts="button" loading="" variant="destructive">
   <template shadowrootmode="open">
-    <button aria-disabled="true" aria-label="Loading" class="button" part="button" type="button">
+    <button aria-disabled="true" aria-label="Loading" class="button" part="button" tabindex="0" type="button">
       <div class="loading-container">
         <ic-loading-indicator theme="inherit" type="linear"></ic-loading-indicator>
       </div>
@@ -105,7 +105,7 @@ exports[`button component should render correct HTML when loading - destructive 
 exports[`button component should render correct HTML when loading - secondary 1`] = `
 <ic-button class="ic-button-loading ic-button-size-medium ic-button-variant-secondary" exportparts="button" loading="" variant="secondary">
   <template shadowrootmode="open">
-    <button aria-disabled="true" aria-label="Loading" class="button" part="button" type="button">
+    <button aria-disabled="true" aria-label="Loading" class="button" part="button" tabindex="0" type="button">
       <div class="loading-container">
         <ic-loading-indicator theme="inherit" type="linear"></ic-loading-indicator>
       </div>
@@ -118,7 +118,7 @@ exports[`button component should render correct HTML when loading - secondary 1`
 exports[`button component should render correct HTML when loading - tertiary 1`] = `
 <ic-button class="ic-button-loading ic-button-size-medium ic-button-variant-tertiary" exportparts="button" loading="" variant="tertiary">
   <template shadowrootmode="open">
-    <button aria-disabled="true" aria-label="Loading" class="button" part="button" type="button">
+    <button aria-disabled="true" aria-label="Loading" class="button" part="button" tabindex="0" type="button">
       <div class="loading-container">
         <ic-loading-indicator theme="inherit" type="linear"></ic-loading-indicator>
       </div>
@@ -131,7 +131,7 @@ exports[`button component should render correct HTML when loading - tertiary 1`]
 exports[`button component should render correct HTML when loading - theme light 1`] = `
 <ic-button class="ic-button-loading ic-button-size-medium ic-button-variant-primary ic-theme-light" exportparts="button" loading="" theme="light">
   <template shadowrootmode="open">
-    <button aria-disabled="true" aria-label="Loading" class="button" part="button" type="button">
+    <button aria-disabled="true" aria-label="Loading" class="button" part="button" tabindex="0" type="button">
       <div class="loading-container">
         <ic-loading-indicator theme="light" type="linear"></ic-loading-indicator>
       </div>
@@ -144,7 +144,7 @@ exports[`button component should render correct HTML when loading - theme light 
 exports[`button component should render correct HTML when loading 1`] = `
 <ic-button class="ic-button-loading ic-button-size-medium ic-button-variant-primary" exportparts="button" loading="">
   <template shadowrootmode="open">
-    <button aria-disabled="true" aria-label="Loading" class="button" part="button" type="button">
+    <button aria-disabled="true" aria-label="Loading" class="button" part="button" tabindex="0" type="button">
       <div class="loading-container">
         <ic-loading-indicator theme="inherit" type="linear"></ic-loading-indicator>
       </div>
@@ -177,7 +177,7 @@ exports[`button component should render correct HTML when using slotted content 
 exports[`button component should render correct HTML with left icon 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <div class="icon-container">
         <slot name="left-icon"></slot>
       </div>
@@ -195,7 +195,7 @@ exports[`button component should render correct HTML with left icon 1`] = `
 exports[`button component should render correct HTML with right icon 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button">
   <template shadowrootmode="open">
-    <button class="button" part="button" type="button">
+    <button class="button" part="button" tabindex="0" type="button">
       <slot></slot>
       <div class="icon-container right-icon">
         <slot name="right-icon"></slot>
@@ -221,7 +221,7 @@ exports[`button component should render icon variant with a tooltip 1`] = `
         </div>
         <slot></slot>
       </template>
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -243,7 +243,7 @@ exports[`button component should render icon variant with a tooltip based on ari
         </div>
         <slot></slot>
       </template>
-      <button aria-label="Tooltip text" class="button" part="button" type="button">
+      <button aria-label="Tooltip text" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -265,7 +265,7 @@ exports[`button component should render icon variant with a tooltip based on tit
         </div>
         <slot></slot>
       </template>
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -277,7 +277,7 @@ exports[`button component should render icon variant with a tooltip based on tit
 exports[`button component should render with "a" tag when href is passed 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button" href="#">
   <template shadowrootmode="open">
-    <a class="button" href="#" part="button">
+    <a class="button" href="#" part="button" tabindex="0">
       <slot></slot>
     </a>
   </template>
@@ -288,7 +288,7 @@ exports[`button component should render with "a" tag when href is passed 1`] = `
 exports[`button component should render with defined "a" tag props 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary" download="" exportparts="button" href="#" rel="nofollow" target="_blank">
   <template shadowrootmode="open">
-    <a class="button" download="" href="#" part="button" rel="nofollow" target="_blank">
+    <a class="button" download="" href="#" part="button" rel="nofollow" tabindex="0" target="_blank">
       <slot></slot>
     </a>
   </template>
@@ -299,7 +299,7 @@ exports[`button component should render with defined "a" tag props 1`] = `
 exports[`button component should test aria-describedby is set 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary ic-theme-dark monochrome" exportparts="button" id="ic-button">
   <template shadowrootmode="open">
-    <button aria-describedby="button-description" class="button" part="button" type="button">
+    <button aria-describedby="button-description" class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
     <span class="ic-button-describedby" id="button-description">
@@ -313,7 +313,7 @@ exports[`button component should test aria-describedby is set 1`] = `
 exports[`button component should test aria-describedby is updated 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary ic-theme-dark monochrome" exportparts="button" id="ic-button">
   <template shadowrootmode="open">
-    <button aria-describedby="button-description" class="button" part="button" type="button">
+    <button aria-describedby="button-description" class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
     <span class="ic-button-describedby" id="button-description">
@@ -327,7 +327,7 @@ exports[`button component should test aria-describedby is updated 1`] = `
 exports[`button component should test button as submit button on form 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-primary ic-theme-dark monochrome" exportparts="button" form="new-form" id="ic-button" type="submit">
   <template shadowrootmode="open">
-    <button class="button" form="new-form" part="button" type="submit">
+    <button class="button" form="new-form" part="button" tabindex="0" type="submit">
       <slot></slot>
     </button>
   </template>
@@ -339,7 +339,7 @@ exports[`button component should test tooltip visibility changes when disable to
 <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark monochrome" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
     <ic-tooltip label="Tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
-      <button aria-label="Tooltip text" class="button" part="button" type="button">
+      <button aria-label="Tooltip text" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -351,7 +351,7 @@ exports[`button component should test tooltip visibility changes when disable to
 exports[`button component should test tooltip visibility changes when disable tooltip prop changes 2`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark monochrome" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
-    <button aria-label="Tooltip text" class="button" part="button" type="button">
+    <button aria-label="Tooltip text" class="button" part="button" tabindex="0" type="button">
       <slot></slot>
     </button>
   </template>
@@ -363,7 +363,7 @@ exports[`button component should test tooltip visibility changes when disable to
 <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark monochrome" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
     <ic-tooltip label="Tooltip text" placement="bottom" silent="" target="ic-button-with-tooltip-test-button">
-      <button aria-label="Tooltip text" class="button" part="button" type="button">
+      <button aria-label="Tooltip text" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -376,7 +376,7 @@ exports[`button component should update aria-expanded when attribute changed 1`]
 <ic-button class="ic-button-size-medium ic-button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
     <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" placement="bottom" target="ic-button-with-tooltip-test-button">
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-expanded="false" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-expanded="false" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -389,7 +389,7 @@ exports[`button component should update aria-expanded when attribute changed 2`]
 <ic-button aria-expanded="true" class="ic-button-size-medium ic-button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
     <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" placement="bottom" target="ic-button-with-tooltip-test-button">
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-expanded="true" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" aria-expanded="true" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -411,7 +411,7 @@ exports[`button component should update aria-label when attribute changed 1`] = 
         </div>
         <slot></slot>
       </template>
-      <button aria-label="Tooltip text" class="button" part="button" type="button">
+      <button aria-label="Tooltip text" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -433,7 +433,7 @@ exports[`button component should update aria-label when attribute changed 2`] = 
         </div>
         <slot></slot>
       </template>
-      <button aria-label="New tooltip text" class="button" part="button" type="button">
+      <button aria-label="New tooltip text" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -446,7 +446,7 @@ exports[`button component should update tooltip label when title attribute chang
 <ic-button class="ic-button-size-medium ic-button-variant-icon" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">
     <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="Tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>
@@ -459,7 +459,7 @@ exports[`button component should update tooltip label when title attribute chang
 <ic-button class="ic-button-size-medium ic-button-variant-icon" exportparts="button" id="test-button" title="New tooltip text" variant="icon">
   <template shadowrootmode="open">
     <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-test-button" label="New tooltip text" placement="bottom" target="ic-button-with-tooltip-test-button">
-      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" type="button">
+      <button aria-describedby="ic-tooltip-ic-button-with-tooltip-test-button" class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </ic-tooltip>

--- a/packages/web-components/src/components/ic-dialog/test/basic/__snapshots__/ic-dialog.spec.ts.snap
+++ b/packages/web-components/src/components/ic-dialog/test/basic/__snapshots__/ic-dialog.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`ic-dialog component should render 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-0">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -62,7 +62,7 @@ exports[`ic-dialog component should render as large size 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-14">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -102,7 +102,7 @@ exports[`ic-dialog component should render as large size and disableWidthConstra
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-154">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -142,7 +142,7 @@ exports[`ic-dialog component should render as medium size 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-12">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -184,7 +184,7 @@ exports[`ic-dialog component should render with a label 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-2">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -258,7 +258,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-6">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -274,7 +274,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
       <div class="dialog-controls">
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-tertiary" exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -282,7 +282,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
         </ic-button>
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-primary" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -304,7 +304,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
   </ic-text-field>
   <ic-button class="ic-button-size-medium ic-button-variant-primary" exportparts="button">
     <template shadowrootmode="open">
-      <button class="button" part="button" type="button">
+      <button class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </template>
@@ -335,7 +335,7 @@ exports[`ic-dialog component should render with slotted controls 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-60">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -355,7 +355,7 @@ exports[`ic-dialog component should render with slotted controls 1`] = `
   </template>
   <ic-button class="ic-button-size-medium ic-button-variant-primary" data-gets-focus exportparts="button" onclick="alert('Confirmed!')" slot="dialog-controls" variant="primary">
     <template shadowrootmode="open">
-      <button class="button" part="button" type="button">
+      <button class="button" part="button" tabindex="0" type="button">
         <slot></slot>
       </button>
     </template>
@@ -386,7 +386,7 @@ exports[`ic-dialog component should render with the close button 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-132">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -402,7 +402,7 @@ exports[`ic-dialog component should render with the close button 1`] = `
       <div class="dialog-controls">
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-tertiary" exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -410,7 +410,7 @@ exports[`ic-dialog component should render with the close button 1`] = `
         </ic-button>
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-primary" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -444,7 +444,7 @@ exports[`ic-dialog component should render with two default buttons 1`] = `
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon" exportparts="button">
           <template shadowrootmode="open">
             <ic-tooltip label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-16">
-              <button aria-label="Dismiss" class="button" part="button" type="button">
+              <button aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -460,7 +460,7 @@ exports[`ic-dialog component should render with two default buttons 1`] = `
       <div class="dialog-controls">
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-tertiary" exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -468,7 +468,7 @@ exports[`ic-dialog component should render with two default buttons 1`] = `
         </ic-button>
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-primary" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -508,7 +508,7 @@ exports[`ic-dialog component should render without the close button 1`] = `
       <div class="dialog-controls">
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-tertiary" exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>
@@ -516,7 +516,7 @@ exports[`ic-dialog component should render without the close button 1`] = `
         </ic-button>
         <ic-button class="dialog-control-button ic-button-size-medium ic-button-variant-primary" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
-            <button class="button" part="button" type="button">
+            <button class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </template>

--- a/packages/web-components/src/components/ic-menu-item/test/basic/__snapshots__/ic-menu-item.spec.ts.snap
+++ b/packages/web-components/src/components/ic-menu-item/test/basic/__snapshots__/ic-menu-item.spec.ts.snap
@@ -98,7 +98,7 @@ exports[`menu item variants should render the toggle variant 1`] = `
   <template shadowrootmode="open">
     <ic-button aria-checked="false" class="ic-button-full-width ic-button-size-medium ic-button-variant-tertiary" exportparts="button" role="menuitemcheckbox">
       <template shadowrootmode="open">
-        <button aria-disabled="false" aria-label="Toggle variant" class="button" part="button" type="button">
+        <button aria-disabled="false" aria-label="Toggle variant" class="button" part="button" tabindex="0" type="button">
           <slot></slot>
         </button>
       </template>

--- a/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-navigation-menu/test/basic/__snapshots__/ic-navigation-menu.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`ic-navigation-menu should test slotted buttons: renders-with-slotted-bu
           <ic-button class="ic-button-size-large ic-button-variant-icon menu-close-button" exportparts="button" id="menu-close-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Close app menu" placement="bottom" silent="" target="ic-button-with-tooltip-menu-close-button">
-                <button aria-label="Close app menu" class="button" part="button" type="button">
+                <button aria-label="Close app menu" class="button" part="button" tabindex="0" type="button">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -80,7 +80,7 @@ exports[`ic-navigation-menu should test slotted buttons: renders-with-slotted-bu
       <ic-button appearance="light" class="ic-button-size-large ic-button-variant-icon ic-theme-light monochrome" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip label="button1" placement="bottom" silent="" target="ic-button-with-tooltip-2">
-            <button aria-label="button1" class="button" part="button" type="button">
+            <button aria-label="button1" class="button" part="button" tabindex="0" type="button">
               <div class="icon-container">
                 <slot name="left-icon"></slot>
               </div>
@@ -148,7 +148,7 @@ exports[`ic-navigation-menu should test slotted navigation and buttons: renders-
           <ic-button class="ic-button-size-large ic-button-variant-icon menu-close-button" exportparts="button" id="menu-close-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Close navigation menu" placement="bottom" silent="" target="ic-button-with-tooltip-menu-close-button">
-                <button aria-label="Close navigation menu" class="button" part="button" type="button">
+                <button aria-label="Close navigation menu" class="button" part="button" tabindex="0" type="button">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -182,7 +182,7 @@ exports[`ic-navigation-menu should test slotted navigation and buttons: renders-
       <ic-button appearance="light" class="ic-button-size-large ic-button-variant-icon ic-theme-light monochrome" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip label="button1" placement="bottom" silent="" target="ic-button-with-tooltip-6">
-            <button aria-label="button1" class="button" part="button" type="button">
+            <button aria-label="button1" class="button" part="button" tabindex="0" type="button">
               <div class="icon-container">
                 <slot name="left-icon"></slot>
               </div>

--- a/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`ic-search-bar search should render aria-label when hideLabel is set: re
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -23,7 +23,7 @@ exports[`ic-search-bar search should render aria-label when hideLabel is set: re
           <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -51,7 +51,7 @@ exports[`ic-search-bar search should render disabled variant: disabled-removed 1
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -64,7 +64,7 @@ exports[`ic-search-bar search should render disabled variant: disabled-removed 1
           <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -92,7 +92,7 @@ exports[`ic-search-bar search should render disabled variant: renders-disabled 1
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -105,7 +105,7 @@ exports[`ic-search-bar search should render disabled variant: renders-disabled 1
           <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -133,7 +133,7 @@ exports[`ic-search-bar search should render readonly variant: renders-readonly 1
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -146,7 +146,7 @@ exports[`ic-search-bar search should render readonly variant: renders-readonly 1
           <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -174,7 +174,7 @@ exports[`ic-search-bar search should render required variant: renders-required 1
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -187,7 +187,7 @@ exports[`ic-search-bar search should render required variant: renders-required 1
           <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -268,7 +268,7 @@ exports[`ic-search-bar search should render with helper-text: renders-with-helpe
             <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
               <template shadowrootmode="open">
                 <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                  <button aria-label="Clear" class="button" part="button" type="submit">
+                  <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                     <slot></slot>
                   </button>
                 </ic-tooltip>
@@ -281,7 +281,7 @@ exports[`ic-search-bar search should render with helper-text: renders-with-helpe
             <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-unfocused" exportparts="button" id="search-submit-button">
               <template shadowrootmode="open">
                 <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                  <button aria-label="Search" class="button" part="button" type="submit">
+                  <button aria-label="Search" class="button" part="button" tabindex="0" type="submit">
                     <slot></slot>
                   </button>
                 </ic-tooltip>
@@ -310,7 +310,7 @@ exports[`ic-search-bar search should render with options: renders-with-options 1
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -323,7 +323,7 @@ exports[`ic-search-bar search should render with options: renders-with-options 1
           <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-label="Search" class="button" part="button" type="submit">
+                <button aria-label="Search" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -351,7 +351,7 @@ exports[`ic-search-bar search should render with value: renders-with-value 1`] =
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -364,7 +364,7 @@ exports[`ic-search-bar search should render with value: renders-with-value 1`] =
           <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-label="Search" class="button" part="button" type="submit">
+                <button aria-label="Search" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -392,7 +392,7 @@ exports[`ic-search-bar search should render: renders 1`] = `
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Clear" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                <button aria-label="Clear" class="button" part="button" type="submit">
+                <button aria-label="Clear" class="button" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>
@@ -405,7 +405,7 @@ exports[`ic-search-bar search should render: renders 1`] = `
           <ic-button class="ic-button-disabled ic-button-size-medium ic-button-variant-icon ic-theme-dark search-submit-button search-submit-button-disabled search-submit-button-unfocused" exportparts="button" id="search-submit-button">
             <template shadowrootmode="open">
               <ic-tooltip label="Search" placement="bottom" silent="" target="ic-button-with-tooltip-search-submit-button">
-                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" type="submit">
+                <button aria-disabled="true" aria-label="Search" class="button" disabled="" part="button" tabindex="0" type="submit">
                   <slot></slot>
                 </button>
               </ic-tooltip>

--- a/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-select/test/basic/__snapshots__/ic-select.spec.tsx.snap
@@ -714,7 +714,7 @@ exports[`ic-select should test with clear button: with-clear-button 1`] = `
             <ic-button class="clear-button ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
               <template shadowrootmode="open">
                 <ic-tooltip label="Clear selection" placement="bottom" silent="" target="ic-button-with-tooltip-clear-button">
-                  <button aria-label="Clear selection" class="button" part="button" type="button">
+                  <button aria-label="Clear selection" class="button" part="button" tabindex="0" type="button">
                     <slot></slot>
                   </button>
                 </ic-tooltip>

--- a/packages/web-components/src/components/ic-toggle-button-group/test/__snapshots__/ic-toggle-button-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-toggle-button-group/test/__snapshots__/ic-toggle-button-group.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-full-width ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -22,7 +22,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-full-width ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -43,7 +43,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -56,7 +56,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -77,7 +77,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-loading ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-disabled="true" aria-label="Loading, Toggle button group" class="button" part="button" type="button">
+          <button aria-disabled="true" aria-label="Loading, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <div class="loading-container">
               <ic-loading-indicator theme="inherit" type="linear"></ic-loading-indicator>
             </div>
@@ -92,7 +92,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-loading ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-disabled="true" aria-label="Loading, Toggle button group" class="button" part="button" type="button">
+          <button aria-disabled="true" aria-label="Loading, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <div class="loading-container">
               <ic-loading-indicator theme="inherit" type="linear"></ic-loading-indicator>
             </div>
@@ -115,7 +115,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -128,7 +128,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -149,7 +149,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -162,7 +162,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -183,7 +183,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -196,7 +196,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -217,7 +217,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-small ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -230,7 +230,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-small ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -251,7 +251,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-large ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -264,7 +264,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-large ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -286,7 +286,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-icon" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip label="Toggle, unticked" placement="bottom" silent="" target="ic-button-with-tooltip-22">
-            <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+            <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </ic-tooltip>
@@ -300,7 +300,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-icon" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip label="Toggle, unticked" placement="bottom" silent="" target="ic-button-with-tooltip-24">
-            <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+            <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
               <slot></slot>
             </button>
           </ic-tooltip>
@@ -321,7 +321,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>
@@ -334,7 +334,7 @@ exports[`ic-toggle-button-group component snapshot tests should render and updat
     <template shadowrootmode="open">
       <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
         <template shadowrootmode="open">
-          <button aria-label="Toggle, unticked" class="button" part="button" type="button">
+          <button aria-label="Toggle, unticked" class="button" part="button" tabindex="0" type="button">
             <slot></slot>
           </button>
         </template>

--- a/packages/web-components/src/components/ic-toggle-button-group/test/ic-toggle-button-group.spec.ts
+++ b/packages/web-components/src/components/ic-toggle-button-group/test/ic-toggle-button-group.spec.ts
@@ -27,7 +27,7 @@ describe("ic-toggle-button-group component snapshot tests", () => {
         <mock:shadow-root>
           <ic-button aria-pressed="false" class="ic-button-disabled ic-button-size-medium ic-button-variant-secondary" exportparts="button">
             <mock:shadow-root>
-              <button aria-disabled="true" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" type="button">
+              <button aria-disabled="true" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </mock:shadow-root>
@@ -40,7 +40,7 @@ describe("ic-toggle-button-group component snapshot tests", () => {
         <mock:shadow-root>
           <ic-button aria-pressed="false" class="ic-button-disabled ic-button-size-medium ic-button-variant-secondary" exportparts="button">
             <mock:shadow-root>
-              <button aria-disabled="true" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" type="button">
+              <button aria-disabled="true" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </mock:shadow-root>
@@ -53,7 +53,7 @@ describe("ic-toggle-button-group component snapshot tests", () => {
         <mock:shadow-root>
           <ic-button aria-pressed="false" class="ic-button-disabled ic-button-size-medium ic-button-variant-secondary" exportparts="button">
             <mock:shadow-root>
-              <button aria-disabled="true" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" type="button">
+              <button aria-disabled="true" aria-label="Toggle, unticked, Toggle button group" class="button" disabled="" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </mock:shadow-root>
@@ -76,7 +76,7 @@ describe("ic-toggle-button-group component snapshot tests", () => {
         <mock:shadow-root>
           <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
             <mock:shadow-root>
-              <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+              <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </mock:shadow-root>
@@ -89,7 +89,7 @@ describe("ic-toggle-button-group component snapshot tests", () => {
         <mock:shadow-root>
           <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
             <mock:shadow-root>
-              <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+              <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </mock:shadow-root>
@@ -102,7 +102,7 @@ describe("ic-toggle-button-group component snapshot tests", () => {
         <mock:shadow-root>
           <ic-button aria-pressed="false" class="ic-button-size-medium ic-button-variant-secondary" exportparts="button">
             <mock:shadow-root>
-              <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" type="button">
+              <button aria-label="Toggle, unticked, Toggle button group" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </mock:shadow-root>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

In safari, buttons do not receive focus on click. This is by design and won't be fixed, however we need a workaround to ensure a consistent developer and user experience across browsers.

~~The ic-button is now manually focused in its click event handler, so it will behave the same in all browsers.~~

The ic-button now has a tabindex of 0. This seems to be sufficient to apply the correct :focus styling to the button on click.


https://github.com/user-attachments/assets/2beac78d-c865-412f-a58c-86f75b980c62


## Related issue
#2186 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.