### PR TITLE
Fix onClick handling of slotted ActionElement table cells

### DIFF
--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTable.cy.tsx
@@ -15,7 +15,14 @@ import {
   IcLink,
 } from "@ukic/react";
 import { IcPaginationBarOptions } from "@ukic/canary-web-components/src/utils/types";
-import { mdiAccountGroup, mdiImage, mdiPlus } from "@mdi/js";
+import {
+  mdiAccountGroup,
+  mdiCellphone,
+  mdiContentCopy,
+  mdiDownload,
+  mdiImage,
+  mdiPlus,
+} from "@mdi/js";
 
 import {
   COLS,
@@ -1242,107 +1249,244 @@ describe("IcDataTables", () => {
     });
   });
 
-  it("should render an element in the table cell if the data prop contains the actionElement key", () => {
-    mount(
-      <IcDataTable
-        columns={COLS}
-        data={ACTION_DATA_ELEMENTS}
-        caption="Data tables"
-      ></IcDataTable>
-    );
+  context("which uses action elements from the data", () => {
+    it("should render an element in the table cell if the data prop contains the actionElement key", () => {
+      mount(
+        <IcDataTable
+          columns={COLS}
+          data={ACTION_DATA_ELEMENTS}
+          caption="Data tables"
+        ></IcDataTable>
+      );
 
-    cy.checkHydrated(DATA_TABLE_SELECTOR);
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
 
-    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-      .eq(0)
-      .find("span")
-      .should(HAVE_CLASS, ACTION_ELEMENT)
-      .find(IC_BUTTON_SELECTOR)
-      .should(BE_VISIBLE);
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(0)
+        .find("span")
+        .should(HAVE_CLASS, ACTION_ELEMENT)
+        .find(IC_BUTTON_SELECTOR)
+        .should(BE_VISIBLE);
 
-    // cy.checkA11yWithWait(undefined, 300);
+      // cy.checkA11yWithWait(undefined, 300);
 
-    cy.compareSnapshot({
-      name: "/action-elements",
-      testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.039),
-      cypressScreenshotOptions: {
-        capture: "viewport",
-      },
+      cy.compareSnapshot({
+        name: "/action-elements",
+        testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.039),
+        cypressScreenshotOptions: {
+          capture: "viewport",
+        },
+      });
+    });
+
+    it("should show tooltips on action elements", () => {
+      mount(
+        <IcDataTable
+          columns={COLS}
+          data={ACTION_DATA_ELEMENTS}
+          caption="Data tables"
+        ></IcDataTable>
+      );
+
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(0)
+        .find("span")
+        .should(HAVE_CLASS, ACTION_ELEMENT)
+        .find(IC_BUTTON_SELECTOR)
+        .eq(1)
+        .shadow()
+        .find("button")
+        .realHover();
+
+      cy.checkA11yWithWait(undefined, 1000);
+
+      cy.compareSnapshot({
+        name: "/action-elements-tooltip",
+        testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.045),
+        cypressScreenshotOptions: {
+          capture: "viewport",
+        },
+      });
+
+      cy.get("body").realHover({ position: "bottomLeft" }); // Removes hover from upcoming tests, to not trigger the hover state unintentionally
+    });
+
+    it("should not render an element in the table cell if the data prop does not contain the actionElement key", () => {
+      mount(
+        <IcDataTable
+          columns={COLS}
+          data={ACTION_DATA_ELEMENTS}
+          caption="Data tables"
+        ></IcDataTable>
+      );
+
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(1)
+        .find("span")
+        .should("not.exist");
+    });
+
+    it("should apply styling to the cell container if an action element is present in the cell", () => {
+      mount(
+        <IcDataTable
+          columns={COLS}
+          data={ACTION_DATA_ELEMENTS}
+          caption="Data tables"
+        ></IcDataTable>
+      );
+
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(0)
+        .find("div")
+        .eq(0)
+        .should(HAVE_CLASS, "cell-grid-wrapper")
+        .should(HAVE_CSS, "grid-template-columns", "156.797px 32px");
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
+        .should(HAVE_CLASS, ACTION_ELEMENT)
+        .should(HAVE_CSS, "justify-content", "right");
     });
   });
 
-  it("should show tooltips on action elements", () => {
-    mount(
-      <IcDataTable
-        columns={COLS}
-        data={ACTION_DATA_ELEMENTS}
-        caption="Data tables"
-      ></IcDataTable>
-    );
+  context("which uses slotted action elements", () => {
+    const mountTableWithSlottedActionElement = (onClick?: () => void) => {
+      mount(
+        <IcDataTable
+          caption="Slotted Action Element"
+          columns={COLS}
+          data={DATA}
+        >
+          <div slot="firstName-0-action-element" style={{ display: "flex" }}>
+            <IcButton
+              variant="icon"
+              size="small"
+              onClick={onClick}
+              aria-label="Download data"
+              data-testid="download-button"
+            >
+              <SlottedSVG path={mdiDownload} viewBox="0 0 24 24" />
+            </IcButton>
+            <IcButton
+              variant="icon"
+              size="small"
+              onClick={onClick}
+              aria-label="Call phone"
+              data-testid="cellphone-button"
+            >
+              <SlottedSVG path={mdiCellphone} viewBox="0 0 24 24" />
+            </IcButton>
+            <IcButton
+              variant="icon"
+              size="small"
+              onClick={onClick}
+              aria-label="Copy data"
+              data-testid="copy-button"
+            >
+              <SlottedSVG path={mdiContentCopy} viewBox="0 0 24 24" />
+            </IcButton>
+          </div>
+        </IcDataTable>
+      );
+    };
 
-    cy.checkHydrated(DATA_TABLE_SELECTOR);
+    // Can be re-enabled once snapshots have been generated
+    it.skip("should render an element in the table cell if the correct slot is used", () => {
+      mountTableWithSlottedActionElement();
 
-    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-      .eq(0)
-      .find("span")
-      .should(HAVE_CLASS, ACTION_ELEMENT)
-      .find(IC_BUTTON_SELECTOR)
-      .eq(1)
-      .shadow()
-      .find("button")
-      .realHover();
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
 
-    cy.checkA11yWithWait(undefined, 1000);
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(0)
+        .find("span")
+        .should(HAVE_CLASS, ACTION_ELEMENT)
+        .find("slot")
+        .should(HAVE_ATTR, "name", "firstName-0-action-element");
 
-    cy.compareSnapshot({
-      name: "/action-elements-tooltip",
-      testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.045),
-      cypressScreenshotOptions: {
-        capture: "viewport",
-      },
+      cy.checkA11yWithWait(undefined, 300);
+
+      cy.compareSnapshot({
+        name: "/slotted-action-elements",
+        testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.039),
+        cypressScreenshotOptions: {
+          capture: "viewport",
+        },
+      });
     });
 
-    cy.get("body").realHover({ position: "bottomLeft" }); // Removes hover from upcoming tests, to not trigger the hover state unintentionally
-  });
+    it("should work with a passed in onClick", () => {
+      const onClickStub = cy.stub();
+      mountTableWithSlottedActionElement(onClickStub);
 
-  it("should not render an element in the table cell if the data prop does not contain the actionElement key", () => {
-    mount(
-      <IcDataTable
-        columns={COLS}
-        data={ACTION_DATA_ELEMENTS}
-        caption="Data tables"
-      ></IcDataTable>
-    );
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
 
-    cy.checkHydrated(DATA_TABLE_SELECTOR);
+      cy.get('[data-testid="download-button"]').click();
+      cy.get('[data-testid="cellphone-button"]').click();
+      cy.get('[data-testid="copy-button"]')
+        .click()
+        .then(() => {
+          expect(onClickStub).to.be.calledThrice;
+        });
+    });
 
-    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-      .eq(1)
-      .find("span")
-      .should("not.exist");
-  });
+    // Can be re-enabled once snapshots have been generated
+    it.skip("should show tooltips on action elements", () => {
+      mountTableWithSlottedActionElement();
 
-  it("should apply styling to the cell container if an action element is present in the cell", () => {
-    mount(
-      <IcDataTable
-        columns={COLS}
-        data={ACTION_DATA_ELEMENTS}
-        caption="Data tables"
-      ></IcDataTable>
-    );
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
+      cy.get('[data-testid="copy-button"]').shadow().find("button").realHover();
 
-    cy.checkHydrated(DATA_TABLE_SELECTOR);
+      cy.checkA11yWithWait(undefined, 1000);
 
-    cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
-      .eq(0)
-      .find("div")
-      .eq(0)
-      .should(HAVE_CLASS, "cell-grid-wrapper")
-      .should(HAVE_CSS, "grid-template-columns", "156.797px 32px");
+      cy.compareSnapshot({
+        name: "/slotted-action-elements-tooltip",
+        testThreshold: setThresholdBasedOnEnv(DEFAULT_THRESHOLD + 0.045),
+        cypressScreenshotOptions: {
+          capture: "viewport",
+        },
+      });
 
-    cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
-      .should(HAVE_CLASS, ACTION_ELEMENT)
-      .should(HAVE_CSS, "justify-content", "right");
+      cy.get("body").realHover({ position: "bottomLeft" }); // Removes hover from upcoming tests, to not trigger the hover state unintentionally
+    });
+
+    it("should not render an element in the table cell if the slot is not used", () => {
+      mount(
+        <IcDataTable
+          columns={COLS}
+          data={DATA}
+          caption="Data tables"
+        ></IcDataTable>
+      );
+
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(1)
+        .find("span")
+        .should(NOT_EXIST);
+    });
+
+    it("should apply styling to the cell container if an action element is present in the cell", () => {
+      mountTableWithSlottedActionElement();
+
+      cy.checkHydrated(DATA_TABLE_SELECTOR);
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "td")
+        .eq(0)
+        .find("div")
+        .eq(0)
+        .should(HAVE_CLASS, "cell-grid-wrapper")
+        .should(HAVE_CSS, "grid-template-columns", "108.797px 80px");
+
+      cy.findShadowEl(DATA_TABLE_SELECTOR, "span")
+        .should(HAVE_CLASS, ACTION_ELEMENT)
+        .should(HAVE_CSS, "justify-content", "right");
+    });
   });
 
   it("should render empty data values", () => {

--- a/packages/canary-react/src/stories/ic-data-table.stories.js
+++ b/packages/canary-react/src/stories/ic-data-table.stories.js
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable react/jsx-no-bind */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { mdiAccountGroup, mdiDelete, mdiImage } from "@mdi/js";
+import { mdiAccountGroup, mdiCellphone, mdiContentCopy, mdiDelete, mdiDownload, mdiImage } from "@mdi/js";
 import {
   IcButton,
   IcEmptyState,
@@ -922,6 +922,32 @@ export const ActionElement = {
     />
   ),
   name: "Action element",
+};
+
+/**
+* The cells can contain a slotted `actionElement`. The `actionElement` will be displayed to the right of the cell data.
+*/
+export const SlottedActionElement = {
+  render: () => (
+   <IcDataTable
+     caption="Slotted Action Element"
+     columns={COLS}
+     data={DATA}
+   >
+     <div slot="firstName-0-action-element" style={{display: "flex"}}>
+       <IcButton variant="icon" size="small" aria-label="Download data" onClick={() => alert("Download button clicked")}>
+         <SlottedSVG path={mdiDownload} viewBox="0 0 24 24" />
+       </IcButton>
+       <IcButton variant="icon" size="small" aria-label="Call phone" onClick={() => alert("Cellphone button clicked")}>
+         <SlottedSVG path={mdiCellphone} viewBox="0 0 24 24" />
+       </IcButton>
+       <IcButton variant="icon" size="small" aria-label="Copy data" onClick={() => alert("Copy button clicked")}>
+         <SlottedSVG path={mdiContentCopy} viewBox="0 0 24 24" />
+       </IcButton>
+     </div>
+   </IcDataTable>
+ ),
+  name: "Slotted action element",
 };
 
 /**

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.js
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.stories.js
@@ -40,6 +40,7 @@ import {
   Updating,
   UpdatingData,
   SelectWithCheckbox,
+  SlottedActionElement,
 } from "./story-data";
 
 export default {
@@ -451,6 +452,14 @@ export const TableSizingAndColumnWidth = {
 export const ActionElementAndOnClickAction = {
   render: () => ActionElement(),
   name: "Action element",
+};
+
+/**
+ * The cells can contain a slotted `actionElement`. The `actionElement` will be displayed to the right of the cell data.
+ */
+export const SlottedActionElements = {
+  render: () => SlottedActionElement(),
+  name: "Slotted action element",
 };
 
 /**

--- a/packages/canary-web-components/src/components/ic-data-table/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/story-data.ts
@@ -26,12 +26,17 @@ const userIconSVG =
   '<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M480-481q-66 0-108-42t-42-108q0-66 42-108t108-42q66 0 108 42t42 108q0 66-42 108t-108 42ZM160-160v-94q0-38 19-65t49-41q67-30 128.5-45T480-420q62 0 123 15.5t127.921 44.694q31.301 14.126 50.19 40.966Q800-292 800-254v94H160Zm60-60h520v-34q0-16-9.5-30.5T707-306q-64-31-117-42.5T480-360q-57 0-111 11.5T252-306q-14 7-23 21.5t-9 30.5v34Zm260-321q39 0 64.5-25.5T570-631q0-39-25.5-64.5T480-721q-39 0-64.5 25.5T390-631q0 39 25.5 64.5T480-541Zm0-90Zm0 411Z"/></svg>';
 const alertIconSVG =
   '<svg aria-label="alert-icon" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 24 24" fill="#000000"><path d="M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z"/></svg>';
-const copyButton =
-  '<ic-button data-testid="copy-button" variant="icon-tertiary" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="copy-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg> </ic-button>';
-const cellphoneButton =
-  '<ic-button data-testid="cellphone-button" variant="icon-tertiary" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="cellphone-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M17,19H7V5H17M17,1H7C5.89,1 5,1.89 5,3V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V3C19,1.89 18.1,1 17,1Z"/></svg> </ic-button>';
-const downloadButton =
-  '<ic-button data-testid="download-button" variant="icon-tertiary" size="small"  aria-label="you can disable tooltips on icon buttons"> <svg aria-label="download-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg> </ic-button>';
+
+const copyIconSVG =
+  '<svg aria-label="copy-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg>';
+const cellphoneIconSVG =
+  '<svg aria-label="cellphone-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M17,19H7V5H17M17,1H7C5.89,1 5,1.89 5,3V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V3C19,1.89 18.1,1 17,1Z"/></svg>';
+const downloadIconSVG =
+  '<svg aria-label="download-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg>';
+
+const copyButton = `<ic-button data-testid="copy-button" variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> ${copyIconSVG} </ic-button>`;
+const cellphoneButton = `<ic-button data-testid="cellphone-button" variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> ${cellphoneIconSVG} </ic-button>`;
+const downloadButton = `<ic-button data-testid="download-button" variant="icon" size="small"  aria-label="you can disable tooltips on icon buttons"> ${downloadIconSVG} </ic-button>`;
 
 // TODO: Add columnOptions
 export const COLS: IcDataTableColumnObject[] = [
@@ -2076,6 +2081,43 @@ export const SelectWithCheckbox = (): HTMLElement => {
   dataTable.addEventListener("icSelectAllRows", (event: CustomEvent) => {
     console.log("Selected all rows", event.detail);
   });
+
+  return dataTable;
+};
+
+export const SlottedActionElement = (): HTMLElement => {
+  const dataTable = createDataTableElement("Action Element", COLS, DATA);
+
+  const actionElement = document.createElement("div");
+  actionElement.setAttribute("slot", "firstName-0-action-element");
+  actionElement.setAttribute("style", "display: flex");
+
+  const downloadButtonEl = document.createElement("ic-button");
+  downloadButtonEl.setAttribute("variant", "icon");
+  downloadButtonEl.setAttribute("size", "small");
+  downloadButtonEl.addEventListener("click", () =>
+    alert("Download button clicked")
+  );
+  downloadButtonEl.innerHTML = downloadIconSVG;
+  actionElement.appendChild(downloadButtonEl);
+
+  const cellphoneButtonEl = document.createElement("ic-button");
+  cellphoneButtonEl.setAttribute("variant", "icon");
+  cellphoneButtonEl.setAttribute("size", "small");
+  cellphoneButtonEl.addEventListener("click", () =>
+    alert("Cellphone button clicked")
+  );
+  cellphoneButtonEl.innerHTML = cellphoneIconSVG;
+  actionElement.appendChild(cellphoneButtonEl);
+
+  const copyButtonEl = document.createElement("ic-button");
+  copyButtonEl.setAttribute("variant", "icon");
+  copyButtonEl.setAttribute("size", "small");
+  copyButtonEl.addEventListener("click", () => alert("Copy button clicked"));
+  copyButtonEl.innerHTML = copyIconSVG;
+  actionElement.appendChild(copyButtonEl);
+
+  dataTable.appendChild(actionElement);
 
   return dataTable;
 };

--- a/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
@@ -41,6 +41,13 @@ const MOCK_TOOLTIP = {
 const CELL_TYPOGRAPHY = ".table-cell ic-typography";
 const TABLE_CONTAINER_CLASS = ".table-container";
 
+const copyIconSVG =
+  '<svg aria-label="copy-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg>';
+const cellphoneIconSVG =
+  '<svg aria-label="cellphone-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M17,19H7V5H17M17,1H7C5.89,1 5,1.89 5,3V21A2,2 0 0,0 7,23H17A2,2 0 0,0 19,21V3C19,1.89 18.1,1 17,1Z"/></svg>';
+const downloadIconSVG =
+  '<svg aria-label="download-button" xmlns="http://www.w3.org/2000/svg"  width="24" height="24" viewBox="0 0 24 24" fill="#000000"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"/></svg>';
+
 const columns: IcDataTableColumnObject[] = [
   { key: "name", title: "Name", dataType: "string" },
   { key: "age", title: "Age", dataType: "number" },
@@ -3135,5 +3142,63 @@ describe(icDataTable, () => {
     actionEl.click();
     await page.waitForChanges();
     expect(page.rootInstance.handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should test slotted action elements", async () => {
+    const mockCallback = jest.fn((x) => x + 1);
+
+    const page = await newSpecPage({
+      components: [DataTable],
+      template: () => (
+        <ic-data-table caption="test table" columns={columns} data={data}>
+          <div slot="name-0-action-element" style={{ display: "flex" }}>
+            <ic-button
+              variant="icon"
+              size="small"
+              onClick={mockCallback(1)}
+              aria-label="Download data"
+              id="download-button"
+              innerHTML={downloadIconSVG}
+            ></ic-button>
+            <ic-button
+              variant="icon"
+              size="small"
+              onClick={mockCallback(2)}
+              aria-label="Call phone"
+              id="cellphone-button"
+              innerHTML={cellphoneIconSVG}
+            ></ic-button>
+            <ic-button
+              variant="icon"
+              size="small"
+              onClick={mockCallback(3)}
+              aria-label="Copy data"
+              id="copy-button"
+              innerHTML={copyIconSVG}
+            ></ic-button>
+          </div>
+        </ic-data-table>
+      ),
+    });
+
+    expect(page.root).toMatchSnapshot();
+    const dataTable = document.querySelector(icDataTable);
+    const actionEl = dataTable?.shadowRoot?.querySelector(".action-element");
+
+    const downloadButton =
+      actionEl?.querySelector<HTMLIcButtonElement>("#download-button");
+    downloadButton?.click();
+
+    const cellphoneButton =
+      actionEl?.querySelector<HTMLIcButtonElement>("#cellphone-button");
+    cellphoneButton?.click();
+
+    const copyButton =
+      actionEl?.querySelector<HTMLIcButtonElement>("#copy-button");
+    copyButton?.click();
+
+    expect(mockCallback.mock.results[0].value).toEqual(2);
+    expect(mockCallback.mock.results[1].value).toEqual(3);
+    expect(mockCallback.mock.results[2].value).toEqual(4);
   });
 });


### PR DESCRIPTION
## Summary of the changes
The current implementation of the actionElement and actionOnClick fields being passed in via data means there is a limit on what can go into that field, because there is both a clickable button and an icon in the actionElement next to each other, then clicking on the icon will trigger the actionOnClick even though it was only supposed to be used for the button.

This is both a usability and an accessibility issue. 

This change means that whole components can be passed in with their original functionality intact.

## Related issue
Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.