### PR TITLE
3527 badge position on navigation items within top navigation mega menu

### DIFF
--- a/packages/react/src/stories/ic-top-navigation.stories.js
+++ b/packages/react/src/stories/ic-top-navigation.stories.js
@@ -499,7 +499,15 @@ export const WithGroupNavigation = {
         expandable="true"
         slot="navigation"
       >
-        <IcNavigationItem label="One" href="/" />
+        <IcNavigationItem label="One" href="/">
+          <IcBadge
+            label="1"
+            slot="badge"
+            custom-color="#d4351c"
+            variant="custom"
+            theme="dark"
+          ></IcBadge>
+        </IcNavigationItem>
         <IcNavigationItem label="Two" href="/" />
         <IcNavigationItem label="Three" href="/" />
         <IcNavigationItem label="Four" href="/" />

--- a/packages/web-components/src/components/ic-badge/ic-badge.tsx
+++ b/packages/web-components/src/components/ic-badge/ic-badge.tsx
@@ -195,7 +195,10 @@ export class Badge {
   };
 
   private setPositionInTopNavigation = () => {
-    this.position = this.isInMobileMode() ? "inline" : this.initialPosition;
+    this.position =
+      this.isInMobileMode() || this.isInNavigationItem()
+        ? "inline"
+        : this.initialPosition;
   };
 
   private setPositionInSideNavigation = () => {
@@ -237,6 +240,12 @@ export class Badge {
         greatGrandparentEl?.tagName === SIDE_NAVIGATION) &&
         greatGrandparentEl.classList.contains("mobile-mode"))
     );
+  };
+
+  private isInNavigationItem = (): boolean => {
+    const parentEl = this.el.parentElement;
+    if (!parentEl) return false;
+    return parentEl.tagName === "IC-NAVIGATION-ITEM";
   };
 
   private isAccessibleLabelDefined = () =>

--- a/packages/web-components/src/components/ic-badge/test/basic/__snapshots__/ic-badge.spec.tsx.snap
+++ b/packages/web-components/src/components/ic-badge/test/basic/__snapshots__/ic-badge.spec.tsx.snap
@@ -188,7 +188,7 @@ exports[`ic-badge should render slotted in a navigation item: should render slot
         <ic-typography variant="label">
           Navigation
         </ic-typography>
-        <div class="badge">
+        <div class="inline-badge">
           <slot name="badge"></slot>
         </div>
         <div class="chevron-container"></div>

--- a/packages/web-components/src/components/ic-badge/test/basic/ic-badge.spec.tsx
+++ b/packages/web-components/src/components/ic-badge/test/basic/ic-badge.spec.tsx
@@ -641,7 +641,9 @@ describe("ic-badge", () => {
     document.dispatchEvent(new CustomEvent("icNavigationMenuClosed"));
     expect(page.rootInstance.mode).toBe("navbar");
     badges.forEach((badge, index) => {
-      expect(badge.position).toBe(initialPositions[index]);
+      if (badge.parentElement?.tagName === "IC-NAVIGATION-BUTTON") {
+        expect(badge.position).toBe(initialPositions[index]);
+      }
     });
   });
 

--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -193,7 +193,7 @@ svg {
 :host(.navigation-item-top-nav-child) .link,
 :host(.navigation-item-top-nav-child) ::slotted(a) {
   height: 2.5rem;
-  width: fit-content;
+  width: calc(100% - var(--ic-space-xl));
   min-width: 9.063rem;
   color: var(--ic-top-navigation-nav-item);
   display: flex;

--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.tsx
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.tsx
@@ -242,14 +242,7 @@ export class NavigationItem {
     );
     const slottedBadgeEl = this.el.querySelector('[slot="badge"]');
     const BadgeComponent = slottedBadgeEl && (
-      <div
-        class={
-          slottedBadgeEl.getAttribute("position") === "inline" ||
-          this.inTopNavSideMenu
-            ? "inline-badge"
-            : "badge"
-        }
-      >
+      <div class="inline-badge">
         <slot name="badge"></slot>
       </div>
     );

--- a/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.js
+++ b/packages/web-components/src/components/ic-top-navigation/ic-top-navigation.stories.js
@@ -457,7 +457,15 @@ export const WithGroupedNavigation = {
         label="Navigation group (expandable on mobile)"
         expandable="true"
       >
-        <ic-navigation-item label="One" href="/"></ic-navigation-item>
+        <ic-navigation-item label="One" href="/">
+          <ic-badge
+            label="1"
+            slot="badge"
+            custom-color="#d4351c"
+            variant="custom"
+            theme="dark"
+          ></ic-badge>
+        </ic-navigation-item>
         <ic-navigation-item label="Two" href="/"></ic-navigation-item>
         <ic-navigation-item label="Three" href="/"></ic-navigation-item>
         <ic-navigation-item label="Four" href="/"></ic-navigation-item>
@@ -477,7 +485,16 @@ export const WithGroupedNavigation = {
       </ic-navigation-group>
       <ic-navigation-group slot="navigation" label="Second navigation group">
         <ic-navigation-item label="Another One" href="/"></ic-navigation-item>
-        <ic-navigation-item label="Another Two" href="/"></ic-navigation-item>
+        <ic-navigation-item label="Another Two" href="/">
+          <ic-badge
+            label="1"
+            slot="badge"
+            custom-color="#d4351c"
+            variant="custom"
+            theme="dark"
+            position="far"
+          ></ic-badge>
+        </ic-navigation-item>
         <ic-navigation-item label="Another Three" href="/"></ic-navigation-item>
         <ic-navigation-item label="Another Four" href="/"></ic-navigation-item>
         <ic-navigation-item label="Another Five" href="/"></ic-navigation-item>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update badges so that they appear inline with navigation items in top nav - to match behaviour in mobile mode of top nav.
Also make navigation items span the full width so that when hovered over, they're not different widths.

Tried to add a Cypress test but I couldn't get the mega menu to stay open for the screenshot. We don't seem to have any Cypress visual tests with the mega menu open so I assume it's an issue we've run into before.

## Related issue
#3527 & #3574

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.