### PR TITLE
fix(web-components): updated aria-live region for loading indicator t…

### DIFF
--- a/packages/web-components/src/components/ic-loading-indicator/test/basic/__snapshots__/ic-loading-indicator.spec.ts.snap
+++ b/packages/web-components/src/components/ic-loading-indicator/test/basic/__snapshots__/ic-loading-indicator.spec.ts.snap
@@ -58,7 +58,7 @@ exports[`ic-loading-indicator component should render a determinate loading indi
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -83,7 +83,7 @@ exports[`ic-loading-indicator component should render an indeterminate loading i
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-label" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-label" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -108,7 +108,7 @@ exports[`ic-loading-indicator component should render an indeterminate loading i
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -174,7 +174,7 @@ exports[`ic-loading-indicator component should set the typography variant for th
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-h2" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-h2" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -199,7 +199,7 @@ exports[`ic-loading-indicator component should set the typography variant for th
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -224,7 +224,7 @@ exports[`ic-loading-indicator component should set the typography variant for th
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-label" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-label" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -244,7 +244,7 @@ exports[`ic-loading-indicator component should update the state when switching f
       <div aria-label="Loading" aria-labelledby="ic-loading-label" aria-valuemax="100" aria-valuemin="0" class="ic-loading-linear-outer indeterminate" role="progressbar">
         <div class="ic-loading-linear-inner"></div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>
@@ -269,7 +269,7 @@ exports[`ic-loading-indicator component should update the state when switching f
           </svg>
         </div>
       </div>
-      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="status">
+      <ic-typography class="ic-loading-label ic-typography-h4" id="ic-loading-label" role="alert">
         <template shadowrootmode="open">
           <slot></slot>
         </template>


### PR DESCRIPTION
## Summary of the changes
Updated the aria role for the loading indicator to be "alert", which will now announce the content by interrupting other announcements. This seemed to be the approach adopted by other guides and examples out there, as it ensures that the state is announced to users on page load, which was my experience with NVDA and VoiceOver. Previously it would announce new changes but on initial load of the element the content would not be added.

## Related issue
#1694 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.