### PR TITLE
ci(root): update release check workflow file to include check for unc…

### DIFF
--- a/.github/workflows/ic-ui-kit-release-check.yml
+++ b/.github/workflows/ic-ui-kit-release-check.yml
@@ -21,6 +21,19 @@ jobs:
         with:
           node-version: 20
       - uses: browser-actions/setup-chrome@97349de5c98094d4fc9412f31c524d7697115ad8 #v1.5.0
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run bootstrap -- -- --ci
+      - name: Build
+        run: npm run build:all
+      - name: Check for uncommitted changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Error: Some auto-generated files have uncommitted changes."
+            git status
+            exit 1
+          fi
       - name: Run release check
         run: |
           RELEASE_CHECK=$((echo y; sleep 0.5; echo $'\n';) | npm run release-check)
@@ -62,7 +75,7 @@ jobs:
           git checkout -b $RELEASE_BRANCH origin/develop
           echo "${{ env.VERSION }}" > DEVELOPMENT_RELEASE_CHECK.md
           git add DEVELOPMENT_RELEASE_CHECK.md
-          git commit -m "chore(release): update development release version check file"
+          git commit -m "chore(release): update development release version check file" --no-verify
           git push origin $RELEASE_BRANCH
       - name: Create release branch -> develop PR 
         run: |


### PR DESCRIPTION
## Summary of the changes
Updated release-check workflow to include a check for uncommitted changes in automatically generated files (docs, readmes etc.). 

Thought this was the best workflow file to put it in so we can know as early as possible in the release process if there are uncommitted changes (this check happens before the Release -> Develop PR is opened).

I tested this on a fork of the ic-ui-kit repo; the check [tells you what files have uncommitted changes](https://github.com/GCHQ-Developer-847/ic-ui-kit/actions/runs/16223725238/job/45811768548) if it fails.

Also I had to add the `--no-verify` because the Cypress tests would start running when the `git commit` is run. Don't know if that was just due to the set-up of my fork but this fixed it

## Related issue
#3641 