### PR TITLE
fix(web-components): increase z-index for skip link

### DIFF
--- a/packages/web-components/src/global/variables.css
+++ b/packages/web-components/src/global/variables.css
@@ -39,7 +39,6 @@
   --ic-z-index-base-value: 0;
   --ic-z-index-page-header: calc(var(--ic-z-index-base-value) + 10);
   --ic-z-index-back-to-top: calc(var(--ic-z-index-base-value) + 20);
-  --ic-z-index-skip-link: calc(var(--ic-z-index-base-value) + 20);
   --ic-z-index-popover: calc(var(--ic-z-index-base-value) + 50);
   --ic-z-index-sticky-page-header: calc(var(--ic-z-index-base-value) + 60);
   --ic-z-index-date-picker: calc(var(--ic-z-index-base-value) + 70);
@@ -51,4 +50,5 @@
   --ic-z-index-toast: calc(var(--ic-z-index-base-value) + 110);
   --ic-z-index-tooltip: calc(var(--ic-z-index-base-value) + 110);
   --ic-z-index-classification-banner: calc(var(--ic-z-index-base-value) + 200);
+  --ic-z-index-skip-link: calc(var(--ic-z-index-base-value) + 210);
 }

--- a/packages/web-components/src/patterns/z-index.stories.js
+++ b/packages/web-components/src/patterns/z-index.stories.js
@@ -12,6 +12,7 @@ export const ComponentZIndex = {
       }
     </style>
     <div style="display:flex;">
+      <ic-skip-link target="main"></ic-skip-link>
       <ic-side-navigation
         app-title="Application Name"
         version="v0.0.7"
@@ -160,7 +161,7 @@ export const ComponentZIndex = {
         class="content-wrapper"
         style="display:flex; flex-direction: column; flex-grow: 1;"
       >
-        <main>
+        <main id="main">
           <ic-top-navigation
             app-title="Application Name"
             status="beta"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

- Increase z-index for `IcSkipLink` so it appears above `IcSideNavigation`
- Add `ic-skip-link` to component z-index story

## Related issue
#3716 

## Checklist

### General 

- [x] All acceptance criteria reviewed and met. 

### Accessibility 

- [x] Manual keyboard testing for logical focus order. 