### PR TITLE
Fix flaky Cypress tests

### DIFF
--- a/packages/react/src/component-tests/IcDialog/IcDialog.cy.tsx
+++ b/packages/react/src/component-tests/IcDialog/IcDialog.cy.tsx
@@ -108,43 +108,40 @@ describe("IcDialog end-to-end tests", () => {
     cy.focused().next().next().should(NOT_EXIST);
   });
 
-  it("should test tabbing through slotted content", () => {
+  it("should tab through slotted content", () => {
     mount(<LotsOfSlottedContentDialog />);
 
     cy.get(DIALOG).should("exist");
     cy.wait(300);
     cy.get(DIALOG).should(HAVE_ATTR, "open");
+    cy.get("ic-link").should(HAVE_FOCUS);
 
     // after 2 tabs, the 2nd radio option should have focus
-    cy.wait(300);
     cy.realPress("Tab");
-    cy.wait(300);
+    cy.get("ic-button[slot=action]").should(HAVE_FOCUS);
     cy.realPress("Tab");
-    cy.wait(300);
     cy.get("ic-radio-option[value=value2] input").should(HAVE_FOCUS);
 
     // after 3 more tabs, the text field should have focus
     cy.realPress("Tab");
-    cy.wait(300);
+    cy.get("ic-text-field[slot=additional-field]").should(HAVE_FOCUS);
     cy.realPress("Tab");
-    cy.wait(300);
+    cy.get("ic-search-bar").should(HAVE_FOCUS);
     cy.realPress("Tab");
-    cy.wait(300);
     cy.get("ic-text-field#dialog-text-field").should(HAVE_FOCUS);
 
     // after 4 more tabs, the chip should have focus
     cy.realPress("Tab");
-    cy.wait(300);
+    cy.get("ic-select").should(HAVE_FOCUS);
     cy.realPress("Tab");
-    cy.wait(300);
+    cy.get("ic-checkbox[label=Confirm]").should(HAVE_FOCUS);
     cy.realPress("Tab");
-    cy.wait(300);
+    cy.get("ic-checkbox[label=Disagree]").should(HAVE_FOCUS);
     cy.realPress("Tab");
-    cy.wait(300);
     cy.get("ic-chip").should(HAVE_FOCUS);
   });
 
-  it("should test tabbing backwards through slotted content", () => {
+  it("should tab backwards through slotted content", () => {
     mount(<LotsOfSlottedContentDialog />);
 
     cy.get(DIALOG).should("exist");
@@ -152,44 +149,43 @@ describe("IcDialog end-to-end tests", () => {
     cy.get(DIALOG).should(HAVE_ATTR, "open");
 
     // after 4 shift + tabs, the switch should have focus
-    cy.wait(300);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.findShadowEl(DIALOG, CLOSE_ICON_BUTTON).should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.findShadowEl(DIALOG, "ic-button.dialog-control-button").should(
+      HAVE_FOCUS
+    );
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.findShadowEl(DIALOG, "ic-button.dialog-control-button").should(
+      HAVE_FOCUS
+    );
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
     cy.get("ic-switch").should(HAVE_FOCUS);
 
     // after 4 more shift + tabs, the select should have focus
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-chip").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-checkbox[label=Disagree]").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-checkbox[label=Confirm]").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
     cy.get("ic-select").should(HAVE_FOCUS);
 
     // after 4 more shift + tabs, the second radio option should have focus
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-text-field#dialog-text-field").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-search-bar").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-text-field[slot=additional-field]").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
     cy.get("ic-radio-option[value=value2] input").should(HAVE_FOCUS);
 
     // after 2 more shift + tabs, the link inside the alert should have focus
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
+    cy.get("ic-button[slot=action]").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
-    cy.wait(300);
     cy.get("ic-link").should(HAVE_FOCUS);
   });
 

--- a/packages/web-components/src/components/ic-alert/ic-alert.tsx
+++ b/packages/web-components/src/components/ic-alert/ic-alert.tsx
@@ -152,7 +152,7 @@ export class Alert {
     this.icDismiss.emit();
   };
 
-  private calculateMinHeight = (): void => {
+  private calculateMinHeight(): void {
     const contentHeight = Number(this.messageEl?.clientHeight);
 
     const minHeight = pxToRem(
@@ -161,7 +161,7 @@ export class Alert {
 
     if (this.el.style.getPropertyValue("--ic-alert-min-height") !== minHeight)
       this.el.style.setProperty("--ic-alert-min-height", minHeight);
-  };
+  }
 
   render() {
     const {


### PR DESCRIPTION
## Summary of the changes
When the Cypress tests are run via GitHub workflows, one of the tests within IcAlert.cy.tsx is occasionally failing due to a type error and a few tests within IcDialog.cy.tsx are occasionally failing as the expected elements do not have focus. These changes attempt to prevent these failures and flakiness.