### PR TITLE
test(canary-react): move dateInput cy test future date back into the future

### DIFF
--- a/packages/canary-react/src/component-tests/IcDateInput/IcDateInput.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDateInput/IcDateInput.cy.tsx
@@ -150,7 +150,7 @@ describe("IcDateInput end-to-end, visual regression and a11y tests", () => {
   });
 
   it("should remove validation status (from now) when disabled date is updated", () => {
-    mount(<IcDateInput label="Test Label" disableFuture value="31/08/2025" />);
+    mount(<IcDateInput label="Test Label" disableFuture value="31/08/2080" />);
 
     cy.checkHydrated(DATE_INPUT);
 


### PR DESCRIPTION

Move the value for a future date in IcDateInput cypress tests far into the future rather than august this year
