### PR TITLE
fix(web-components): moved padding to child label element

### DIFF
--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
@@ -123,10 +123,13 @@
 }
 
 .checkbox-label {
-  padding-left: var(--ic-space-sm);
   color: var(--ic-checkbox-text);
 
   --ic-typography-color: var(--ic-checkbox-text);
+}
+
+.checkbox-label > label {
+  padding-left: var(--ic-space-sm);
 }
 
 :host(.ic-checkbox-disabled) .checkbox-label {

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -89,7 +89,6 @@ export class Checkbox {
    */
   @Prop() indeterminate = false;
   @State() displayIndeterminate = this.indeterminate;
-
   @Watch("indeterminate")
   watchIndeterminateHandler(): void {
     this.displayIndeterminate =
@@ -155,10 +154,11 @@ export class Checkbox {
 
   componentDidRender(): void {
     if (this.additionalFieldDisplay === "static") {
-      const textfieldElements = this.el.querySelectorAll("ic-text-field");
-      textfieldElements.forEach((textfield) =>
-        textfield.setAttribute("disabled", this.checked ? "false" : "true")
-      );
+      this.el
+        .querySelectorAll("ic-text-field")
+        .forEach((textfield) =>
+          textfield.setAttribute("disabled", `${!this.checked}`)
+        );
     } else if (this.additionalFieldContainer) {
       this.additionalFieldContainer.style.display = !this.checked
         ? "none"


### PR DESCRIPTION
## Summary of the changes
Moved padding to child label element so that the htmlFor attribute accounts for the gap between the two elements and is clickable

## Related issue
#3185 
