### PR TITLE
Side nav status prop fix

### DIFF
--- a/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
+++ b/packages/web-components/src/components/ic-side-navigation/ic-side-navigation.tsx
@@ -836,7 +836,7 @@ export class SideNavigation {
                 ></button>
               )}
               <div class="app-status-wrapper">
-                {status !== "" && (
+                {status && (
                   <div
                     class={{
                       ["app-status"]: true,
@@ -851,7 +851,7 @@ export class SideNavigation {
                     </ic-typography>
                   </div>
                 )}
-                {version !== "" && (
+                {version && (
                   <ic-typography
                     variant="label"
                     class="app-version"

--- a/packages/web-components/src/components/ic-side-navigation/test/basic/__snapshots__/ic-side-navigation.spec.ts.snap
+++ b/packages/web-components/src/components/ic-side-navigation/test/basic/__snapshots__/ic-side-navigation.spec.ts.snap
@@ -26,12 +26,7 @@ exports[`ic-side-navigation should render expanded: renders-expanded 1`] = `
           <button aria-label="Collapse side navigation" class="menu-expand-button">
             svg
           </button>
-          <div class="app-status-wrapper">
-            <div class="app-status">
-              <ic-typography aria-label="app tag" class="app-status-text" variant="label-uppercase"></ic-typography>
-            </div>
-            <ic-typography aria-label="app version" class="app-version" variant="label"></ic-typography>
-          </div>
+          <div class="app-status-wrapper"></div>
         </div>
       </div>
     </div>
@@ -108,12 +103,7 @@ exports[`ic-side-navigation should render with app-title: renders-with-app-title
           <button aria-label="Expand side navigation" class="menu-expand-button">
             svg
           </button>
-          <div class="app-status-wrapper">
-            <div class="app-status">
-              <ic-typography aria-label="app tag" class="app-status-text" variant="label-uppercase"></ic-typography>
-            </div>
-            <ic-typography aria-label="app version" class="app-version" variant="label"></ic-typography>
-          </div>
+          <div class="app-status-wrapper"></div>
         </div>
       </div>
     </div>
@@ -172,7 +162,16 @@ exports[`ic-side-navigation should render with primary navigation items and coll
   </template>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav navigation-item-side-nav-collapsed navigation-item-side-nav-collapsed-with-label" collapsed-icon-label="true" display-navigation-tooltip="false" href="/" label="Home" role="listitem" slot="primary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="Home" placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              Home
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <a class="link" href="/" part="link">
           <div class="icon">
             <slot name="icon"></slot>
@@ -242,7 +241,16 @@ exports[`ic-side-navigation should render with primary navigation items: renders
   </template>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav navigation-item-side-nav-collapsed" display-navigation-tooltip="false" href="/" label="Home" role="listitem" slot="primary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="Home" placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              Home
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <a class="link" href="/" part="link">
           <div class="icon">
             <slot name="icon"></slot>
@@ -312,7 +320,16 @@ exports[`ic-side-navigation should render with secondary navigation items: rende
   </template>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav navigation-item-side-nav-collapsed" display-navigation-tooltip="false" href="/" label="a11y" role="listitem" slot="secondary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="a11y" placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              a11y
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <a class="link" href="/" part="link">
           <div class="icon">
             <slot name="icon"></slot>
@@ -375,24 +392,23 @@ exports[`ic-side-navigation should render with slotted navigation item - collaps
           <button aria-label="Expand side navigation" class="menu-expand-button">
             svg
           </button>
-          <div class="app-status-wrapper">
-            <div class="app-status">
-              <ic-typography aria-label="app tag" class="app-status-text" variant="label-uppercase"></ic-typography>
-            </div>
-            <ic-typography aria-label="app version" class="app-version" variant="label"></ic-typography>
-          </div>
+          <div class="app-status-wrapper"></div>
         </div>
       </div>
     </div>
   </template>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav navigation-item-side-nav-collapsed navigation-item-side-nav-collapsed-with-label" collapsed-icon-label="true" display-navigation-tooltip="false" role="listitem" slot="primary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="
-              
-                
-              
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
               Daily Tippers
-            " placement="right" target="navigation-item">
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <slot name="navigation-item"></slot>
       </ic-tooltip>
     </template>
@@ -409,7 +425,16 @@ exports[`ic-side-navigation should render with slotted navigation item - collaps
   </ic-navigation-item>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav navigation-item-side-nav-collapsed navigation-item-side-nav-collapsed-with-label" collapsed-icon-label="true" display-navigation-tooltip="false" href="/" label="a11y" role="listitem" slot="secondary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="a11y" placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              a11y
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <a class="link" href="/" part="link">
           <div class="icon">
             <slot name="icon"></slot>
@@ -472,21 +497,23 @@ exports[`ic-side-navigation should render with slotted navigation item - collaps
           <button aria-label="Collapse side navigation" class="menu-expand-button">
             svg
           </button>
-          <div class="app-status-wrapper">
-            <div class="app-status">
-              <ic-typography aria-label="app tag" class="app-status-text" variant="label-uppercase"></ic-typography>
-            </div>
-            <ic-typography aria-label="app version" class="app-version" variant="label"></ic-typography>
-          </div>
+          <div class="app-status-wrapper"></div>
         </div>
       </div>
     </div>
   </template>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav" collapsed-icon-label="true" display-navigation-tooltip="false" role="listitem" slot="primary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="
-                
-              Daily Tippers" placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item tooltip-navigation-item-side-nav-collapsed" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              Daily Tippers
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <slot name="navigation-item"></slot>
       </ic-tooltip>
     </template>
@@ -503,7 +530,16 @@ exports[`ic-side-navigation should render with slotted navigation item - collaps
   </ic-navigation-item>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav" collapsed-icon-label="true" display-navigation-tooltip="false" href="/" label="a11y" role="listitem" slot="secondary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="a11y" placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item tooltip-navigation-item-side-nav-collapsed" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              a11y
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <a class="link" href="/" part="link">
           <div class="icon">
             <slot name="icon"></slot>
@@ -557,24 +593,23 @@ exports[`ic-side-navigation should render with slotted navigation item: slotted-
           <button aria-label="Expand side navigation" class="menu-expand-button">
             svg
           </button>
-          <div class="app-status-wrapper">
-            <div class="app-status">
-              <ic-typography aria-label="app tag" class="app-status-text" variant="label-uppercase"></ic-typography>
-            </div>
-            <ic-typography aria-label="app version" class="app-version" variant="label"></ic-typography>
-          </div>
+          <div class="app-status-wrapper"></div>
         </div>
       </div>
     </div>
   </template>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav navigation-item-side-nav-collapsed" display-navigation-tooltip="false" role="listitem" slot="primary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="
-              
-                
-              
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
               Daily Tippers
-            " placement="right" target="navigation-item">
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <slot name="navigation-item"></slot>
       </ic-tooltip>
     </template>
@@ -656,12 +691,16 @@ exports[`ic-side-navigation should render with slotted primary secondary navigat
   </svg>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav" role="listitem" slot="primary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="
-          
-            
-          
-          Daily Tippers
-        " placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              Daily Tippers
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <slot name="navigation-item"></slot>
       </ic-tooltip>
     </template>
@@ -692,12 +731,16 @@ exports[`ic-side-navigation should render with slotted primary secondary navigat
     </template>
     <ic-navigation-item class="light navigation-item navigation-item-side-nav" role="listitem">
       <template shadowrootmode="open">
-        <ic-tooltip class="tooltip-navigation-item" label="
-            
-              
-            
-            Daily Tippers
-          " placement="right" target="navigation-item">
+        <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+          <template shadowrootmode="open">
+            <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+              <ic-typography variant="caption">
+                Daily Tippers
+              </ic-typography>
+              <div class="ic-tooltip-arrow"></div>
+            </div>
+            <slot></slot>
+          </template>
           <slot name="navigation-item"></slot>
         </ic-tooltip>
       </template>
@@ -715,12 +758,16 @@ exports[`ic-side-navigation should render with slotted primary secondary navigat
   </ic-navigation-group>
   <ic-navigation-item class="light navigation-item navigation-item-side-nav" role="listitem" slot="secondary-navigation">
     <template shadowrootmode="open">
-      <ic-tooltip class="tooltip-navigation-item" label="
-          
-            
-          
-          bar
-        " placement="right" target="navigation-item">
+      <ic-tooltip class="ic-tooltip tooltip-navigation-item" target="navigation-item">
+        <template shadowrootmode="open">
+          <div aria-hidden="false" class="ic-tooltip-container" role="tooltip">
+            <ic-typography variant="caption">
+              bar
+            </ic-typography>
+            <div class="ic-tooltip-arrow"></div>
+          </div>
+          <slot></slot>
+        </template>
         <slot name="navigation-item"></slot>
       </ic-tooltip>
     </template>

--- a/packages/web-components/src/components/ic-side-navigation/test/basic/ic-side-navigation.spec.ts
+++ b/packages/web-components/src/components/ic-side-navigation/test/basic/ic-side-navigation.spec.ts
@@ -3,6 +3,7 @@ import { DEVICE_SIZES } from "../../../../utils/helpers";
 import { Button } from "../../../ic-button/ic-button";
 import { NavigationGroup } from "../../../ic-navigation-group/ic-navigation-group";
 import { NavigationItem } from "../../../ic-navigation-item/ic-navigation-item";
+import { Tooltip } from "../../../ic-tooltip/ic-tooltip";
 import { SideNavigation } from "../../ic-side-navigation";
 
 describe("ic-side-navigation", () => {
@@ -26,7 +27,7 @@ describe("ic-side-navigation", () => {
 
   it("should render with primary navigation items", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `
         <ic-side-navigation version="v0.0.0" app-title="ACME" status="BETA">
           <ic-navigation-item slot="primary-navigation" href="/" label="Home">
@@ -53,7 +54,7 @@ describe("ic-side-navigation", () => {
 
   it("should render with secondary navigation items", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `
         <ic-side-navigation version="v0.0.0" status="BETA" app-title="ACME">
         <ic-navigation-item slot="secondary-navigation" href="/" label="a11y">
@@ -82,7 +83,7 @@ describe("ic-side-navigation", () => {
 
   it("should render with slotted navigation item", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `<ic-side-navigation app-title="ACME">
         <ic-navigation-item slot="primary-navigation">
             <a
@@ -115,7 +116,7 @@ describe("ic-side-navigation", () => {
 
   it("should render with slotted navigation item - collapsed icon labels true", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `<ic-side-navigation app-title="ACME" collapsed-icon-labels="true">
         <ic-navigation-item slot="primary-navigation">
             <a
@@ -174,7 +175,7 @@ describe("ic-side-navigation", () => {
 
   it("should test menu toggle slotted nav items - collapsed icon labels false", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `<ic-side-navigation app-title="ACME" collapsed-icon-labels="false">
         <ic-navigation-item slot="primary-navigation">
             <a
@@ -211,7 +212,7 @@ describe("ic-side-navigation", () => {
 
   it("should set navigation item width to 320px when expanded", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `<ic-side-navigation app-title="ACME" collapsed-icon-labels="false">
         <ic-navigation-item slot="primary-navigation">
             <a
@@ -262,7 +263,7 @@ describe("ic-side-navigation", () => {
 
   it("should render with primary navigation items and collapsed icon labels", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `
         <ic-side-navigation version="v0.0.0" app-title="ACME" status="BETA" collapsed-icon-labels="true">
           <ic-navigation-item slot="primary-navigation" href="/" label="Home">
@@ -324,7 +325,7 @@ describe("ic-side-navigation", () => {
 
   it("should test menu toggle", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem, Button],
+      components: [SideNavigation, NavigationItem, Button, Tooltip],
       html: `<ic-side-navigation app-title="ACME" version="v0.0.0" status="BETA">
       <ic-navigation-item slot="primary-navigation">
       <a
@@ -366,7 +367,7 @@ describe("ic-side-navigation", () => {
 
   it("should test resizing - collapsed icon labels false", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `<ic-side-navigation version="v0.0.0" status="BETA" app-title="ACME" collapsed-icon-labels="false">
       <ic-navigation-item slot="primary-navigation">
       <a
@@ -400,7 +401,7 @@ describe("ic-side-navigation", () => {
 
   it("should test transitionend event", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `
         <ic-side-navigation version="v0.0.0" status="BETA" app-title="ACME" collapsed-icon-labels="true">
         <ic-navigation-item slot="primary-navigation" href="/" label="Home">
@@ -454,7 +455,7 @@ describe("ic-side-navigation", () => {
 
   it("should collapse side navigation when closeOnNavItemClick is true and nav item is clicked", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem],
+      components: [SideNavigation, NavigationItem, Tooltip],
       html: `<ic-side-navigation close-on-nav-item-click="true" expanded="true" app-title="ACME">
         <ic-navigation-item slot="primary-navigation" label="Home"></ic-navigation-item>
       </ic-side-navigation>
@@ -495,7 +496,7 @@ describe("ic-side-navigation", () => {
 
   it("should render with slotted primary secondary navigation and expanded", async () => {
     const page = await newSpecPage({
-      components: [SideNavigation, NavigationItem, NavigationGroup],
+      components: [SideNavigation, NavigationItem, NavigationGroup, Tooltip],
       html: `<ic-side-navigation app-title="Application Name" version="v0.0.0" status="BETA" expanded="true">
       <svg
         slot="app-icon"


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fixes issue where status tag would display empty in side navigation if `status` prop was not specified
Applied the same logic to the version prop

Also fixed issue with unit tests throwing multiple errors due to tooltip component not being included

## Related issue
#3756 

## Checklist

### Testing

- [x] Relevant unit tests and visual regression tests added. 

### Testing content extremes

- [x] Props/slots can be updated after initial render.