### PR TITLE
fix(web-components): fix ic-button form prop and pass form submission…

### DIFF
--- a/packages/web-components/src/components/ic-button/ic-button.tsx
+++ b/packages/web-components/src/components/ic-button/ic-button.tsx
@@ -16,6 +16,7 @@ import {
 
 import {
   getBrandFromContext,
+  handleHiddenFormButtonClick,
   inheritAttributes,
   isSlotUsed,
   removeDisabledFalse,
@@ -384,17 +385,13 @@ export class Button {
     if (
       (this.el.type === "submit" || this.el.type === "reset") &&
       !this.hasRouterSlot() &&
-      !!this.el.closest("FORM")
+      (this.form || !!this.el.closest("FORM"))
     ) {
-      const hiddenFormButton = document.createElement("button");
+      const form = this.form
+        ? document.querySelector<HTMLFormElement>(`form[id=${this.form}]`)
+        : this.el.closest<HTMLFormElement>("FORM");
 
-      hiddenFormButton.setAttribute("type", this.el.type);
-      hiddenFormButton.style.display = "none";
-
-      this.el.closest("FORM")?.appendChild(hiddenFormButton);
-
-      hiddenFormButton.click();
-      hiddenFormButton.remove();
+      handleHiddenFormButtonClick(form, this.el);
     }
   };
 

--- a/packages/web-components/src/components/ic-button/readme.md
+++ b/packages/web-components/src/components/ic-button/readme.md
@@ -1,5 +1,7 @@
 # ic-button
 
+
+
 <!-- Auto Generated Below -->
 
 
@@ -70,14 +72,6 @@ Type: `Promise<void>`
 | `"right-icon"`  | Content will be placed to the right of the button label.                                                      |
 | `"router-item"` | Handle routing by nesting your routes in this slot. Setting loading to true will have no impact on this slot. |
 | `"top-icon"`    | Content will be placed above the button label.                                                                |
-
-
-## CSS Custom Properties
-
-| Name          | Description                  |
-| ------------- | ---------------------------- |
-| `--height`    | The height of the button.    |
-| `--min-width` | Minimum width of the button. |
 
 
 ## Dependencies

--- a/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
+++ b/packages/web-components/src/components/ic-button/test/basic/__snapshots__/ic-button.spec.ts.snap
@@ -324,17 +324,6 @@ exports[`button component should test aria-describedby is updated 1`] = `
 </ic-button>
 `;
 
-exports[`button component should test button as submit button on form 1`] = `
-<ic-button class="ic-button-size-medium ic-button-variant-primary ic-theme-dark monochrome" exportparts="button" form="new-form" id="ic-button" type="submit">
-  <template shadowrootmode="open">
-    <button class="button" form="new-form" part="button" tabindex="0" type="submit">
-      <slot></slot>
-    </button>
-  </template>
-  Button
-</ic-button>
-`;
-
 exports[`button component should test tooltip visibility changes when disable tooltip prop changes 1`] = `
 <ic-button class="ic-button-size-medium ic-button-variant-icon ic-theme-dark monochrome" exportparts="button" id="test-button" variant="icon">
   <template shadowrootmode="open">

--- a/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
+++ b/packages/web-components/src/components/ic-button/test/basic/ic-button.spec.ts
@@ -362,16 +362,130 @@ describe("button component", () => {
     expect(page.rootInstance.theme).toEqual("dark");
   });
 
-  it("should test button as submit button on form", async () => {
+  it("should test submit and reset buttons in a form", async () => {
     const page = await newSpecPage({
       components: [Button],
-      html: `<form id="new-form"><form><ic-button id='ic-button' type="submit" form="new-form">Button</ic-button>`,
+      html: `
+        <form>
+          <ic-text-field id="text" label="test input" value="test"></ic-text-field>
+          <ic-button id="reset" type="reset">Reset</ic-button>
+          <ic-button id="submit" type="submit">Submit</ic-button>
+        </form>
+      `,
     });
 
-    const btn = document.getElementById("ic-button");
-    btn?.click();
+    const resetBtn = document.getElementById("reset");
+    const submitBtn = document.getElementById("submit");
 
-    expect(page.root).toMatchSnapshot();
+    page.win.addEventListener("click", (ev) =>
+      console.log((ev.target as HTMLButtonElement)?.id)
+    );
+    const consoleSpy = jest.spyOn(console, "log");
+
+    // Testing form reset: LightDOM button of type "reset" created and clicked, textfield empty
+    resetBtn?.click();
+    expect(
+      page.body.querySelector<HTMLButtonElement>("#hidden-form-reset-button")
+        ?.type
+    ).toBe("reset");
+    expect(consoleSpy).toHaveBeenCalledWith("hidden-form-reset-button");
+
+    // Testing form submit: LightDOM button of type "submit" created and clicked
+    submitBtn?.click();
+    expect(
+      page.body.querySelector<HTMLButtonElement>("#hidden-form-submit-button")
+        ?.type
+    ).toBe("submit");
+    expect(consoleSpy).toHaveBeenCalledWith("hidden-form-submit-button");
+  });
+
+  it("should test submit and reset buttons associated with a form", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: `
+        <form id="testForm">
+          <ic-text-field id="text" label="test input" value="test"></ic-text-field>
+        </form>
+        <ic-button id="reset" form="testForm" type="reset">Reset</ic-button>
+        <ic-button id="submit" form="testForm" type="submit">Submit</ic-button>
+      `,
+    });
+
+    const resetBtn = document.getElementById("reset");
+    const submitBtn = document.getElementById("submit");
+
+    page.win.addEventListener("click", (ev) =>
+      console.log((ev.target as HTMLButtonElement)?.id)
+    );
+    const consoleSpy = jest.spyOn(console, "log");
+
+    // Testing form reset: LightDOM button of type "reset" created and clickedy
+    resetBtn?.click();
+    expect(
+      page.body.querySelector<HTMLButtonElement>("#hidden-form-reset-button")
+        ?.type
+    ).toBe("reset");
+    expect(consoleSpy).toHaveBeenCalledWith("hidden-form-reset-button");
+
+    // Testing form submit: LightDOM button of type "submit" created and clicked
+    submitBtn?.click();
+    expect(
+      page.body.querySelector<HTMLButtonElement>("#hidden-form-submit-button")
+        ?.type
+    ).toBe("submit");
+    expect(consoleSpy).toHaveBeenCalledWith("hidden-form-submit-button");
+  });
+
+  it("should test form submission props on buttons in a form", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: `
+        <form>
+          <ic-text-field id="text" label="test input" value="test"></ic-text-field>
+          <ic-button id="submit" type="submit" formaction="#" formenctype="text/plain" formmethod="post" formnovalidate formtarget="_blank">Submit</ic-button>
+        </form>
+      `,
+    });
+
+    const submitBtn = document.getElementById("submit");
+
+    // Form submission props are passed to the hidden form submit button
+    submitBtn?.click();
+    const hiddenSubmitBtn = page.body.querySelector<HTMLButtonElement>(
+      "#hidden-form-submit-button"
+    );
+    expect(hiddenSubmitBtn?.type).toBe("submit");
+    expect(hiddenSubmitBtn?.formAction).toBe("#");
+    expect(hiddenSubmitBtn?.formEnctype).toBe("text/plain");
+    expect(hiddenSubmitBtn?.formMethod).toBe("post");
+    expect(hiddenSubmitBtn?.formNoValidate).toBe(true);
+    expect(hiddenSubmitBtn?.formTarget).toBe("_blank");
+  });
+
+  it("should test form submission props on buttons associated with a form", async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: `
+        <form id="testForm">
+          <ic-text-field id="text" label="test input" value="test"></ic-text-field>
+        </form>
+        <ic-button id="submit" type="submit" form="testForm" formaction="#" formenctype="text/plain" formmethod="post" formnovalidate formtarget="_blank">Submit</ic-button>
+      `,
+    });
+
+    const submitBtn = document.getElementById("submit");
+
+    // Form submission props are passed to the hidden form submit button
+    submitBtn?.click();
+    const hiddenSubmitBtn = page.body.querySelector<HTMLButtonElement>(
+      "#hidden-form-submit-button"
+    );
+    expect(hiddenSubmitBtn?.type).toBe("submit");
+    expect(hiddenSubmitBtn?.formAction).toBe("#");
+    expect(hiddenSubmitBtn?.formEnctype).toBe("text/plain");
+    expect(hiddenSubmitBtn?.formMethod).toBe("post");
+    expect(hiddenSubmitBtn?.formNoValidate).toBe(true);
+    expect(hiddenSubmitBtn?.formTarget).toBe("_blank");
   });
 
   it("should test aria-describedby is set", async () => {

--- a/packages/web-components/src/components/ic-search-bar/test/basic/ic-search-bar.spec.ts
+++ b/packages/web-components/src/components/ic-search-bar/test/basic/ic-search-bar.spec.ts
@@ -728,7 +728,7 @@ describe("ic-search-bar search", () => {
     const page = await newSpecPage({
       components: [SearchBar, Button, Menu, InputContainer, InputLabel],
       html: `
-        <form id="form" onsubmit=>
+        <form id="form">
           <ic-search-bar label="Test label" value="test"></ic-search-bar>
         </form>
       `,
@@ -753,12 +753,12 @@ describe("ic-search-bar search", () => {
     submitButton?.click();
 
     const hiddenFormButton = page.body.querySelector<HTMLButtonElement>(
-      "#hidden-form-button"
+      "#hidden-form-submit-button"
     );
 
     // LightDOM button should be created with type="submit" and clicked
     expect(hiddenFormButton?.getAttribute("type")).toBe("submit"); // will submit form on click
-    expect(consoleSpy).toHaveBeenCalledWith("hidden-form-button"); // hidden form button clicked
+    expect(consoleSpy).toHaveBeenCalledWith("hidden-form-submit-button"); // hidden form button clicked
   });
 
   it("should not submit parent form on icSubmitSearch if preventFormSubmitOnSearch is true", async () => {
@@ -778,7 +778,7 @@ describe("ic-search-bar search", () => {
       );
     expect(
       submitButton?.shadowRoot
-        ?.querySelector<HTMLButtonElement>('[aria-label="Search"]')
+        ?.querySelector<HTMLIcButtonElement>('[aria-label="Search"]')
         ?.getAttribute("type")
     ).toBe("button");
 

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -258,25 +258,36 @@ export const isMobileOrTablet = (): boolean =>
     : false;
 
 /**
- * Will create a button within the lightDOM which interacts with the parent form.
+ * Will create a button within the lightDOM which interacts with the form.
  * This is required as buttons within the shadowDOM will not invoke a submit or reset
  *
- * @param form - parent form element which contains shadowDom button
+ * @param form - form element to associate button with
  * @param button - shadowDOM button
  */
 export const handleHiddenFormButtonClick = (
-  form: HTMLFormElement,
-  button: HTMLIcButtonElement | HTMLButtonElement
+  form: HTMLFormElement | null,
+  button: HTMLIcButtonElement
 ): void => {
+  const hiddenFormButtonId =
+    button.type === "submit" || button.type === "reset"
+      ? `hidden-form-${button.type}-button`
+      : "hidden-form-button";
+
   const hiddenFormButton =
-    document.querySelector<HTMLButtonElement>("#hidden-form-button") ??
+    document.querySelector<HTMLButtonElement>(`#${hiddenFormButtonId}`) ??
     document.createElement("button");
 
   hiddenFormButton.setAttribute("type", button.type ?? "button");
-  hiddenFormButton.id = "hidden-form-button";
+  hiddenFormButton.id = hiddenFormButtonId;
   hiddenFormButton.style.display = "none";
 
-  form.appendChild(hiddenFormButton);
+  hiddenFormButton.formAction = button.formaction ?? "";
+  hiddenFormButton.formEnctype = button.formenctype ?? "";
+  hiddenFormButton.formMethod = button.formmethod ?? "";
+  hiddenFormButton.formNoValidate = button.formnovalidate ?? false;
+  hiddenFormButton.formTarget = button.formtarget ?? "";
+
+  form?.appendChild(hiddenFormButton);
   hiddenFormButton.click();
 };
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

If form submission props are used on an ic-button of type submit or reset (formation, formenctype, formmethod, formnovalidate, formtarget) they are passed through to the lightDOM button that is created to invoke the submit and reset events.

If the form prop on an ic-button is used, it associates the ic-button with the form with the corresponding id, even if the ic-button is not a descendant of that form. If the form prop is not used, the form is associated with its closest form ancestor if there is one. This matches the behaviour of the form attribute that can be used on a HTML button.

## Related issue
#3729

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.