### PR TITLE
test(react): add skip to IcAlert high contrast visual regression tests

### DIFF
--- a/packages/react/src/component-tests/IcAlert/IcAlert.cy.tsx
+++ b/packages/react/src/component-tests/IcAlert/IcAlert.cy.tsx
@@ -363,7 +363,7 @@ describe("IcAlert visual regression and a11y tests", () => {
   });
 });
 
-describe("IcAlert visual regression tests in high contrast mode", () => {
+describe.skip("IcAlert visual regression tests in high contrast mode", () => {
   before(() => {
     cy.enableForcedColors();
   });


### PR DESCRIPTION
## Summary of the changes
Noticed the IcAlert tests are still failing occasionally so created this PR to temporarily skip the problematic tests before investigating an actual fix, so as not to waste dev time with workflows having to be re-run.