### PR TITLE
[ic-tree-item]: add prop for custom tree item id

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -9,7 +9,7 @@
       "filePath": "src/components/ic-card-horizontal/ic-card-horizontal.tsx",
       "encapsulation": "shadow",
       "tag": "ic-card-horizontal",
-      "readme": "# ic-horizontal-card\r\n\r\n\r\n\r",
+      "readme": "# ic-horizontal-card\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -472,7 +472,7 @@
       "filePath": "src/components/ic-data-table/ic-data-table.tsx",
       "encapsulation": "shadow",
       "tag": "ic-data-table",
-      "readme": "# ic-data-table\r\n\r\n\r\n\r",
+      "readme": "# ic-data-table\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -809,7 +809,7 @@
           "name": "loadingOptions",
           "type": "undefined | { description?: string | undefined; label?: string | undefined; labelDuration?: number | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; overlay?: boolean | undefined; }",
           "complexType": {
-            "original": "{\r\n    description?: string;\r\n    label?: string;\r\n    labelDuration?: number;\r\n    max?: number;\r\n    min?: number;\r\n    progress?: number;\r\n    monochrome?: boolean;\r\n    overlay?: boolean;\r\n  }",
+            "original": "{\n    description?: string;\n    label?: string;\n    labelDuration?: number;\n    max?: number;\n    min?: number;\n    progress?: number;\n    monochrome?: boolean;\n    overlay?: boolean;\n  }",
             "resolved": "undefined | { description?: string | undefined; label?: string | undefined; labelDuration?: number | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; overlay?: boolean | undefined; }",
             "references": {}
           },
@@ -948,7 +948,7 @@
           "reflectToAttr": false,
           "docs": "Sets the props for the built-in pagination bar. If the `pagination-bar` slot is used then this prop is ignored.",
           "docsTags": [],
-          "default": "{\r\n    alignment: \"right\",\r\n    hideAllFromItemsPerPage: false,\r\n    hideRangeLabel: false,\r\n    itemLabel: \"Item\",\r\n    itemsPerPageOptions: [\r\n      { label: \"10\", value: \"10\" },\r\n      { label: \"25\", value: \"25\" },\r\n      { label: \"50\", value: \"50\" },\r\n    ],\r\n    monochrome: false,\r\n    pageLabel: \"Page\",\r\n    rangeLabelType: \"page\",\r\n    selectedItemsPerPage: 10,\r\n    selectItemsPerPageOnEnter: true,\r\n    setToFirstPageOnPaginationChange: false,\r\n    showGoToPageControl: true,\r\n    showItemsPerPageControl: true,\r\n    type: \"simple\",\r\n  }",
+          "default": "{\n    alignment: \"right\",\n    hideAllFromItemsPerPage: false,\n    hideRangeLabel: false,\n    itemLabel: \"Item\",\n    itemsPerPageOptions: [\n      { label: \"10\", value: \"10\" },\n      { label: \"25\", value: \"25\" },\n      { label: \"50\", value: \"50\" },\n    ],\n    monochrome: false,\n    pageLabel: \"Page\",\n    rangeLabelType: \"page\",\n    selectedItemsPerPage: 10,\n    selectItemsPerPageOnEnter: true,\n    setToFirstPageOnPaginationChange: false,\n    showGoToPageControl: true,\n    showItemsPerPageControl: true,\n    type: \"simple\",\n  }",
           "values": [
             {
               "type": "IcPaginationBarOptions"
@@ -1014,7 +1014,7 @@
           "name": "sortOptions",
           "type": "{ sortOrders: IcDataTableSortOrderOptions[]; defaultColumn?: string | undefined; }",
           "complexType": {
-            "original": "{\r\n    sortOrders: IcDataTableSortOrderOptions[];\r\n    defaultColumn?: string;\r\n  }",
+            "original": "{\n    sortOrders: IcDataTableSortOrderOptions[];\n    defaultColumn?: string;\n  }",
             "resolved": "{ sortOrders: IcDataTableSortOrderOptions[]; defaultColumn?: string | undefined; }",
             "references": {
               "IcDataTableSortOrderOptions": {
@@ -1028,7 +1028,7 @@
           "reflectToAttr": false,
           "docs": "Sets the order columns will be sorted in and allows for 'default' sorts to be added.",
           "docsTags": [],
-          "default": "{\r\n    sortOrders: [\"unsorted\", \"ascending\", \"descending\"],\r\n    defaultColumn: \"\",\r\n  }",
+          "default": "{\n    sortOrders: [\"unsorted\", \"ascending\", \"descending\"],\n    defaultColumn: \"\",\n  }",
           "values": [
             {
               "type": "{ sortOrders: IcDataTableSortOrderOptions[]; defaultColumn?: string"
@@ -1256,7 +1256,7 @@
           "name": "updatingOptions",
           "type": "undefined | { description?: string | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; }",
           "complexType": {
-            "original": "{\r\n    description?: string;\r\n    max?: number;\r\n    min?: number;\r\n    progress?: number;\r\n    monochrome?: boolean;\r\n  }",
+            "original": "{\n    description?: string;\n    max?: number;\n    min?: number;\n    progress?: number;\n    monochrome?: boolean;\n  }",
             "resolved": "undefined | { description?: string | undefined; max?: number | undefined; min?: number | undefined; progress?: number | undefined; monochrome?: boolean | undefined; }",
             "references": {}
           },
@@ -1296,7 +1296,7 @@
           "name": "variableRowHeight",
           "type": "((params: { [key: string]: any; index: number; }) => IcDataTableRowHeights | null) | undefined",
           "complexType": {
-            "original": "(params: {\r\n    [key: string]: any;\r\n    index: number;\r\n  }) => IcDataTableRowHeights | null",
+            "original": "(params: {\n    [key: string]: any;\n    index: number;\n  }) => IcDataTableRowHeights | null",
             "resolved": "((params: { [key: string]: any; index: number; }) => IcDataTableRowHeights | null) | undefined",
             "references": {
               "IcDataTableRowHeights": {
@@ -1308,7 +1308,7 @@
           },
           "mutable": true,
           "reflectToAttr": false,
-          "docs": "Allows for custom setting of row heights on individual rows based on an individual value from the `data` prop and the row index.\r\nIf the function returns `null`, that row's height will be set to the `globalRowHeight` property.",
+          "docs": "Allows for custom setting of row heights on individual rows based on an individual value from the `data` prop and the row index.\nIf the function returns `null`, that row's height will be set to the `globalRowHeight` property.",
           "docsTags": [],
           "values": [
             {
@@ -1457,7 +1457,7 @@
           "detail": "{ row: IcDataTableDataType | null; selectedRows: IcDataTableDataType[]; }",
           "bubbles": true,
           "complexType": {
-            "original": "{\r\n    row: IcDataTableDataType | null;\r\n    selectedRows: IcDataTableDataType[];\r\n  }",
+            "original": "{\n    row: IcDataTableDataType | null;\n    selectedRows: IcDataTableDataType[];\n  }",
             "resolved": "{ row: IcDataTableDataType | null; selectedRows: IcDataTableDataType[]; }",
             "references": {
               "IcDataTableDataType": {
@@ -1626,7 +1626,7 @@
       "filePath": "src/components/ic-data-table-title-bar/ic-data-table-title-bar.tsx",
       "encapsulation": "shadow",
       "tag": "ic-data-table-title-bar",
-      "readme": "# ic-data-table-title-bar\r\n\r\n\r\n\r",
+      "readme": "# ic-data-table-title-bar\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -1846,7 +1846,7 @@
       "filePath": "src/components/ic-date-input/ic-date-input.tsx",
       "encapsulation": "shadow",
       "tag": "ic-date-input",
-      "readme": "# ic-date-input\r\n\r\n\r\n\r",
+      "readme": "# ic-date-input\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -2722,7 +2722,7 @@
       "filePath": "src/components/ic-date-picker/ic-date-picker.tsx",
       "encapsulation": "shadow",
       "tag": "ic-date-picker",
-      "readme": "# ic-date-picker\r\n\r\n\r\n\r",
+      "readme": "# ic-date-picker\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -3711,7 +3711,7 @@
       "filePath": "src/components/ic-pagination-bar/ic-pagination-bar.tsx",
       "encapsulation": "shadow",
       "tag": "ic-pagination-bar",
-      "readme": "# ic-pagination-bar\r\n\r\n\r\n\r",
+      "readme": "# ic-pagination-bar\n\n\n",
       "docs": "",
       "docsTags": [],
       "usage": {},
@@ -3870,7 +3870,7 @@
           "name": "itemsPerPageOptions",
           "type": "undefined | { label: string; value: string; }[]",
           "complexType": {
-            "original": "{\r\n    label: string;\r\n    value: string;\r\n  }[]",
+            "original": "{\n    label: string;\n    value: string;\n  }[]",
             "resolved": "undefined | { label: string; value: string; }[]",
             "references": {}
           },
@@ -4251,7 +4251,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when a page is navigated to via the 'go to' input.\r\nThe `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.",
+          "docs": "Emitted when a page is navigated to via the 'go to' input.\nThe `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.",
           "docsTags": []
         }
       ],
@@ -4339,7 +4339,7 @@
       "filePath": "src/components/ic-tree-item/ic-tree-item.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tree-item",
-      "readme": "# ic-tree-item\r\n\r\n\r\n\r",
+      "readme": "# ic-tree-item\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -4664,6 +4664,32 @@
           "setter": false
         },
         {
+          "name": "treeItemId",
+          "type": "string | undefined",
+          "complexType": {
+            "original": "string",
+            "resolved": "string | undefined",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "tree-item-id",
+          "reflectToAttr": false,
+          "docs": "Sets the tree item id. Must be unique.",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "undefined"
+            }
+          ],
+          "optional": true,
+          "required": false,
+          "getter": false,
+          "setter": false
+        },
+        {
           "name": "truncateTreeItem",
           "type": "boolean | undefined",
           "complexType": {
@@ -4717,11 +4743,11 @@
       "events": [
         {
           "event": "icTreeItemExpanded",
-          "detail": "{ isExpanded: boolean; }",
+          "detail": "{ isExpanded: boolean; id: string; }",
           "bubbles": true,
           "complexType": {
-            "original": "{ isExpanded: boolean }",
-            "resolved": "{ isExpanded: boolean; }",
+            "original": "{\n    isExpanded: boolean;\n    id: string;\n  }",
+            "resolved": "{ isExpanded: boolean; id: string; }",
             "references": {}
           },
           "cancelable": true,
@@ -4786,7 +4812,7 @@
       "filePath": "src/components/ic-tree-view/ic-tree-view.tsx",
       "encapsulation": "shadow",
       "tag": "ic-tree-view",
-      "readme": "# ic-tree-view\r\n\r\n\r\n\r",
+      "readme": "# ic-tree-view\n\n\n",
       "docs": "",
       "docsTags": [
         {
@@ -4948,7 +4974,7 @@
           "mutable": true,
           "attr": "truncate-heading",
           "reflectToAttr": false,
-          "docs": "If `true`, the tree view heading will be truncated instead of text wrapping.\r\nWhen used on small devices, this prop will be overridden and headings will be set to text-wrap.",
+          "docs": "If `true`, the tree view heading will be truncated instead of text wrapping.\nWhen used on small devices, this prop will be overridden and headings will be set to text-wrap.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -4972,7 +4998,7 @@
           "mutable": true,
           "attr": "truncate-tree-items",
           "reflectToAttr": false,
-          "docs": "If `true`, tree items will be truncated, unless they are individually overridden.\r\nWhen used on small devices, this prop will be overridden and tree-items will be set to text-wrap.",
+          "docs": "If `true`, tree items will be truncated, unless they are individually overridden.\nWhen used on small devices, this prop will be overridden and tree-items will be set to text-wrap.",
           "docsTags": [],
           "default": "false",
           "values": [
@@ -5041,7 +5067,7 @@
       "path": "../web-components/dist/types/interface.d.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDataTableColumnObject": {
-      "declaration": "{\r\n  key: string;\r\n  title: string;\r\n  dataType: IcDataTableColumnDataTypes;\r\n  columnAlignment?: {\r\n    horizontal?: string;\r\n    vertical?: string;\r\n  };\r\n  rowOptions?: {\r\n    textWrap: boolean;\r\n  };\r\n  columnWidth?: string | IcDataTableColumnWidthTypes;\r\n  textWrap?: boolean;\r\n  cellAlignment?: string;\r\n  emphasis?: string;\r\n  colspan?: number;\r\n  icon?: {\r\n    icon: string;\r\n    onAllCells?: boolean;\r\n    hideOnHeader?: boolean;\r\n  };\r\n  excludeColumnFromSort?: boolean;\r\n}",
+      "declaration": "{\n  key: string;\n  title: string;\n  dataType: IcDataTableColumnDataTypes;\n  columnAlignment?: {\n    horizontal?: string;\n    vertical?: string;\n  };\n  rowOptions?: {\n    textWrap: boolean;\n  };\n  columnWidth?: string | IcDataTableColumnWidthTypes;\n  textWrap?: boolean;\n  cellAlignment?: string;\n  emphasis?: string;\n  colspan?: number;\n  icon?: {\n    icon: string;\n    onAllCells?: boolean;\n    hideOnHeader?: boolean;\n  };\n  excludeColumnFromSort?: boolean;\n}",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5061,12 +5087,12 @@
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
     "src/utils/types.ts::IcPaginationBarOptions": {
-      "declaration": "export interface IcPaginationBarOptions {\r\n  alignment?: IcPaginationAlignmentOptions;\r\n  hideAllFromItemsPerPage?: boolean;\r\n  hideRangeLabel?: boolean;\r\n  itemLabel?: string;\r\n  itemsPerPageOptions?: { label: string; value: string }[];\r\n  monochrome?: boolean;\r\n  pageLabel?: string;\r\n  rangeLabelType?: IcPaginationLabelTypes;\r\n  selectedItemsPerPage?: number;\r\n  selectItemsPerPageOnEnter?: boolean;\r\n  setToFirstPageOnPaginationChange?: boolean;\r\n  showGoToPageControl?: boolean;\r\n  showItemsPerPageControl?: boolean;\r\n  theme?: IcThemeMode;\r\n  type?: IcPaginationTypes;\r\n}",
+      "declaration": "export interface IcPaginationBarOptions {\n  alignment?: IcPaginationAlignmentOptions;\n  hideAllFromItemsPerPage?: boolean;\n  hideRangeLabel?: boolean;\n  itemLabel?: string;\n  itemsPerPageOptions?: { label: string; value: string }[];\n  monochrome?: boolean;\n  pageLabel?: string;\n  rangeLabelType?: IcPaginationLabelTypes;\n  selectedItemsPerPage?: number;\n  selectItemsPerPageOnEnter?: boolean;\n  setToFirstPageOnPaginationChange?: boolean;\n  showGoToPageControl?: boolean;\n  showItemsPerPageControl?: boolean;\n  theme?: IcThemeMode;\n  type?: IcPaginationTypes;\n}",
       "docstring": "",
       "path": "src/utils/types.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDataTableSortOrderOptions": {
-      "declaration": "export type IcDataTableSortOrderOptions =\r\n  | \"unsorted\"\r\n  | \"ascending\"\r\n  | \"descending\";",
+      "declaration": "export type IcDataTableSortOrderOptions =\n  | \"unsorted\"\n  | \"ascending\"\n  | \"descending\";",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5081,7 +5107,7 @@
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcSortEventDetail": {
-      "declaration": "export interface IcSortEventDetail {\r\n  columnName: string;\r\n  sorted: IcDataTableSortOrderOptions;\r\n}",
+      "declaration": "export interface IcSortEventDetail {\n  columnName: string;\n  sorted: IcDataTableSortOrderOptions;\n}",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5106,7 +5132,7 @@
       "path": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts"
     },
     "src/components/ic-data-table/ic-data-table.types.tsx::IcDensityUpdateEventDetail": {
-      "declaration": "export interface IcDensityUpdateEventDetail {\r\n  value: IcDataTableDensityOptions;\r\n}",
+      "declaration": "export interface IcDensityUpdateEventDetail {\n  value: IcDataTableDensityOptions;\n}",
       "docstring": "",
       "path": "src/components/ic-data-table/ic-data-table.types.tsx"
     },
@@ -5116,7 +5142,7 @@
       "path": "src/utils/types.ts"
     },
     "src/utils/types.ts::IcWeekDays": {
-      "declaration": "export enum IcWeekDays {\r\n  Sunday = 0,\r\n  Monday = 1,\r\n  Tuesday = 2,\r\n  Wednesday = 3,\r\n  Thursday = 4,\r\n  Friday = 5,\r\n  Saturday = 6,\r\n}",
+      "declaration": "export enum IcWeekDays {\n  Sunday = 0,\n  Monday = 1,\n  Tuesday = 2,\n  Wednesday = 3,\n  Thursday = 4,\n  Friday = 5,\n  Saturday = 6,\n}",
       "docstring": "",
       "path": "src/utils/types.ts"
     },
@@ -5131,7 +5157,7 @@
       "path": "src/utils/types.ts"
     },
     "src/components/ic-tree-view/ic-tree-view.types.tsx::IcTreeItemOptions": {
-      "declaration": "{\n  label: string;\n  icon?: string;\n  children?: IcTreeItemOptions[];\n  disabled?: boolean;\n  expanded?: boolean;\n  href?: string;\n  selected?: boolean;\n  theme?: IcThemeMode;\n  truncateTreeItem?: boolean;\n}",
+      "declaration": "{\n  label: string;\n  icon?: string;\n  children?: IcTreeItemOptions[];\n  disabled?: boolean;\n  expanded?: boolean;\n  href?: string;\n  selected?: boolean;\n  treeItemId?: string;\n  theme?: IcThemeMode;\n  truncateTreeItem?: boolean;\n}",
       "docstring": "",
       "path": "src/components/ic-tree-view/ic-tree-view.types.tsx"
     }

--- a/packages/canary-react/src/component-tests/IcTreeView/IcTreeView.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcTreeView/IcTreeView.cy.tsx
@@ -925,6 +925,28 @@ describe("IcTreeView", () => {
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.011),
     });
   });
+
+  it("should retain the custom ID after re-render", () => {
+    mount(
+      <IcTreeView heading="foo">
+        <IcTreeItem treeItemId="bar-1" label="bar" />
+        <IcTreeItem treeItemId="baz-1" label="baz">
+          <IcTreeItem label="qux" />
+        </IcTreeItem>
+      </IcTreeView>
+    );
+
+    cy.checkHydrated(TREE_VIEW);
+
+    cy.get(TREE_ITEM).should("have.id", "bar-1");
+
+    cy.get(TREE_VIEW).find(TREE_ITEM).eq(1).should("have.id", "baz-1");
+
+    cy.get(TREE_VIEW).find(TREE_ITEM).eq(1).click();
+
+    // Assert ID doesn't change after a re-render
+    cy.get(TREE_VIEW).find(TREE_ITEM).eq(1).should("have.id", "baz-1");
+  });
 });
 
 describe("IcTreeView visual regression tests in high contrast mode", () => {

--- a/packages/canary-react/src/stories/ic-tree-view.stories.js
+++ b/packages/canary-react/src/stories/ic-tree-view.stories.js
@@ -98,6 +98,40 @@ export const NestedSlotted = {
   name: "Nested - slotted",
 };
 
+
+export const CustomIDs = {
+  render: () => (
+    <div style={{ width: "250px" }}>
+      <IcTreeView
+        heading="Menu"
+        treeItemData={[
+          { label: "Coffee", treeItemId: "coffee-1"},
+          { label: "Tea", treeItemId: "tea-1"},
+          { label: "Hot chocolate", treeItemId: "hot-chocolate-1" },
+        ]}
+      />
+    </div>
+  ),
+  name: "Custom IDs with Tree Item Data",
+};
+
+export const SlottedCustomIds = {
+  render: () => (
+    <div style={{ width: "250px" }}>
+      <IcTreeView heading="Menu">
+        <IcTreeItem label="Coffee" treeItemId="coffee-1">
+          <IcTreeItem label="Americano" treeItemId="americano-1">
+            <IcTreeItem label="With milk" treeItemId="with-milk-1" />
+          </IcTreeItem>
+        </IcTreeItem>
+        <IcTreeItem label="Tea" treeItemId="tea-1" />
+      </IcTreeView>
+    </div>
+  ),
+  name: "Custom IDs with Slotted",
+};
+
+
 export const WithIcons = {
   render: () => (
     <div style={{ width: "250px" }}>
@@ -826,6 +860,7 @@ const defaultArgs = {
   truncateTreeItems: false,
   treeItemDisabled: false,
   treeItemHref: "",
+  treeItemId: "",
   treeItemLabel: "Coffee",
   treeItemSelected: false,
   showTreeItemIcon: false,
@@ -845,7 +880,8 @@ export const Playground = {
           href: args.treeItemHref,
           disabled: args.treeItemDisabled,
           selected: args.treeItemSelected,
-          icon: args.showTreeItemIcon && '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13,9V3.5L18.5,9M6,2C4.89,2 4,2.89 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6Z" /></svg>'
+          icon: args.showTreeItemIcon && '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13,9V3.5L18.5,9M6,2C4.89,2 4,2.89 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6Z" /></svg>',
+          treeItemId: args.treeItemId
         },
         { label: "Tea" },
         { label: "Hot chocolate" }
@@ -874,6 +910,7 @@ const defaultSlottedArgs = {
   truncateTreeItems: false,
   treeItemDisabled: false,
   treeItemHref: "",
+  treeItemId: "",
   treeItemLabel: "Coffee",
   treeItemSelected: false,
   showTreeItemIcon: false,
@@ -906,6 +943,7 @@ export const PlaygroundSlotted = {
         disabled={args.treeItemDisabled}
         selected={args.treeItemSelected}
         href={args.treeItemHref}
+        treeItemId={args.treeItemId}
       >
         {args.showTreeItemIcon && (
           <SlottedSVG

--- a/packages/canary-web-components/src/components.d.ts
+++ b/packages/canary-web-components/src/components.d.ts
@@ -583,6 +583,10 @@ export namespace Components {
          */
         "theme"?: IcThemeMode1;
         /**
+          * Sets the tree item id. Must be unique.
+         */
+        "treeItemId"?: string;
+        /**
           * If `true`, the tree item label will be truncated instead of text wrapping.
          */
         "truncateTreeItem"?: boolean;
@@ -753,7 +757,10 @@ declare global {
     };
     interface HTMLIcTreeItemElementEventMap {
         "icTreeItemSelected": { id: string };
-        "icTreeItemExpanded": { isExpanded: boolean };
+        "icTreeItemExpanded": {
+    isExpanded: boolean;
+    id: string;
+  };
     }
     interface HTMLIcTreeItemElement extends Components.IcTreeItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIcTreeItemElementEventMap>(type: K, listener: (this: HTMLIcTreeItemElement, ev: IcTreeItemCustomEvent<HTMLIcTreeItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1374,7 +1381,10 @@ declare namespace LocalJSX {
         /**
           * Emitted when tree item is expanded.
          */
-        "onIcTreeItemExpanded"?: (event: IcTreeItemCustomEvent<{ isExpanded: boolean }>) => void;
+        "onIcTreeItemExpanded"?: (event: IcTreeItemCustomEvent<{
+    isExpanded: boolean;
+    id: string;
+  }>) => void;
         /**
           * Emitted when tree item is selected.
          */
@@ -1401,6 +1411,10 @@ declare namespace LocalJSX {
           * Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.
          */
         "theme"?: IcThemeMode1;
+        /**
+          * Sets the tree item id. Must be unique.
+         */
+        "treeItemId"?: string;
         /**
           * If `true`, the tree item label will be truncated instead of text wrapping.
          */

--- a/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-item/ic-tree-item.tsx
@@ -33,7 +33,6 @@ let treeItemIds = 0;
   shadow: true,
 })
 export class TreeItem {
-  private treeItemId = `ic-tree-item-${treeItemIds++}`;
   private treeItemElement: HTMLElement | undefined;
   private treeItemTag = "IC-TREE-ITEM";
   private routerSlot: HTMLElement | null;
@@ -61,7 +60,7 @@ export class TreeItem {
   @Prop({ mutable: true }) expanded: boolean = false;
   @Watch("expanded")
   watchExpandedHandler(): void {
-    this.icTreeItemExpanded.emit({ isExpanded: this.expanded });
+    this.icTreeItemExpanded.emit({ isExpanded: this.expanded, id: this.el.id });
   }
 
   /**
@@ -127,6 +126,11 @@ export class TreeItem {
   @Prop() target?: string;
 
   /**
+   * Sets the tree item id. Must be unique.
+   */
+  @Prop() treeItemId?: string;
+
+  /**
    * Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.
    */
   @Prop() theme?: IcThemeMode = "inherit";
@@ -144,7 +148,10 @@ export class TreeItem {
   /**
    * Emitted when tree item is expanded.
    */
-  @Event() icTreeItemExpanded: EventEmitter<{ isExpanded: boolean }>;
+  @Event() icTreeItemExpanded: EventEmitter<{
+    isExpanded: boolean;
+    id: string;
+  }>;
 
   disconnectedCallback(): void {
     this.hostMutationObserver?.disconnect();
@@ -447,7 +454,7 @@ export class TreeItem {
           [`ic-theme-${theme}`]: theme !== "inherit",
           "ic-tree-item-truncate": !!this.truncateTreeItem,
         }}
-        id={this.treeItemId}
+        id={this.treeItemId ?? `ic-tree-item-${treeItemIds++}`}
       >
         {this.hasRouterSlot() ? (
           <slot name="router-item" />

--- a/packages/canary-web-components/src/components/ic-tree-item/readme.md
+++ b/packages/canary-web-components/src/components/ic-tree-item/readme.md
@@ -19,15 +19,16 @@
 | `selected`         | `selected`           | If `true`, the tree item appears in the selected state.                                                                                 | `boolean`                                                                                                                                                                                             | `false`     |
 | `target`           | `target`             | The place to display the linked URL, as the name for a browsing context (a tab, window, or iframe).                                     | `string \| undefined`                                                                                                                                                                                 | `undefined` |
 | `theme`            | `theme`              | Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component. | `"dark" \| "inherit" \| "light" \| undefined`                                                                                                                                                         | `"inherit"` |
+| `treeItemId`       | `tree-item-id`       | Sets the tree item id. Must be unique.                                                                                                  | `string \| undefined`                                                                                                                                                                                 | `undefined` |
 | `truncateTreeItem` | `truncate-tree-item` | If `true`, the tree item label will be truncated instead of text wrapping.                                                              | `boolean \| undefined`                                                                                                                                                                                | `undefined` |
 
 
 ## Events
 
-| Event                | Description                         | Type                                    |
-| -------------------- | ----------------------------------- | --------------------------------------- |
-| `icTreeItemExpanded` | Emitted when tree item is expanded. | `CustomEvent<{ isExpanded: boolean; }>` |
-| `icTreeItemSelected` | Emitted when tree item is selected. | `CustomEvent<{ id: string; }>`          |
+| Event                | Description                         | Type                                                |
+| -------------------- | ----------------------------------- | --------------------------------------------------- |
+| `icTreeItemExpanded` | Emitted when tree item is expanded. | `CustomEvent<{ isExpanded: boolean; id: string; }>` |
+| `icTreeItemSelected` | Emitted when tree item is selected. | `CustomEvent<{ id: string; }>`                      |
 
 
 ## Methods

--- a/packages/canary-web-components/src/components/ic-tree-item/test/basic/ic-tree-item.spec.ts
+++ b/packages/canary-web-components/src/components/ic-tree-item/test/basic/ic-tree-item.spec.ts
@@ -58,6 +58,15 @@ describe("ic-tree-item component", () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it("should render custom ids", async () => {
+    const page = await newSpecPage({
+      components: [TreeItem],
+      html: `<ic-tree-item label="Item 1" tree-item-id="item-1"><ic-tree-item>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+  });
+
   it("should render disabled", async () => {
     const page = await newSpecPage({
       components: [TreeItem],

--- a/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.stories.js
+++ b/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.stories.js
@@ -97,6 +97,37 @@ export const NestedSlotted = {
   name: "Nested - slotted",
 };
 
+export const CustomIDs = {
+  render: () => html`
+    <div style="width:250px">
+      <ic-tree-view id="nested-tree-view" heading="Menu"> </ic-tree-view>
+    </div>
+    <script>
+      document.querySelector("#nested-tree-view").treeItemData = [
+        { label: "Coffee", treeItemId: "coffee-1" },
+        { label: "Tea", treeItemId: "tea-1" },
+        { label: "Hot chocolate", treeItemId: "hot-chocolate-1" },
+      ];
+    </script>
+  `,
+  name: "Custom IDs with Tree Item Data",
+};
+
+export const SlottedCustomIds = {
+  render: () => html`
+    <div style="width:250px">
+      <ic-tree-view heading="Menu">
+        <ic-tree-item label="Coffee" tree-item-id="coffee-1">
+          <ic-tree-item label="Americano">
+            <ic-tree-item label="With milk" tree-item-id="with-milk-1"></ic-tree-item>
+          </ic-tree-item>
+        </ic-tree-item>
+        <ic-tree-item label="Tea" tree-item-id="tea-1"></ic-tree-view>
+    </div>
+  `,
+  name: "Custom IDs with Slotted",
+};
+
 export const WithIcons = {
   render: () => html`
     <div style="width:250px">

--- a/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.types.tsx
+++ b/packages/canary-web-components/src/components/ic-tree-view/ic-tree-view.types.tsx
@@ -8,6 +8,7 @@ export type IcTreeItemOptions = {
   expanded?: boolean;
   href?: string;
   selected?: boolean;
+  treeItemId?: string;
   theme?: IcThemeMode;
   truncateTreeItem?: boolean;
 };


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
- Added new `treeItemId` prop to `ic-tree-item`. This allows developers to provide their own custom IDs.
- Added the Tree Item ID to the expanded emitted event.

## Related issue
#3670 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 

### Resize/zoom behaviour 

N/A

### System modes

N/A

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 