### PR TITLE
3294 ic data table column specific disableautosort

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -9,7 +9,7 @@
       "filePath": "src/components/ic-card-horizontal/ic-card-horizontal.tsx",
       "encapsulation": "shadow",
       "tag": "ic-card-horizontal",
-      "readme": "# ic-horizontal-card\n\n\n",
+      "readme": "# ic-horizontal-card\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -472,7 +472,7 @@
       "filePath": "src/components/ic-data-table/ic-data-table.tsx",
       "encapsulation": "shadow",
       "tag": "ic-data-table",
-      "readme": "# ic-data-table\n\n\n",
+      "readme": "# ic-data-table\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -809,7 +809,7 @@
           "name": "loadingOptions",
           "type": "undefined | { description?: string | undefined; label?: string | undefined; labelDuration?: number | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; overlay?: boolean | undefined; }",
           "complexType": {
-            "original": "{\n    description?: string;\n    label?: string;\n    labelDuration?: number;\n    max?: number;\n    min?: number;\n    progress?: number;\n    monochrome?: boolean;\n    overlay?: boolean;\n  }",
+            "original": "{\r\n    description?: string;\r\n    label?: string;\r\n    labelDuration?: number;\r\n    max?: number;\r\n    min?: number;\r\n    progress?: number;\r\n    monochrome?: boolean;\r\n    overlay?: boolean;\r\n  }",
             "resolved": "undefined | { description?: string | undefined; label?: string | undefined; labelDuration?: number | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; overlay?: boolean | undefined; }",
             "references": {}
           },
@@ -948,7 +948,7 @@
           "reflectToAttr": false,
           "docs": "Sets the props for the built-in pagination bar. If the `pagination-bar` slot is used then this prop is ignored.",
           "docsTags": [],
-          "default": "{\n    alignment: \"right\",\n    hideAllFromItemsPerPage: false,\n    hideRangeLabel: false,\n    itemLabel: \"Item\",\n    itemsPerPageOptions: [\n      { label: \"10\", value: \"10\" },\n      { label: \"25\", value: \"25\" },\n      { label: \"50\", value: \"50\" },\n    ],\n    monochrome: false,\n    pageLabel: \"Page\",\n    rangeLabelType: \"page\",\n    selectedItemsPerPage: 10,\n    selectItemsPerPageOnEnter: true,\n    setToFirstPageOnPaginationChange: false,\n    showGoToPageControl: true,\n    showItemsPerPageControl: true,\n    type: \"simple\",\n  }",
+          "default": "{\r\n    alignment: \"right\",\r\n    hideAllFromItemsPerPage: false,\r\n    hideRangeLabel: false,\r\n    itemLabel: \"Item\",\r\n    itemsPerPageOptions: [\r\n      { label: \"10\", value: \"10\" },\r\n      { label: \"25\", value: \"25\" },\r\n      { label: \"50\", value: \"50\" },\r\n    ],\r\n    monochrome: false,\r\n    pageLabel: \"Page\",\r\n    rangeLabelType: \"page\",\r\n    selectedItemsPerPage: 10,\r\n    selectItemsPerPageOnEnter: true,\r\n    setToFirstPageOnPaginationChange: false,\r\n    showGoToPageControl: true,\r\n    showItemsPerPageControl: true,\r\n    type: \"simple\",\r\n  }",
           "values": [
             {
               "type": "IcPaginationBarOptions"
@@ -1014,7 +1014,7 @@
           "name": "sortOptions",
           "type": "{ sortOrders: IcDataTableSortOrderOptions[]; defaultColumn?: string | undefined; }",
           "complexType": {
-            "original": "{\n    sortOrders: IcDataTableSortOrderOptions[];\n    defaultColumn?: string;\n  }",
+            "original": "{\r\n    sortOrders: IcDataTableSortOrderOptions[];\r\n    defaultColumn?: string;\r\n  }",
             "resolved": "{ sortOrders: IcDataTableSortOrderOptions[]; defaultColumn?: string | undefined; }",
             "references": {
               "IcDataTableSortOrderOptions": {
@@ -1028,7 +1028,7 @@
           "reflectToAttr": false,
           "docs": "Sets the order columns will be sorted in and allows for 'default' sorts to be added.",
           "docsTags": [],
-          "default": "{\n    sortOrders: [\"unsorted\", \"ascending\", \"descending\"],\n    defaultColumn: \"\",\n  }",
+          "default": "{\r\n    sortOrders: [\"unsorted\", \"ascending\", \"descending\"],\r\n    defaultColumn: \"\",\r\n  }",
           "values": [
             {
               "type": "{ sortOrders: IcDataTableSortOrderOptions[]; defaultColumn?: string"
@@ -1256,7 +1256,7 @@
           "name": "updatingOptions",
           "type": "undefined | { description?: string | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; }",
           "complexType": {
-            "original": "{\n    description?: string;\n    max?: number;\n    min?: number;\n    progress?: number;\n    monochrome?: boolean;\n  }",
+            "original": "{\r\n    description?: string;\r\n    max?: number;\r\n    min?: number;\r\n    progress?: number;\r\n    monochrome?: boolean;\r\n  }",
             "resolved": "undefined | { description?: string | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; }",
             "references": {}
           },
@@ -1296,7 +1296,7 @@
           "name": "variableRowHeight",
           "type": "((params: { [key: string]: any; index: number; }) => IcDataTableRowHeights | null) | undefined",
           "complexType": {
-            "original": "(params: {\n    [key: string]: any;\n    index: number;\n  }) => IcDataTableRowHeights | null",
+            "original": "(params: {\r\n    [key: string]: any;\r\n    index: number;\r\n  }) => IcDataTableRowHeights | null",
             "resolved": "((params: { [key: string]: any; index: number; }) => IcDataTableRowHeights | null) | undefined",
             "references": {
               "IcDataTableRowHeights": {
@@ -1308,7 +1308,7 @@
           },
           "mutable": true,
           "reflectToAttr": false,
-          "docs": "Allows for custom setting of row heights on individual rows based on an individual value from the `data` prop and the row index.\nIf the function returns `null`, that row's height will be set to the `globalRowHeight` property.",
+          "docs": "Allows for custom setting of row heights on individual rows based on an individual value from the `data` prop and the row index.\r\nIf the function returns `null`, that row's height will be set to the `globalRowHeight` property.",
           "docsTags": [],
           "values": [
             {
@@ -1457,7 +1457,7 @@
           "detail": "{ row: IcDataTableDataType | null; selectedRows: IcDataTableDataType[]; }",
           "bubbles": true,
           "complexType": {
-            "original": "{\n    row: IcDataTableDataType | null;\n    selectedRows: IcDataTableDataType[];\n  }",
+            "original": "{\r\n    row: IcDataTableDataType | null;\r\n    selectedRows: IcDataTableDataType[];\r\n  }",
             "resolved": "{ row: IcDataTableDataType | null; selectedRows: IcDataTableDataType[]; }",
             "references": {
               "IcDataTableDataType": {
@@ -1626,7 +1626,7 @@
       "filePath": "src/components/ic-data-table-title-bar/ic-data-table-title-bar.tsx",
       "encapsulation": "shadow",
       "tag": "ic-data-table-title-bar",
-      "readme": "# ic-data-table-title-bar\n\n\n",
+      "readme": "# ic-data-table-title-bar\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -1846,7 +1846,7 @@
       "filePath": "src/components/ic-date-input/ic-date-input.tsx",
       "encapsulation": "shadow",
       "tag": "ic-date-input",
-      "readme": "# ic-date-input\n\n\n",
+      "readme": "# ic-date-input\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -2265,7 +2265,7 @@
           "mutable": false,
           "attr": "max",
           "reflectToAttr": false,
-          "docs": "The latest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\nThe value of this prop is ignored if `disableFuture` is set to `true`.",
+          "docs": "The latest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\r\nThe value of this prop is ignored if `disableFuture` is set to `true`.",
           "docsTags": [],
           "default": "\"\"",
           "values": [
@@ -2297,7 +2297,7 @@
           "mutable": false,
           "attr": "min",
           "reflectToAttr": false,
-          "docs": "The earliest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\nThe value of this prop is ignored if `disablePast` is set to `true`.",
+          "docs": "The earliest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\r\nThe value of this prop is ignored if `disablePast` is set to `true`.",
           "docsTags": [],
           "default": "\"\"",
           "values": [
@@ -2635,7 +2635,7 @@
           "detail": "{ value: Date | null; dateObject: { day: string | null; month: string | null; year: string | null; }; utcValue: Date | null; }",
           "bubbles": true,
           "complexType": {
-            "original": "{\n    value: Date | null;\n    dateObject: {\n      day: string | null;\n      month: string | null;\n      year: string | null;\n    };\n    utcValue: Date | null;\n  }",
+            "original": "{\r\n    value: Date | null;\r\n    dateObject: {\r\n      day: string | null;\r\n      month: string | null;\r\n      year: string | null;\r\n    };\r\n    utcValue: Date | null;\r\n  }",
             "resolved": "{ value: Date | null; dateObject: { day: string | null; month: string | null; year: string | null; }; utcValue: Date | null; }",
             "references": {
               "Date": {
@@ -2722,7 +2722,7 @@
       "filePath": "src/components/ic-date-picker/ic-date-picker.tsx",
       "encapsulation": "shadow",
       "tag": "ic-date-picker",
-      "readme": "# ic-date-picker\n\n\n",
+      "readme": "# ic-date-picker\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -3158,7 +3158,7 @@
           "mutable": false,
           "attr": "max",
           "reflectToAttr": false,
-          "docs": "The latest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\nThe value of this prop is ignored if `disableFuture` is set to `true`.",
+          "docs": "The latest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\r\nThe value of this prop is ignored if `disableFuture` is set to `true`.",
           "docsTags": [],
           "default": "\"\"",
           "values": [
@@ -3190,7 +3190,7 @@
           "mutable": false,
           "attr": "min",
           "reflectToAttr": false,
-          "docs": "The earliest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\nThe value of this prop is ignored if `disablePast` is set to `true`.",
+          "docs": "The earliest date that will be allowed. The value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.\r\nThe value of this prop is ignored if `disablePast` is set to `true`.",
           "docsTags": [],
           "default": "\"\"",
           "values": [
@@ -3248,7 +3248,7 @@
           "mutable": false,
           "attr": "open-at-date",
           "reflectToAttr": false,
-          "docs": "The date visible when the calendar opens. Used if no date is currently selected.\nThe value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.",
+          "docs": "The date visible when the calendar opens. Used if no date is currently selected.\r\nThe value can be in any format supported as `dateFormat`, in ISO 8601 date string format (`yyyy-mm-dd`) or as a JavaScript `Date` object.",
           "docsTags": [],
           "default": "\"\"",
           "values": [
@@ -3431,7 +3431,7 @@
           "mutable": false,
           "attr": "start-of-week",
           "reflectToAttr": false,
-          "docs": "The first day of the week. `0` for Sunday, `1` for Monday, etc.\nDefault is Monday.",
+          "docs": "The first day of the week. `0` for Sunday, `1` for Monday, etc.\r\nDefault is Monday.",
           "docsTags": [],
           "default": "IcWeekDays.Monday",
           "values": [
@@ -3711,7 +3711,7 @@
       "filePath": "src/components/ic-pagination-bar/ic-pagination-bar.tsx",
       "encapsulation": "shadow",
       "tag": "ic-pagination-bar",
-      "readme": "# ic-pagination-bar\n\n\n",
+      "readme": "# ic-pagination-bar\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -3870,7 +3870,7 @@
           "name": "itemsPerPageOptions",
           "type": "undefined | { label: string; value: string; }[]",
           "complexType": {
-            "original": "{\n    label: string;\n    value: string;\n  }[]",
+            "original": "{\r\n    label: string;\r\n    value: string;\r\n  }[]",
             "resolved": "undefined | { label: string; value: string; }[]",
             "references": {}
           },
@@ -4251,7 +4251,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when a page is navigated to via the 'go to' input.\nThe `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.",
+          "docs": "Emitted when a page is navigated to via the 'go to' input.\r\nThe `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.",
           "docsTags": []
         }
       ],
@@ -4339,7 +4339,7 @@
       "filePath": "src/components/ic-tree-item/ic-tree-item.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tree-item",
-      "readme": "# ic-tree-item\n\n\n",
+      "readme": "# ic-tree-item\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -4746,7 +4746,7 @@
           "detail": "{ isExpanded: boolean; id: string; }",
           "bubbles": true,
           "complexType": {
-            "original": "{\n    isExpanded: boolean;\n    id: string;\n  }",
+            "original": "{\r\n    isExpanded: boolean;\r\n    id: string;\r\n  }",
             "resolved": "{ isExpanded: boolean; id: string; }",
             "references": {}
           },
@@ -4812,7 +4812,7 @@
       "filePath": "src/components/ic-tree-view/ic-tree-view.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tree-view",
-      "readme": "# ic-tree-view\n\n\n",
+      "readme": "# ic-tree-view\r\n\r\n\r\n\r",
       "docs": "",
       "docsTags": [
         {
@@ -4974,7 +4974,7 @@
           "mutable": true,
           "attr": "truncate-heading",
           "reflectToAttr": false,
-          "docs": "If `true`, the tree view heading will be truncated instead of text wrapping.\nWhen used on small devices, this prop will be overridden and headings will be set to text-wrap.",
+          "docs": "If `true`, the tree view heading will be truncated instead of text wrapping.\r\nWhen used on small devices, this prop will be overridden and headings will be set to text-wrap.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -4998,7 +4998,7 @@
           "mutable": true,
           "attr": "truncate-tree-items",
           "reflectToAttr": false,
-          "docs": "If `true`, tree items will be truncated, unless they are individually overridden.\nWhen used on small devices, this prop will be overridden and tree-items will be set to text-wrap.",
+          "docs": "If `true`, tree items will be truncated, unless they are individually overridden.\r\nWhen used on small devices, this prop will be overridden and tree-items will be set to text-wrap.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -5067,7 +5067,7 @@
       "path": "../web-components/dist/types/interface.d.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDataTableColumnObject": {
-      "declaration": "{\n  key: string;\n  title: string;\n  dataType: IcDataTableColumnDataTypes;\n  columnAlignment?: {\n    horizontal?: string;\n    vertical?: string;\n  };\n  rowOptions?: {\n    textWrap: boolean;\n  };\n  columnWidth?: string | IcDataTableColumnWidthTypes;\n  textWrap?: boolean;\n  cellAlignment?: string;\n  emphasis?: string;\n  colspan?: number;\n  icon?: {\n    icon: string;\n    onAllCells?: boolean;\n    hideOnHeader?: boolean;\n  };\n  excludeColumnFromSort?: boolean;\n}",
+      "declaration": "{\r\n  key: string;\r\n  title: string;\r\n  dataType: IcDataTableColumnDataTypes;\r\n  columnAlignment?: {\r\n    horizontal?: string;\r\n    vertical?: string;\r\n  };\r\n  rowOptions?: {\r\n    textWrap: boolean;\r\n  };\r\n  columnWidth?: string | IcDataTableColumnWidthTypes;\r\n  textWrap?: boolean;\r\n  cellAlignment?: string;\r\n  emphasis?: string;\r\n  colspan?: number;\r\n  icon?: {\r\n    icon: string;\r\n    onAllCells?: boolean;\r\n    hideOnHeader?: boolean;\r\n  };\r\n  excludeColumnFromSort?: boolean;\r\n  disableAutoSort?: boolean;\r\n}",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5087,12 +5087,12 @@
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
     "src/utils/types.ts::IcPaginationBarOptions": {
-      "declaration": "export interface IcPaginationBarOptions {\n  alignment?: IcPaginationAlignmentOptions;\n  hideAllFromItemsPerPage?: boolean;\n  hideRangeLabel?: boolean;\n  itemLabel?: string;\n  itemsPerPageOptions?: { label: string; value: string }[];\n  monochrome?: boolean;\n  pageLabel?: string;\n  rangeLabelType?: IcPaginationLabelTypes;\n  selectedItemsPerPage?: number;\n  selectItemsPerPageOnEnter?: boolean;\n  setToFirstPageOnPaginationChange?: boolean;\n  showGoToPageControl?: boolean;\n  showItemsPerPageControl?: boolean;\n  theme?: IcThemeMode;\n  type?: IcPaginationTypes;\n}",
+      "declaration": "export interface IcPaginationBarOptions {\r\n  alignment?: IcPaginationAlignmentOptions;\r\n  hideAllFromItemsPerPage?: boolean;\r\n  hideRangeLabel?: boolean;\r\n  itemLabel?: string;\r\n  itemsPerPageOptions?: { label: string; value: string }[];\r\n  monochrome?: boolean;\r\n  pageLabel?: string;\r\n  rangeLabelType?: IcPaginationLabelTypes;\r\n  selectedItemsPerPage?: number;\r\n  selectItemsPerPageOnEnter?: boolean;\r\n  setToFirstPageOnPaginationChange?: boolean;\r\n  showGoToPageControl?: boolean;\r\n  showItemsPerPageControl?: boolean;\r\n  theme?: IcThemeMode;\r\n  type?: IcPaginationTypes;\r\n}",
       "docstring": "",
       "path": "src/utils/types.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDataTableSortOrderOptions": {
-      "declaration": "export type IcDataTableSortOrderOptions =\n  | \"unsorted\"\n  | \"ascending\"\n  | \"descending\";",
+      "declaration": "export type IcDataTableSortOrderOptions =\r\n  | \"unsorted\"\r\n  | \"ascending\"\r\n  | \"descending\";",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5107,7 +5107,7 @@
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcSortEventDetail": {
-      "declaration": "export interface IcSortEventDetail {\n  columnName: string;\n  sorted: IcDataTableSortOrderOptions;\n}",
+      "declaration": "export interface IcSortEventDetail {\r\n  columnName: string;\r\n  sorted: IcDataTableSortOrderOptions;\r\n}",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5132,7 +5132,7 @@
       "path": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDensityUpdateEventDetail": {
-      "declaration": "export interface IcDensityUpdateEventDetail {\n  value: IcDataTableDensityOptions;\n}",
+      "declaration": "export interface IcDensityUpdateEventDetail {\r\n  value: IcDataTableDensityOptions;\r\n}",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5142,7 +5142,7 @@
       "path": "src/utils/types.ts"
     },
     "src/utils/types.ts::IcWeekDays": {
-      "declaration": "export enum IcWeekDays {\n  Sunday = 0,\n  Monday = 1,\n  Tuesday = 2,\n  Wednesday = 3,\n  Thursday = 4,\n  Friday = 5,\n  Saturday = 6,\n}",
+      "declaration": "export enum IcWeekDays {\r\n  Sunday = 0,\r\n  Monday = 1,\r\n  Tuesday = 2,\r\n  Wednesday = 3,\r\n  Thursday = 4,\r\n  Friday = 5,\r\n  Saturday = 6,\r\n}",
       "docstring": "",
       "path": "src/utils/types.ts"
     },
@@ -5157,7 +5157,7 @@
       "path": "src/utils/types.ts"
     },
     "src/components/ic-tree-view/ic-tree-view.types.tsx::IcTreeItemOptions": {
-      "declaration": "{\n  label: string;\n  icon?: string;\n  children?: IcTreeItemOptions[];\n  disabled?: boolean;\n  expanded?: boolean;\n  href?: string;\n  selected?: boolean;\n  treeItemId?: string;\n  theme?: IcThemeMode;\n  truncateTreeItem?: boolean;\n}",
+      "declaration": "{\r\n  label: string;\r\n  icon?: string;\r\n  children?: IcTreeItemOptions[];\r\n  disabled?: boolean;\r\n  expanded?: boolean;\r\n  href?: string;\r\n  selected?: boolean;\r\n  treeItemId?: string;\r\n  theme?: IcThemeMode;\r\n  truncateTreeItem?: boolean;\r\n}",
       "docstring": "",
       "path": "src/components/ic-tree-view/ic-tree-view.types.tsx"
     }

--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
@@ -50,6 +50,7 @@ import {
   DATA_WITH_EMPTY_VALUES,
   LONG_DATA_ELEMENTS_WITH_DESCRIPTIONS,
   DATA_ELEMENTS_PAGINATION,
+  COLS_DISABLE_AUTO_SORT,
 } from "@ukic/canary-web-components/src/components/ic-data-table/story-data";
 
 import {
@@ -184,6 +185,34 @@ export const ExternalSortDataTable = (): ReactElement => {
       caption="Data Tables"
       sortable
       disableAutoSort
+      onIcSortChange={(e) => handleSort(e.detail)}
+      sortOptions={{
+        sortOrders: ["ascending", "descending"],
+      }}
+    />
+  );
+};
+
+export const ExternalSortColumnDataTable = (): ReactElement => {
+  const ExternalData = [...DATA];
+
+  const handleSort = ({ columnName, sorted }: IcSortEventDetail) => {
+    if (columnName !== "firstName") return;
+
+    const sortedAscending = sorted === "ascending";
+    ExternalData.sort((a, b) => {
+      if (a[columnName] < b[columnName]) return sortedAscending ? -1 : 1;
+      if (a[columnName] > b[columnName]) return sortedAscending ? 1 : -1;
+      return 0;
+    });
+  };
+
+  return (
+    <IcDataTable
+      columns={COLS_DISABLE_AUTO_SORT}
+      data={ExternalData}
+      caption="Disable auto sort on columns"
+      sortable
       onIcSortChange={(e) => handleSort(e.detail)}
       sortOptions={{
         sortOrders: ["ascending", "descending"],
@@ -438,6 +467,42 @@ describe("IcDataTables", () => {
 
   it("should sort data externally if disableAutoSort is true", () => {
     mount(<ExternalSortDataTable />);
+
+    cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR)
+      .eq(0)
+      .shadow()
+      .find(TOOLTIP_BUTTON_SELECTOR)
+      .should(HAVE_ATTR, ARIA_LABEL, SORT_ASCENDING);
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR).eq(0).click();
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "tr")
+      .eq(1)
+      .find("td")
+      .eq(0)
+      .should(HAVE_TEXT, "Joe");
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR)
+      .eq(0)
+      .shadow()
+      .find(TOOLTIP_BUTTON_SELECTOR)
+      .should(HAVE_ATTR, ARIA_LABEL, "Sort descending");
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, SORT_BUTTON_SELECTOR).eq(0).click();
+
+    cy.findShadowEl(DATA_TABLE_SELECTOR, "tr")
+      .eq(1)
+      .find("td")
+      .eq(0)
+      .should(HAVE_TEXT, "Sarah");
+
+    cy.checkA11yWithWait();
+  });
+
+  it("should sort data externally if disableAutoSort is true on a column", () => {
+    mount(<ExternalSortColumnDataTable />);
 
     cy.checkHydrated(DATA_TABLE_SELECTOR);
 

--- a/packages/canary-react/src/stories/ic-data-table.stories.js
+++ b/packages/canary-react/src/stories/ic-data-table.stories.js
@@ -15,6 +15,7 @@ import {
   ACTION_DATA_ELEMENTS,
   COLS,
   COLS_ALIGNMENT,
+  COLS_DISABLE_AUTO_SORT,
   COLS_ELEMENTS,
   COLS_ELEMENTS_SINGLE_ACTION,
   COLS_EXCLUDE_SORT,
@@ -236,6 +237,42 @@ export const DisableSort = {
     );
   },
   name: "Disable sort",
+};
+
+/**
+ * Alternatively, set `disableAutoSort` to `true` within the column object to have it apply only to certain columns that may require special custom sorting.
+ */
+export const DisableAutoSortOnColumns = {
+  render: () => {
+    const ExternalData = [...DATA];
+
+    const handleSort = ({ columnName, sorted }) => {
+      console.log("Sort changed", columnName, sorted);
+      if (columnName !== "firstName") return;
+
+      const sortedAscending = sorted === "ascending";
+      ExternalData.sort((a, b) => {
+        if (a[columnName] < b[columnName]) return sortedAscending ? -1 : 1;
+        if (a[columnName] > b[columnName]) return sortedAscending ? 1 : -1;
+        return 0;
+      });
+      console.log("Custom sort applied");
+    };
+
+    return (
+      <IcDataTable
+        columns={COLS_DISABLE_AUTO_SORT}
+        data={ExternalData}
+        caption="Disable auto sort on columns"
+        sortable
+        onIcSortChange={(e) => handleSort(e.detail)}
+        sortOptions={{
+          sortOrders: ["ascending", "descending"],
+        }}
+      />
+    );
+  },
+  name: "Disable sort on columns",
 };
 
 /**

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.js
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.js
@@ -12,6 +12,7 @@ import {
   DataTableSizing,
   Dense,
   DevArea,
+  DisableAutoSortColumns,
   DisableSort,
   Embedded,
   Empty,
@@ -144,6 +145,14 @@ export const SortOptionsExample = {
 export const DisableSortExample = {
   render: () => DisableSort(),
   name: "Disable sort",
+};
+
+/**
+ * Alternatively, set `disable-auto-sort` to `true` within the column object to have it apply only to certain columns that may require special custom sorting.
+ */
+export const DisableAutoSortOnColumns = {
+  render: () => DisableAutoSortColumns(),
+  name: "Disable sort on columns",
 };
 
 /**

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -1770,9 +1770,13 @@ export class DataTable {
 
     return this.organisedData
       ?.sort(
-        !this.sortable || this.disableAutoSort
-          ? undefined
-          : this.getSortFunction()
+        this.sortable &&
+          !this.disableAutoSort &&
+          this.sortedColumn &&
+          !this.columns.find((col) => col.key === this.sortedColumn)
+            ?.disableAutoSort
+          ? this.getSortFunction()
+          : undefined
       )
       .map((row, index) => {
         const isRowSelected =
@@ -1875,9 +1879,7 @@ export class DataTable {
     if (column !== this.sortedColumn) {
       if (this.sortedColumn) {
         this.el.shadowRoot
-          ?.querySelector<HTMLIcButtonElement>(
-            `#sort-button-${this.sortedColumn}`
-          )
+          ?.querySelector(`#sort-button-${this.sortedColumn}`)
           ?.setAttribute("aria-label", this.getSortButtonLabel(column)); // Passing through unsorted column returns correct label for newly unsorted column
       }
       this.sortedColumn = column;
@@ -1893,7 +1895,7 @@ export class DataTable {
     this.sortedColumnOrder = sortOrders[nextSortOrderIndex];
 
     this.el.shadowRoot
-      ?.querySelector<HTMLIcButtonElement>(`#sort-button-${column}`)
+      ?.querySelector(`#sort-button-${column}`)
       ?.setAttribute("aria-label", this.getSortButtonLabel(column));
 
     this.tableSorted = true;

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.types.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.types.tsx
@@ -41,6 +41,7 @@ export type IcDataTableColumnObject = {
   };
   excludeColumnFromSort?: boolean;
   hidden?: boolean;
+  disableAutoSort?: boolean;
 };
 
 export type IcLoadingOptions = {

--- a/packages/canary-web-components/src/components/ic-data-table/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/story-data.ts
@@ -1,6 +1,9 @@
 /* istanbul ignore file */
 
-import { IcDataTableColumnObject } from "./ic-data-table.types";
+import {
+  IcDataTableColumnObject,
+  IcSortEventDetail,
+} from "./ic-data-table.types";
 
 /* eslint-disable */
 const name1 = "John Smith";
@@ -89,6 +92,37 @@ export const COLS_WIDTH: IcDataTableColumnObject[] = [
     key: "address",
     title: "Address",
     dataType: "address",
+  },
+];
+
+export const COLS_DISABLE_AUTO_SORT: IcDataTableColumnObject[] = [
+  {
+    key: "firstName",
+    title: "First name",
+    dataType: "string",
+    disableAutoSort: true,
+  },
+  {
+    key: "lastName",
+    title: "Last name",
+    dataType: "string",
+  },
+  {
+    key: "age",
+    title: "Age",
+    dataType: "number",
+  },
+  {
+    key: "jobTitle",
+    title: "Job title",
+    dataType: "string",
+    excludeColumnFromSort: true,
+  },
+  {
+    key: "address",
+    title: "Address",
+    dataType: "address",
+    excludeColumnFromSort: true,
   },
 ];
 
@@ -1634,6 +1668,39 @@ export const DisableSort = (): HTMLIcDataTableElement => {
     }
     dataTable.data = [...DATA];
   });
+  return dataTable;
+};
+
+export const DisableAutoSortColumns = () => {
+  const originalData = [...DATA];
+  const dataTable = createDataTableElement(
+    "Disable sort on columns",
+    COLS_DISABLE_AUTO_SORT,
+    DATA
+  );
+  dataTable.setAttribute("sortable", "true");
+  dataTable.addEventListener(
+    "icSortChange",
+    (event: CustomEvent<IcSortEventDetail>) => {
+      const { columnName, sorted } = event.detail;
+      console.log("Sort changed", columnName, sorted);
+      if (columnName !== "firstName") return;
+
+      if (sorted === "unsorted") {
+        DATA.splice(0, DATA.length, ...originalData);
+      } else {
+        const sortedAscending = sorted === "ascending";
+        DATA.sort((a, b) => {
+          if (a[columnName] < b[columnName]) return sortedAscending ? -1 : 1;
+          if (a[columnName] > b[columnName]) return sortedAscending ? 1 : -1;
+          return 0;
+        });
+      }
+      dataTable.data = [...DATA];
+      console.log("Custom sort applied");
+    }
+  );
+
   return dataTable;
 };
 


### PR DESCRIPTION
## Summary of the changes
- Added `disableAutoSort` to the data table column object to enable external sorting for specific columns
- Added tests and stories 

## Related issue
#3294 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.