### PR TITLE
fix(web-components): dynamic fields on Checkboxes/Radio Buttons and screenreaders

### DIFF
--- a/packages/react/src/stories/ic-checkbox.stories.js
+++ b/packages/react/src/stories/ic-checkbox.stories.js
@@ -560,21 +560,21 @@ export const ConditionalStatic = {
 export const HelperText = {
   render: () => (
     <>
-    <IcCheckboxGroup label="This is a label" name="1" helperText="Helper text">
-      <IcCheckbox value="valueName1" label="Unselected / Default" />
-      <IcCheckbox value="valueName2" label="Selected / Default" checked />
-      <IcCheckbox value="valueName3" label="Unselected / Disabled" disabled />
+    <IcCheckboxGroup label="Coffee Extras" name="1" helperText="Helper text provided by prop">
+      <IcCheckbox value="valueName1" label="Sugar" />
+      <IcCheckbox value="valueName2" label="Milk" checked />
+      <IcCheckbox value="valueName3" label="Salt" disabled />
     </IcCheckboxGroup>
     <br />
-    <IcCheckboxGroup label="This is a label" name="2">
+    <IcCheckboxGroup label="More coffee extras" name="2">
       <IcTypography variant="caption" slot="helper-text">
         <span>
-          Slotted helper text with a <IcLink href="#">link</IcLink>
+          Slotted helper text with a <IcLink href="#">helpful link to guidance</IcLink>
         </span>
       </IcTypography>
-      <IcCheckbox value="valueName1" label="Unselected / Default" />
-      <IcCheckbox value="valueName2" label="Selected / Default" checked />
-      <IcCheckbox value="valueName3" label="Unselected / Disabled" disabled />
+      <IcCheckbox value="valueName1" label="Shortbread" />
+      <IcCheckbox value="valueName2" label="Scone" checked />
+      <IcCheckbox value="valueName3" label="Ham sandwich" disabled />
     </IcCheckboxGroup>
     </>
   ),

--- a/packages/react/src/stories/ic-radio-group.stories.js
+++ b/packages/react/src/stories/ic-radio-group.stories.js
@@ -373,12 +373,12 @@ export const ConditionalStatic = {
 export const HelperText = {
   render: () => (
     <>
-    <IcRadioGroup label="This is a label" name="1" helperText="Helper text">
-      <IcRadioOption value="valueName1" label="Unselected / Default" />
-      <IcRadioOption value="valueName2" label="Selected / Default" selected />
+    <IcRadioGroup label="Pick your coffee" name="1" helperText="Helper text provided by prop">
+      <IcRadioOption value="valueName1" label="Mocha" />
+      <IcRadioOption value="valueName2" label="Americano" selected />
       <IcRadioOption
         value="valueName3"
-        label="Unselected / Disabled"
+        label="Tea"
         disabled
       />
     </IcRadioGroup>
@@ -386,14 +386,14 @@ export const HelperText = {
     <IcRadioGroup label="This is a label" name="2">
       <IcTypography variant="caption" slot="helper-text">
         <span>
-          Slotted helper text with a <IcLink href="#">link</IcLink>
+          Slotted helper text with a <IcLink href="#">helpful link to guidance</IcLink>
         </span>
       </IcTypography>
-      <IcRadioOption value="valueName1" label="Unselected / Default" />
-      <IcRadioOption value="valueName2" label="Selected / Default" selected />
+      <IcRadioOption value="valueName1" label="Flat White" />
+      <IcRadioOption value="valueName2" label="Espresso" selected />
       <IcRadioOption
         value="valueName3"
-        label="Unselected / Disabled"
+        label="Orange Juice"
         disabled
       />
     </IcRadioGroup>

--- a/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.stories.js
+++ b/packages/web-components/src/components/ic-checkbox-group/ic-checkbox-group.stories.js
@@ -317,44 +317,27 @@ export const ConditionalStatic = {
 export const HelperText = {
   render: (args) => html`
     <ic-checkbox-group
-      label="This is a label"
+      label="Coffee extras"
       name="group1"
-      helper-text="Helper text"
+      helper-text="Helper text provided by prop"
     >
-      <ic-checkbox
-        value="valueName1"
-        label="Unselected / Default"
-      ></ic-checkbox>
-      <ic-checkbox
-        value="valueName2"
-        label="Selected / Default"
-        checked
-      ></ic-checkbox>
-      <ic-checkbox
-        value="valueName3"
-        label="Unselected / Disabled"
-        Disabled
-      ></ic-checkbox>
+      <ic-checkbox value="valueName1" label="Sugar"></ic-checkbox>
+      <ic-checkbox value="valueName2" label="Milk" checked></ic-checkbox>
+      <ic-checkbox value="valueName3" label="salt" Disabled></ic-checkbox>
     </ic-checkbox-group>
     <br />
-    <ic-checkbox-group label="This is a label" name="group2">
+    <ic-checkbox-group label="More coffee extras" name="group2">
       <ic-typography variant="caption" slot="helper-text">
         <span>
-          Slotted helper text with a <ic-link href="#">link</ic-link>
+          Slotted helper text with a
+          <ic-link href="#">helpful link to guidance</ic-link>
         </span>
       </ic-typography>
-      <ic-checkbox
-        value="valueName1"
-        label="Unselected / Default"
-      ></ic-checkbox>
-      <ic-checkbox
-        value="valueName2"
-        label="Selected / Default"
-        checked
-      ></ic-checkbox>
+      <ic-checkbox value="valueName1" label="Shortbread"></ic-checkbox>
+      <ic-checkbox value="valueName2" label="Scone" checked></ic-checkbox>
       <ic-checkbox
         value="valueName3"
-        label="Unselected / Disabled"
+        label="Ham Sandwich"
         Disabled
       ></ic-checkbox>
     </ic-checkbox-group>

--- a/packages/web-components/src/components/ic-checkbox-group/test/basic/__snapshots__/ic-checkbox-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-checkbox-group/test/basic/__snapshots__/ic-checkbox-group.spec.ts.snap
@@ -24,6 +24,7 @@ exports[`ic-checkbox-group should pass the size on the checkbox group to the chi
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
   <ic-checkbox additional-field-display="static" class="ic-checkbox-small" label="test label" value="test">
@@ -36,6 +37,7 @@ exports[`ic-checkbox-group should pass the size on the checkbox group to the chi
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -65,6 +67,7 @@ exports[`ic-checkbox-group should prioritise the size on an individual checkbox 
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
   <ic-checkbox additional-field-display="static" class="ic-checkbox-small" id="small-checkbox" label="test label" size="small" value="test">
@@ -77,6 +80,7 @@ exports[`ic-checkbox-group should prioritise the size on an individual checkbox 
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -101,6 +105,7 @@ exports[`ic-checkbox-group should render an aria label when checkbox label hidde
       <div class="container">
         <input aria-label="test label" class="checkbox" id="ic-checkbox-test-label-test-label" name="test" role="checkbox" type="checkbox" value="test">
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -128,6 +133,7 @@ exports[`ic-checkbox-group should render an aria label when group label hidden: 
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -157,6 +163,7 @@ exports[`ic-checkbox-group should render as helper text: renders-with-helpertext
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -189,6 +196,7 @@ exports[`ic-checkbox-group should render as required: renders-required 1`] = `
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -224,6 +232,7 @@ exports[`ic-checkbox-group should render checked: renders-checked 1`] = `
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
     <input class="ic-input" name="test" type="hidden" value="test">
   </ic-checkbox>
@@ -254,6 +263,7 @@ exports[`ic-checkbox-group should render in a disabled state: disabled-removed 1
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -283,6 +293,7 @@ exports[`ic-checkbox-group should render in a disabled state: renders-disabled 1
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -313,6 +324,7 @@ exports[`ic-checkbox-group should render indeterminate: renders-indeterminate 1`
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
     <input class="ic-input" name="test" type="hidden" value="test">
   </ic-checkbox>
@@ -342,6 +354,7 @@ exports[`ic-checkbox-group should render with disabled static additional field: 
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
       <div class="dynamic-container">
         <div class="dynamic-field-container">
           <div class="additional-field-wrapper">
@@ -375,6 +388,7 @@ exports[`ic-checkbox-group should render with disabled static additional field: 
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
       <div class="dynamic-container">
         <div class="dynamic-field-container">
           <div class="additional-field-wrapper">
@@ -446,11 +460,14 @@ exports[`ic-checkbox-group should render with dynamic additional field when chec
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert">
+        This selection requires additional answers
+      </span>
       <div class="dynamic-container" style="display: flex;">
         <div class="branch-corner"></div>
         <div class="dynamic-field-container">
           <ic-typography variant="caption">
-            <p aria-live="polite" class="dynamic-text">
+            <p class="dynamic-text">
               This selection requires additional answers
             </p>
           </ic-typography>
@@ -502,13 +519,12 @@ exports[`ic-checkbox-group should render with hidden dynamic additional field: r
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
       <div class="dynamic-container" style="display: none;">
         <div class="branch-corner"></div>
         <div class="dynamic-field-container">
           <ic-typography variant="caption">
-            <p aria-live="polite" class="dynamic-text">
-              This selection requires additional answers
-            </p>
+            <p class="dynamic-text"></p>
           </ic-typography>
           <div>
             <slot name="additional-field"></slot>
@@ -557,6 +573,7 @@ exports[`ic-checkbox-group should render with validation status: renders-with-va
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -586,6 +603,7 @@ exports[`ic-checkbox-group should render: renders 1`] = `
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -620,6 +638,7 @@ exports[`ic-checkbox-group should set disabled attribute to false on static addi
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
       <div class="dynamic-container">
         <div class="dynamic-field-container">
           <div class="additional-field-wrapper">
@@ -660,6 +679,7 @@ exports[`ic-checkbox-group should set disabled attribute to false on static addi
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
       <div class="dynamic-container">
         <div class="dynamic-field-container">
           <div class="additional-field-wrapper">
@@ -714,6 +734,7 @@ exports[`ic-checkbox-group should test checkbox option as submit on form 1`] = `
         </label>
       </ic-typography>
     </div>
+    <span class="sr-only" id="ic-checkbox-IC-Checkbox-Test-undefined-additional-field-description" role="alert"></span>
   </template>
 </ic-checkbox>
 `;
@@ -742,6 +763,7 @@ exports[`ic-checkbox-group should test labelNameHandler 1`] = `
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-test-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>
@@ -771,6 +793,7 @@ exports[`ic-checkbox-group should test labelNameHandler 2`] = `
           </label>
         </ic-typography>
       </div>
+      <span class="sr-only" id="ic-checkbox-test-label-new-label-additional-field-description" role="alert"></span>
     </template>
   </ic-checkbox>
 </ic-checkbox-group>

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.css
@@ -222,6 +222,11 @@
   flex: 100%;
 }
 
+.sr-only {
+  position: absolute;
+  left: -9999px;
+}
+
 @media (max-width: 576px) {
   ::slotted(*) {
     --input-width: 100%;

--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -266,6 +266,13 @@ export class Checkbox {
             </ic-typography>
           )}
         </div>
+        <span
+          id={`${id}-additional-field-description`}
+          role="alert"
+          class="sr-only"
+        >
+          {isDynamicAdditionalField && checked ? dynamicText : ""}
+        </span>
         {isSlotUsed(el, "additional-field") && (
           <div
             class="dynamic-container"
@@ -275,8 +282,8 @@ export class Checkbox {
             <div class="dynamic-field-container">
               {isDynamicAdditionalField && (
                 <ic-typography variant="caption">
-                  <p class="dynamic-text" aria-live="polite">
-                    {dynamicText}
+                  <p class="dynamic-text">
+                    {isDynamicAdditionalField && checked ? dynamicText : ""}
                   </p>
                 </ic-typography>
               )}

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.js
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.stories.js
@@ -248,41 +248,40 @@ export const ConditionalStatic = {
 
 export const HelperText = {
   render: (args) => html`
-    <ic-radio-group label="This is a label" name="1" helper-text="Helper text">
-      <ic-radio-option
-        value="valueName1"
-        label="Unselected / Default"
-      ></ic-radio-option>
+    <ic-radio-group
+      label="Pick Your Coffee"
+      name="1"
+      helper-text="Helper text provided by prop"
+    >
+      <ic-radio-option value="valueName1" label="Mocha"></ic-radio-option>
       <ic-radio-option
         value="valueName2"
-        label="Selected / Default"
+        label="Americano"
         selected
       ></ic-radio-option>
       <ic-radio-option
         value="valueName3"
-        label="Unselected / Disabled"
+        label="Tea"
         disabled
       ></ic-radio-option>
     </ic-radio-group>
     <br />
-    <ic-radio-group label="This is a label" name="2">
+    <ic-radio-group label="Another Coffee Choice" name="2">
       <ic-typography variant="caption" slot="helper-text">
         <span>
-          Slotted helper text with a <ic-link href="#">link</ic-link>
+          Slotted helper text with a
+          <ic-link href="#">helpful link to guidance</ic-link>
         </span>
       </ic-typography>
-      <ic-radio-option
-        value="valueName1"
-        label="Unselected / Default"
-      ></ic-radio-option>
+      <ic-radio-option value="valueName1" label="Flat White"></ic-radio-option>
       <ic-radio-option
         value="valueName2"
-        label="Selected / Default"
+        label="Espresso"
         selected
       ></ic-radio-option>
       <ic-radio-option
         value="valueName3"
-        label="Unselected / Disabled"
+        label="Orange Juice"
         disabled
       ></ic-radio-option>
     </ic-radio-group>

--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -365,23 +365,26 @@ export class RadioGroup {
           [`ic-theme-${theme}`]: theme !== "inherit",
         }}
       >
-        <div
+        <fieldset
           role="radiogroup"
-          aria-label={`${label}${required ? ", required" : ""}`}
+          id={this.name}
+          // aria-label={`${label} ${required ? ", required" : ""}`}
         >
           {!hideLabel && (
-            <ic-input-label
-              class={{
-                [`${validationStatus}`]: true,
-                ["disabled"]: !!disabled,
-              }}
-              label={label}
-              helperText={helperText}
-              required={required}
-              disabled={disabled}
-            >
-              <slot name="helper-text" slot="helper-text"></slot>
-            </ic-input-label>
+            <legend>
+              <ic-input-label
+                class={{
+                  [`${validationStatus}`]: true,
+                  ["disabled"]: !!disabled,
+                }}
+                label={label}
+                helperText={helperText}
+                required={required}
+                disabled={disabled}
+              >
+                <slot name="helper-text" slot="helper-text"></slot>
+              </ic-input-label>
+            </legend>
           )}
           <div
             class={{
@@ -392,7 +395,7 @@ export class RadioGroup {
           >
             <slot></slot>
           </div>
-        </div>
+        </fieldset>
         {hasValidationStatus(validationStatus, disabled) && (
           <ic-input-validation
             ariaLiveMode="polite"

--- a/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/__snapshots__/ic-radio-group.spec.ts.snap
@@ -3,14 +3,16 @@
 exports[`ic-radio-group should render as helper text: renders-with-helpertext 1`] = `
 <ic-radio-group helpertext="helper test" label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" value="test">
     <!---->
@@ -30,14 +32,16 @@ exports[`ic-radio-group should render as helper text: renders-with-helpertext 1`
 exports[`ic-radio-group should render as required: renders-required 1`] = `
 <ic-radio-group label="test label" name="test" required="">
   <template shadowrootmode="open">
-    <div aria-label="test label, required" role="radiogroup">
-      <ic-input-label label="test label" required="">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label" required="">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" value="test">
     <!---->
@@ -57,14 +61,16 @@ exports[`ic-radio-group should render as required: renders-required 1`] = `
 exports[`ic-radio-group should render radio group disabled: disabled-removed 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" group-label="test group" label="test label" value="test">
     <!---->
@@ -86,14 +92,16 @@ exports[`ic-radio-group should render radio group disabled: disabled-removed 1`]
 exports[`ic-radio-group should render radio group disabled: renders-disabled 1`] = `
 <ic-radio-group disabled="" label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label class="disabled" disabled="" label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label class="disabled" disabled="" label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" class="ic-radio-option-disabled" group-label="test group" label="test label" value="test">
     <!---->
@@ -115,14 +123,16 @@ exports[`ic-radio-group should render radio group disabled: renders-disabled 1`]
 exports[`ic-radio-group should render radio option disabled: disabled-removed 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" group-label="test group" label="test label" value="test">
     <!---->
@@ -144,14 +154,16 @@ exports[`ic-radio-group should render radio option disabled: disabled-removed 1`
 exports[`ic-radio-group should render radio option disabled: renders-option-disabled 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" class="ic-radio-option-disabled" disabled="" group-label="test group" label="test label" value="test">
     <!---->
@@ -173,14 +185,16 @@ exports[`ic-radio-group should render radio option disabled: renders-option-disa
 exports[`ic-radio-group should render with dynamic additional field: renders-with-dynamic-additional-field 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="dynamic" group-label="test group" label="test label" selected="" value="test">
     <!---->
@@ -198,7 +212,7 @@ exports[`ic-radio-group should render with dynamic additional field: renders-wit
     <div class="dynamic-container">
       <div class="branch-corner"></div>
       <div>
-        <ic-typography variant="caption">
+        <ic-typography role="alert" variant="caption">
           <p class="dynamic-text">
             This selection requires additional answers
           </p>
@@ -227,14 +241,16 @@ exports[`ic-radio-group should render with dynamic additional field: renders-wit
 exports[`ic-radio-group should render with selected option: renders-with-selected-option 1`] = `
 <ic-radio-group label="test label" name="test" required="">
   <template shadowrootmode="open">
-    <div aria-label="test label, required" role="radiogroup">
-      <ic-input-label label="test label" required="">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label" required="">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" selected="" value="test">
     <!---->
@@ -254,14 +270,16 @@ exports[`ic-radio-group should render with selected option: renders-with-selecte
 exports[`ic-radio-group should render with selected static additional field: renders-with-selected-additional-field 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" group-label="test group" label="test label" selected="" value="test">
     <!---->
@@ -302,14 +320,16 @@ exports[`ic-radio-group should render with selected static additional field: ren
 exports[`ic-radio-group should render with unselected static additional field: renders-with-unselected-additional-field 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" class="ic-radio-option-disabled" disabled="" group-label="test group" label="test label" value="test">
     <!---->
@@ -350,14 +370,16 @@ exports[`ic-radio-group should render with unselected static additional field: r
 exports[`ic-radio-group should render with validation status: renders-with-validation-status 1`] = `
 <ic-radio-group label="test label" name="test" required="" validation-status="error" validation-text="error">
   <template shadowrootmode="open">
-    <div aria-label="test label, required" role="radiogroup">
-      <ic-input-label class="error" label="test label" required="">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label class="error" label="test label" required="">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
     <ic-input-validation arialivemode="polite" message="error" status="error"></ic-input-validation>
   </template>
   <ic-radio-option additional-field-display="static" selected="" value="test">
@@ -378,14 +400,16 @@ exports[`ic-radio-group should render with validation status: renders-with-valid
 exports[`ic-radio-group should render: renders 1`] = `
 <ic-radio-group label="test label" name="test">
   <template shadowrootmode="open">
-    <div aria-label="test label" role="radiogroup">
-      <ic-input-label label="test label">
-        <slot name="helper-text" slot="helper-text"></slot>
-      </ic-input-label>
+    <fieldset id="test" role="radiogroup">
+      <legend>
+        <ic-input-label label="test label">
+          <slot name="helper-text" slot="helper-text"></slot>
+        </ic-input-label>
+      </legend>
       <div class="radio-buttons-container">
         <slot></slot>
       </div>
-    </div>
+    </fieldset>
   </template>
   <ic-radio-option additional-field-display="static" value="test">
     <!---->

--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.tsx
@@ -293,7 +293,6 @@ export class RadioOption {
             <label htmlFor={id}>{label}</label>
           </ic-typography>
         </div>
-
         {hasAdditionalField && (
           <div
             class={{
@@ -306,7 +305,7 @@ export class RadioOption {
             )}
             <div>
               {additionalFieldDisplay === "dynamic" && (
-                <ic-typography variant="caption">
+                <ic-typography variant="caption" role="alert">
                   <p class="dynamic-text">{dynamicText}</p>
                 </ic-typography>
               )}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Added role=alert to radiobutton and checkboxes that announces the dynamicText information when the parent input is checked.

Bonus fix: Refactored radio group so that helper text reads to screenreaders

Tested with NVDA (reading the speechviewer) and with VO on Mac. 


## Related issue
#3898

## Checklist

Removed unrelated checklist items

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 
