### PR TITLE
3774 differing white space in docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior to LF line endings.
+* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
To test: 
- Make sure your local git config is not overriding line endings by running
```
git config --global core.autocrlf false
git config --global core.eol lf
```
- Then run 
```
git rm --cached -r .
git reset --hard
```
It should update all files to have LF line endings.
For new clones of the project, this won't be necessary, it should just automatically use LF line endings.

## Related issue
#3774

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 
