### PR TITLE
3724 radio focus on dialog

### DIFF
--- a/packages/react/src/component-tests/IcDialog/IcDialog.cy.tsx
+++ b/packages/react/src/component-tests/IcDialog/IcDialog.cy.tsx
@@ -9,6 +9,7 @@ import {
   SlottedContentDialog,
   SlottedUpdatedContentDialog,
   LotsOfSlottedContentDialog,
+  SlottedUnselectedRadiosDialog,
   NoHeightConstraintDialog,
   AlertDialog,
   SizeDialog,
@@ -187,6 +188,29 @@ describe("IcDialog end-to-end tests", () => {
     cy.get("ic-button[slot=action]").should(HAVE_FOCUS);
     cy.realPress(["Shift", "Tab"]);
     cy.get("ic-link").should(HAVE_FOCUS);
+  });
+
+  it("should test focus of radio options when none selected", () => {
+    mount(<SlottedUnselectedRadiosDialog />);
+
+    cy.get(DIALOG).should("exist");
+    cy.wait(300);
+    cy.get(DIALOG).should(HAVE_ATTR, "open");
+
+    // the first unselected radio option should have focus
+    cy.wait(300);
+    cy.get("ic-radio-option[value=value1] input").should(HAVE_FOCUS);
+
+    // after tab, the text field should have focus
+    cy.realPress("Tab");
+    cy.wait(300);
+    cy.get("ic-text-field#dialog-text-field").should(HAVE_FOCUS);
+
+    // after shift + tab press, the first unselected radio option should have focus
+    cy.realPress(["Shift", "Tab"]);
+    cy.wait(300);
+
+    cy.get("ic-radio-option[value=value1] input").should(HAVE_FOCUS);
   });
 
   it("should hide dialog on pressing escape on dialog", () => {

--- a/packages/react/src/component-tests/IcDialog/IcDialogTestData.tsx
+++ b/packages/react/src/component-tests/IcDialog/IcDialogTestData.tsx
@@ -249,6 +249,62 @@ export const LotsOfSlottedContentDialog = () => {
   );
 };
 
+export const SlottedUnselectedRadiosDialog = () => {
+  return (
+    <>
+      <IcDialog disableWidthConstraint size="large" open>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.75rem",
+          }}
+        >
+          <IcTypography slot="heading" variant="h4">
+            This is a slotted heading
+          </IcTypography>
+          <IcTypography slot="label" variant="label">
+            Slotted label
+          </IcTypography>
+          <IcRadioGroup label="This is a label" name="1">
+            <IcRadioOption
+              value="value1"
+              label="Unselected / Default"
+              additionalFieldDisplay="dynamic"
+            >
+              <IcTextField
+                slot="additional-field"
+                placeholder="Placeholder"
+                label="What's your favourite type of coffee?"
+              ></IcTextField>
+            </IcRadioOption>
+            <IcRadioOption
+              value="value2"
+              label="Selected / Default"
+              additionalFieldDisplay="static"
+            >
+              <IcTextField
+                slot="additional-field"
+                placeholder="Placeholder"
+                label="What's your favourite type of coffee?"
+              ></IcTextField>
+            </IcRadioOption>
+            <IcRadioOption
+              value="value3"
+              label="Unselected / Disabled"
+              disabled
+            ></IcRadioOption>
+          </IcRadioGroup>
+          <IcTextField
+            id="dialog-text-field"
+            label="What is your favourite coffee?"
+          />
+        </div>
+      </IcDialog>
+    </>
+  );
+};
+
 export const DialogAccordion = () => {
   const dialogEl = useRef<HTMLIcDialogElement>(null);
   const handleClick = () => {

--- a/packages/react/src/stories/ic-dialog.stories.js
+++ b/packages/react/src/stories/ic-dialog.stories.js
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { SlottedSVG } from "../";
 import {
   IcAlert,
+  IcAccordion,
   IcButton,
   IcCheckbox,
   IcCheckboxGroup,
@@ -245,20 +246,28 @@ export const SlottedContent = {
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </IcTypography>
-          <IcRadioGroup label="This is a label" name="1">
-            <IcRadioOption
-              value="valueName1"
-              label="Unselected / Default" 
-              additionalFieldDisplay="dynamic"       
-            >
+           <IcAccordion heading="This is an accordion">
+            <IcCheckbox label="Confirm" value="confirm" additionalFieldDisplay="static">
               <IcTextField
                 slot="additional-field"
                 placeholder="Placeholder"
                 label="What's your favourite type of coffee?"
+              />
+            </IcCheckbox>
+            <IcRadioGroup label="This is a label" name="1">
+              <IcRadioOption
+                value="valueName1"
+                label="Unselected / Default" 
+                additionalFieldDisplay="dynamic"       
               >
-              </IcTextField>
-            </IcRadioOption>
-            <IcRadioOption
+                <IcTextField
+                  slot="additional-field"
+                  placeholder="Placeholder"
+                  label="What's your favourite type of coffee?"
+                >
+                </IcTextField>
+              </IcRadioOption>
+              <IcRadioOption
               value="valueName2"
               label="Selected / Default"
               additionalFieldDisplay="static"
@@ -277,6 +286,7 @@ export const SlottedContent = {
               disabled
             ></IcRadioOption>
           </IcRadioGroup>
+          </IcAccordion>
           <IcSearchBar label="What is your favourite coffee?"></IcSearchBar>
           <IcTextField label="What is your favourite coffee?" />
           <IcSelect label="What is your favourite coffee?" options={options} />

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.stories.js
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.stories.js
@@ -138,38 +138,47 @@ export const SlottedContent = {
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua.
         </ic-typography>
-        <ic-radio-group label="This is a label" name="1">
-        <ic-radio-option
-          value="valueName1"
-          label="Unselected / Default" 
-          additional-field-display="dynamic"       
-        >
-          <ic-text-field
-            slot="additional-field"
-            placeholder="Placeholder"
-            label="What's your favourite type of coffee?"
+        <ic-accordion heading="This is an accordion">
+          <ic-checkbox label="Agree" value="confirm" additional-field-display="static">
+            <ic-text-field
+              slot="additional-field"
+              placeholder="Placeholder"
+              label="What's your favourite type of coffee?"
+            />
+          </ic-checkbox>
+          <ic-radio-group label="This is a label" name="1">
+          <ic-radio-option
+            value="valueName1"
+            label="Unselected / Default" 
+            additional-field-display="dynamic"       
           >
-          </ic-text-field>
-        </ic-radio-option>
-        <ic-radio-option
-          value="valueName2"
-          label="Selected / Default"
-          additional-field-display="static"
-          selected
-        >
-          <ic-text-field
-            slot="additional-field"
-            placeholder="Placeholder"
-            label="What's your favourite type of coffee?"
+            <ic-text-field
+              slot="additional-field"
+              placeholder="Placeholder"
+              label="What's your favourite type of coffee?"
+            >
+            </ic-text-field>
+          </ic-radio-option>
+          <ic-radio-option
+            value="valueName2"
+            label="Selected / Default"
+            additional-field-display="static"
+            selected
           >
-          </ic-text-field>
-        </ic-radio-option>
-        <ic-radio-option
-          value="valueName3"
-          label="Unselected / Disabled"
-          disabled
-        ></ic-radio-option>
-      </ic-radio-group>
+            <ic-text-field
+              slot="additional-field"
+              placeholder="Placeholder"
+              label="What's your favourite type of coffee?"
+            >
+            </ic-text-field>
+          </ic-radio-option>
+          <ic-radio-option
+            value="valueName3"
+            label="Unselected / Disabled"
+            disabled
+          ></ic-radio-option>
+        </ic-radio-group>
+      </ic-accordion>
       <ic-search-bar label="What is your favourite coffee?"></ic-search-bar>
       <ic-text-field label="What is your favourite coffee?"></ic-text-field>
       <ic-select

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
@@ -420,7 +420,7 @@ export class Dialog {
       isHidden ||
       (element.getAttribute("type") === "radio" &&
         !!radioEl &&
-        !radioEl.hasAttribute("selected"))
+        !(radioEl.hasAttribute("selected") || element.tabIndex === 0))
     );
   };
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes issue where unselected radio options did not receive focus on dialog

## Related issue
#3724 

## Checklist

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] Manual keyboard testing for keyboard controls and logical focus order. 

### System modes

- [x] Browser support tested (Chrome, Firefox and Edge). 

