### PR TITLE
fix(web-components): remove aria-label from ic-search-bar when using …

### DIFF
--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -873,7 +873,7 @@ export class SearchBar {
               onInput={this.onInput}
               onBlur={this.onInputBlur}
               onFocus={this.onInputFocus}
-              aria-label={label}
+              aria-label={hideLabel ? label : undefined}
               aria-activedescendant={ariaActiveDescendant}
               aria-expanded={
                 options.length > 0 && menuRendered ? `${menuOpen}` : undefined

--- a/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/__snapshots__/ic-search-bar.spec.ts.snap
@@ -48,7 +48,7 @@ exports[`ic-search-bar search should render disabled variant: disabled-removed 1
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container size="medium">
-        <input aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-4" inputmode="search" name="ic-search-bar-input-4" placeholder="Search" value="">
+        <input autocapitalize="off" autocomplete="off" id="ic-search-bar-input-4" inputmode="search" name="ic-search-bar-input-4" placeholder="Search" value="">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
@@ -91,7 +91,7 @@ exports[`ic-search-bar search should render disabled variant: renders-disabled 1
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container disabled="" size="medium">
-        <input aria-label="Test label" autocapitalize="off" autocomplete="off" disabled="" id="ic-search-bar-input-4" inputmode="search" name="ic-search-bar-input-4" placeholder="Search" value="">
+        <input autocapitalize="off" autocomplete="off" disabled="" id="ic-search-bar-input-4" inputmode="search" name="ic-search-bar-input-4" placeholder="Search" value="">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
@@ -134,7 +134,7 @@ exports[`ic-search-bar search should render readonly variant: renders-readonly 1
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container disabled="" readonly="" size="medium">
-        <input aria-label="Test label" autocapitalize="off" autocomplete="off" class="no-left-pad readonly" disabled="" id="ic-search-bar-input-5" inputmode="search" name="ic-search-bar-input-5" placeholder="Search" readonly="" value="">
+        <input autocapitalize="off" autocomplete="off" class="no-left-pad readonly" disabled="" id="ic-search-bar-input-5" inputmode="search" name="ic-search-bar-input-5" placeholder="Search" readonly="" value="">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
@@ -177,7 +177,7 @@ exports[`ic-search-bar search should render required variant: renders-required 1
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container size="medium">
-        <input aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-3" inputmode="search" name="ic-search-bar-input-3" placeholder="Search" required="" value="">
+        <input autocapitalize="off" autocomplete="off" id="ic-search-bar-input-3" inputmode="search" name="ic-search-bar-input-3" placeholder="Search" required="" value="">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
@@ -228,7 +228,7 @@ exports[`ic-search-bar search should render with characters-until-suggestion set
           </ic-typography>
         </ic-input-label>
         <ic-input-component-container size="medium">
-          <input aria-autocomplete="list" aria-controls="ic-search-bar-input-30-menu" aria-describedby="ic-search-bar-input-30-assistive-hint" aria-expanded="true" aria-haspopup="listbox" aria-label="Test label" aria-owns="ic-search-bar-input-30-menu" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-30" inputmode="search" name="ic-search-bar-input-30" placeholder="Search" role="combobox" value="">
+          <input aria-autocomplete="list" aria-controls="ic-search-bar-input-30-menu" aria-describedby="ic-search-bar-input-30-assistive-hint" aria-expanded="true" aria-haspopup="listbox" aria-owns="ic-search-bar-input-30-menu" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-30" inputmode="search" name="ic-search-bar-input-30" placeholder="Search" role="combobox" value="">
           <div class="clear-button-container">
             <ic-button aria-label="Clear" class="clear-button clear-button-unfocused" id="clear-button" size="medium" theme="dark" type="submit" variant="icon">
               svg
@@ -275,7 +275,7 @@ exports[`ic-search-bar search should render with helper-text: renders-with-helpe
           </ic-typography>
         </ic-input-label>
         <ic-input-component-container size="medium">
-          <input aria-autocomplete="list" aria-describedby="ic-search-bar-input-7-helper-text ic-search-bar-input-7-assistive-hint" aria-haspopup="listbox" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-7" inputmode="search" name="ic-search-bar-input-7" placeholder="Search" value="Espresso">
+          <input aria-autocomplete="list" aria-describedby="ic-search-bar-input-7-helper-text ic-search-bar-input-7-assistive-hint" aria-haspopup="listbox" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-7" inputmode="search" name="ic-search-bar-input-7" placeholder="Search" value="Espresso">
           <div class="clear-button-container">
             <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
               <template shadowrootmode="open">
@@ -319,7 +319,7 @@ exports[`ic-search-bar search should render with options: renders-with-options 1
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container size="medium">
-        <input aria-autocomplete="list" aria-describedby="ic-search-bar-input-6-assistive-hint" aria-haspopup="listbox" aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-6" inputmode="search" name="ic-search-bar-input-6" placeholder="Search" value="Espresso">
+        <input aria-autocomplete="list" aria-describedby="ic-search-bar-input-6-assistive-hint" aria-haspopup="listbox" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-6" inputmode="search" name="ic-search-bar-input-6" placeholder="Search" value="Espresso">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
@@ -362,7 +362,7 @@ exports[`ic-search-bar search should render with value: renders-with-value 1`] =
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container size="medium">
-        <input aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-1" inputmode="search" name="ic-search-bar-input-1" placeholder="Search" value="foo">
+        <input autocapitalize="off" autocomplete="off" id="ic-search-bar-input-1" inputmode="search" name="ic-search-bar-input-1" placeholder="Search" value="foo">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">
@@ -405,7 +405,7 @@ exports[`ic-search-bar search should render: renders 1`] = `
         <slot name="helper-text" slot="helper-text"></slot>
       </ic-input-label>
       <ic-input-component-container size="medium">
-        <input aria-label="Test label" autocapitalize="off" autocomplete="off" id="ic-search-bar-input-0" inputmode="search" name="ic-search-bar-input-0" placeholder="Search" value="">
+        <input autocapitalize="off" autocomplete="off" id="ic-search-bar-input-0" inputmode="search" name="ic-search-bar-input-0" placeholder="Search" value="">
         <div class="clear-button-container">
           <ic-button class="clear-button clear-button-unfocused ic-button-size-medium ic-button-variant-icon ic-theme-dark" exportparts="button" id="clear-button">
             <template shadowrootmode="open">


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
ic-search-bar only has an aria-label set when hide-label is true (so there is no visible label).

## Related issue
#2068 internal issue 2780

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.