### PR TITLE
Chore/update package locks

### DIFF
--- a/packages/canary-react/package-lock.json
+++ b/packages/canary-react/package-lock.json
@@ -61,171 +61,6 @@
         "react-dom": "^16.7.0 || ^17.0.2 || ^18.2.0 || ^19.0.0"
       }
     },
-    "../canary-web-components": {
-      "name": "@ukic/canary-web-components",
-      "version": "3.0.0-canary.2",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.2",
-        "@stencil/core": "^4.26.0"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.16.0",
-        "@babel/preset-env": "^7.16.7",
-        "@babel/preset-typescript": "^7.23.3",
-        "@mdx-js/react": "^1.6.22",
-        "@open-wc/testing-helpers": "^2.0.2",
-        "@stencil/postcss": "^2.1.0",
-        "@stencil/react-output-target": "^0.5.3",
-        "@storybook/addon-a11y": "^7.6.10",
-        "@storybook/addon-actions": "^7.6.10",
-        "@storybook/addon-docs": "^7.6.10",
-        "@storybook/addon-essentials": "^7.6.10",
-        "@storybook/addon-links": "^7.6.10",
-        "@storybook/addon-mdx-gfm": "^7.6.10",
-        "@storybook/addon-postcss": "^2.0.0",
-        "@storybook/web-components": "^7.6.10",
-        "@storybook/web-components-webpack5": "^7.6.10",
-        "@types/autoprefixer": "^10.2.0",
-        "@types/jest": "^26.0.24",
-        "@types/jest-axe": "^3.5.3",
-        "autoprefixer": "^10.4.2",
-        "babel-loader": "^8.2.3",
-        "github-markdown-css": "^5.5.0",
-        "jest": "^26.6.3",
-        "jest-axe": "^5.0.1",
-        "jest-cli": "^26.6.3",
-        "kill-port-process": "^3.2.1",
-        "lit": "^2.0.2",
-        "loki": "^0.34.0",
-        "npm-run-all": "^4.1.5",
-        "puppeteer": "^13.1.3",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-markdown": "^8.0.7",
-        "remark-gfm": "^3.0.1",
-        "stencil-inline-svg": "^1.1.0",
-        "storybook": "^7.6.10",
-        "ts-jest": "^26.5.6",
-        "webpack": "^5.76.0"
-      },
-      "peerDependencies": {
-        "@ukic/fonts": "^3.1.0"
-      }
-    },
-    "../react": {
-      "name": "@ukic/react",
-      "version": "3.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@babel/preset-react": "^7.24.7",
-        "@cypress-audit/lighthouse": "^1.4.2",
-        "@cypress/react": "^8.0.0",
-        "@cypress/webpack-preprocessor": "^6.0.0",
-        "@mdi/js": "^7.2.96",
-        "@stencil/react-output-target": "^0.5.3",
-        "@storybook/addon-a11y": "^7.6.7",
-        "@storybook/addon-actions": "^7.6.7",
-        "@storybook/addon-docs": "^7.6.7",
-        "@storybook/addon-essentials": "^7.6.7",
-        "@storybook/addon-links": "^7.6.7",
-        "@storybook/addon-mdx-gfm": "^7.6.7",
-        "@storybook/addon-postcss": "^2.0.0",
-        "@storybook/react": "^7.6.7",
-        "@storybook/react-webpack5": "^7.6.7",
-        "@types/node": "^16.11.11",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "ag-grid-community": "^32.0.2",
-        "ag-grid-react": "^32.0.2",
-        "axe-core": "^4.8.2",
-        "babel-loader": "^8.3.0",
-        "cross-env": "^7.0.3",
-        "cross-port-killer": "^1.4.0",
-        "css-loader": "^6.8.1",
-        "cypress": "^13.3.1",
-        "cypress-audit": "^1.1.0",
-        "cypress-axe": "^1.5.0",
-        "cypress-file-upload": "^5.0.8",
-        "cypress-image-diff-js": "^2.1.3",
-        "cypress-real-events": "^1.12.0",
-        "eslint-plugin-cypress": "^2.15.1",
-        "html-webpack-plugin": "^5.6.0",
-        "http-proxy-middleware": "^2.0.7",
-        "mkdirp": "^1.0.4",
-        "np": "^7.6.0",
-        "npm-run-all": "^4.1.5",
-        "react": "^16.14.0",
-        "react-dom": "^16.14.0",
-        "react-hook-form": "^7.38.0",
-        "react-router-dom": "^6.26.2",
-        "storybook": "^7.6.7",
-        "storybook-addon-performance": "^0.17.3",
-        "ts-loader": "^9.5.0",
-        "typescript": "^4.9.5",
-        "wait-on": "^8.0.1",
-        "webpack": "^5.94.0",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^4.15.2"
-      },
-      "peerDependencies": {
-        "@ukic/fonts": "^3.1.0",
-        "react": "^16.7.0 || ^17.0.2 || ^18.2.0",
-        "react-dom": "^16.7.0 || ^17.0.2 || ^18.2.0"
-      }
-    },
-    "../web-components": {
-      "name": "@ukic/web-components",
-      "version": "3.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.2",
-        "@stencil/core": "^4.26.0"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@mdx-js/react": "^1.6.22",
-        "@open-wc/testing-helpers": "^2.0.2",
-        "@stencil/postcss": "^2.1.0",
-        "@stencil/react-output-target": "^0.5.3",
-        "@storybook/addon-a11y": "^7.6.7",
-        "@storybook/addon-actions": "^7.6.7",
-        "@storybook/addon-essentials": "^7.6.7",
-        "@storybook/addon-links": "^7.6.7",
-        "@storybook/addon-mdx-gfm": "^7.6.7",
-        "@storybook/addon-postcss": "^2.0.0",
-        "@storybook/web-components": "^7.6.7",
-        "@storybook/web-components-webpack5": "^7.6.7",
-        "@types/autoprefixer": "^10.2.0",
-        "@types/jest": "^26.0.24",
-        "@types/jest-axe": "^3.5.3",
-        "autoprefixer": "^10.4.2",
-        "babel-loader": "^8.2.3",
-        "jest": "^26.6.3",
-        "jest-axe": "^5.0.1",
-        "jest-cli": "^26.6.3",
-        "kill-port-process": "^3.2.1",
-        "lit": "^2.0.2",
-        "loki": "^0.34.0",
-        "npm-run-all": "^4.1.5",
-        "puppeteer": "^13.1.3",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "stencil-inline-svg": "^1.1.0",
-        "storybook": "^7.6.7",
-        "ts-jest": "^26.5.6",
-        "webpack": "^5.76.0"
-      },
-      "peerDependencies": {
-        "@ukic/fonts": "^3.1.0"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "dev": true,
@@ -4330,7 +4165,9 @@
     },
     "node_modules/@stencil/core": {
       "version": "4.26.0",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -12559,7 +12396,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -13691,6 +13529,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -16605,6 +16444,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17549,6 +17389,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -17558,6 +17399,7 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -17708,6 +17550,7 @@
     },
     "node_modules/react": {
       "version": "16.14.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -17752,6 +17595,7 @@
     },
     "node_modules/react-dom": {
       "version": "16.14.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19422,6 +19266,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.19.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",

--- a/packages/canary-web-components/package-lock.json
+++ b/packages/canary-web-components/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.2",
-        "@stencil/core": "^4.26.0",
-        "@ukic/web-components": "^3.3.0"
+        "@stencil/core": "^4.26.0"
       },
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -73,60 +73,6 @@
         "react-dom": "^16.7.0 || ^17.0.2 || ^18.2.0 || ^19.0.0"
       }
     },
-    "../web-components": {
-      "name": "@ukic/web-components",
-      "version": "3.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@popperjs/core": "^2.11.2",
-        "@stencil/core": "^4.26.0"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@mdx-js/react": "^1.6.22",
-        "@open-wc/testing-helpers": "^2.0.2",
-        "@stencil/postcss": "^2.1.0",
-        "@stencil/react-output-target": "^0.5.3",
-        "@storybook/addon-a11y": "^8.5.3",
-        "@storybook/addon-actions": "^8.5.3",
-        "@storybook/addon-essentials": "^8.5.3",
-        "@storybook/addon-links": "^8.5.3",
-        "@storybook/addon-mdx-gfm": "^8.5.3",
-        "@storybook/addon-postcss": "^2.0.0",
-        "@storybook/addon-webpack5-compiler-babel": "^3.0.5",
-        "@storybook/blocks": "^8.5.3",
-        "@storybook/preview-api": "^8.5.3",
-        "@storybook/web-components": "^8.5.3",
-        "@storybook/web-components-webpack5": "^8.5.3",
-        "@types/autoprefixer": "^10.2.0",
-        "@types/jest": "^26.0.24",
-        "@types/jest-axe": "^3.5.3",
-        "@types/react": "^17.0.37",
-        "@types/react-dom": "^17.0.11",
-        "autoprefixer": "^10.4.2",
-        "babel-loader": "^8.2.3",
-        "jest": "^26.6.3",
-        "jest-axe": "^5.0.1",
-        "jest-cli": "^26.6.3",
-        "kill-port-process": "^3.2.1",
-        "lit": "^2.0.2",
-        "npm-run-all": "^4.1.5",
-        "puppeteer": "^13.1.3",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "stencil-inline-svg": "^1.1.0",
-        "storybook": "^8.5.3",
-        "ts-jest": "^26.5.6",
-        "webpack": "^5.76.0"
-      },
-      "peerDependencies": {
-        "@ukic/fonts": "^2.6.0"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "dev": true,


### PR DESCRIPTION
## Summary of the changes
Remove local file references in package-locks. 

I re-cloned the repo, manually removed the references, and did an npm install and run bootstrap - which is why there are few extra small changes.

This is an attempt to fix a build error a customer is having, particularly as the local file references use older versions of the packages so they are likely causing issues

## Related issue
N/A