### PR TITLE
fix(web-components): fixed double tab on top-nav title

### DIFF
--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.css
@@ -165,6 +165,7 @@ slot[name="app-icon"]::slotted(*) {
   fill: var(--ic-top-navigation-logo);
   width: 2em;
   height: 2em;
+  cursor: pointer;
 }
 
 slot[name="toggle-icon"] svg {

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.tsx
@@ -52,6 +52,7 @@ import { IcSearchBarBlurEventDetail } from "../ic-search-bar/ic-search-bar.types
 })
 export class TopNavigation {
   private hasAppIcon = false;
+  private hasAppTitleSlot = false;
   private hasIconButtons = false;
   private hasNavigation = false;
   private hasSearchSlotContent = false;
@@ -152,7 +153,7 @@ export class TopNavigation {
 
   componentDidLoad(): void {
     checkResizeObserver(this.runResizeObserver);
-    if (!isSlotUsed(this.el, "app-title")) {
+    if (!this.hasAppTitleSlot) {
       onComponentRequiredPropUndefined(
         [{ prop: this.appTitle, propName: "app-title" }],
         "Top Navigation"
@@ -195,9 +196,17 @@ export class TopNavigation {
 
   private checkSlots = () => {
     this.hasAppIcon = isSlotUsed(this.el, "app-icon");
+    this.hasAppTitleSlot = isSlotUsed(this.el, "app-title");
     this.hasNavigation = isSlotUsed(this.el, "navigation");
     this.hasIconButtons = isSlotUsed(this.el, "buttons");
     this.hasSearchSlotContent = isSlotUsed(this.el, "search");
+
+    if (this.hasAppIcon) {
+      const slottedAppIcon =
+        this.el.querySelector<HTMLElement>('[slot="app-icon"]');
+      if (slottedAppIcon && slottedAppIcon.tagName === "A")
+        slottedAppIcon.tabIndex = -1;
+    }
   };
 
   private initialiseSearchBar = () => {
@@ -293,6 +302,7 @@ export class TopNavigation {
       el,
       foregroundColor,
       hasAppIcon,
+      hasAppTitleSlot,
       hasFullWidthSearchBar,
       hasIconButtons,
       hasNavigation,
@@ -333,7 +343,6 @@ export class TopNavigation {
     const menuSize = isSmallDeviceSize ? "small" : "medium";
 
     const shortAppTitleSlot = isSlotUsed(el, "short-app-title");
-    const hasAppTitleSlot = isSlotUsed(el, "app-title");
     const Component = hasAppTitleSlot ? "div" : "a";
     const attrs = Component == "a" && {
       href: href,

--- a/packages/web-components/src/components/ic-top-navigation/test/basic/__snapshots__/ic-top-navigation.spec.ts.snap
+++ b/packages/web-components/src/components/ic-top-navigation/test/basic/__snapshots__/ic-top-navigation.spec.ts.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ic-top-navigation should render with app icon & title as links: renders-with-slotted links 1`] = `
+<ic-top-navigation>
+  <template shadowrootmode="open">
+    <div class="top-navigation">
+      <ic-section-container aligned="full-width" full-height="">
+        <header role="banner">
+          <div class="top-panel-container">
+            <div class="app-details-container">
+              <div class="title-link">
+                <div class="app-icon-container">
+                  <slot name="app-icon"></slot>
+                </div>
+                <ic-typography variant="h3">
+                  <h1 class="title-wrap">
+                    <slot name="app-title"></slot>
+                  </h1>
+                </ic-typography>
+              </div>
+            </div>
+          </div>
+        </header>
+      </ic-section-container>
+    </div>
+  </template>
+  <a href="/" slot="app-title">
+    Application Name
+  </a>
+  <a href="/" slot="short-app-title">
+    App name
+  </a>
+  <a href="/" slot="app-icon" tabindex="-1">
+    <svg fill="inherit" height="inherit" viewBox="0 0 24 24" width="inherit" xmlns="http://www.w3.org/2000/svg">
+      <path d="M0 0h24v24H0V0z" fill="none"></path>
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"></path>
+    </svg>
+  </a>
+</ic-top-navigation>
+`;
+
 exports[`ic-top-navigation should render with app icon & title: renders-with-app-icon-and-title 1`] = `
 <ic-top-navigation app-title="ApplicationName">
   <template shadowrootmode="open">

--- a/packages/web-components/src/components/ic-top-navigation/test/basic/ic-top-navigation.spec.ts
+++ b/packages/web-components/src/components/ic-top-navigation/test/basic/ic-top-navigation.spec.ts
@@ -44,6 +44,31 @@ describe("ic-top-navigation", () => {
     expect(page.root).toMatchSnapshot("renders-with-app-icon-and-title");
   });
 
+  it("should render with app icon & title as links", async () => {
+    const page = await newSpecPage({
+      components: [TopNavigation],
+      html: `<ic-top-navigation>
+      <a slot="app-title" href="/">Application Name</a>
+      <a slot="short-app-title" href="/">App name</a>
+      <a slot="app-icon" href="/">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="inherit"
+          viewBox="0 0 24 24"
+          width="inherit"
+          fill="inherit"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"
+          />
+        </svg>
+      </a>
+    </ic-top-navigation>`,
+    });
+    expect(page.root).toMatchSnapshot("renders-with-slotted links");
+  });
+
   it("should render with custom title link url", async () => {
     const page = await newSpecPage({
       components: [TopNavigation],


### PR DESCRIPTION
## Summary of the changes
- When a slotted app-icon is used and is a link, sets the tabindex to be -1 to skip it in the focus order. Focus now moves to the title-link wrapper which still lets the user navigate and click. Can still click the app-icon link.
- Added test to check the tabindex is being set. Added minor css to apply a pointer cursor even when the app-icon is not a link, since it can still be clicked due to it being contained by the title-link wrapper.

## Related issue
#1508 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.