### PR TITLE
fix(canary-web-components): make date input clear button visible in HCM

### DIFF
--- a/packages/canary-web-components/src/components/ic-date-input/ic-date-input.css
+++ b/packages/canary-web-components/src/components/ic-date-input/ic-date-input.css
@@ -177,3 +177,9 @@ ic-input-validation {
   --ic-input-validation-warning-icon-color: var(--ic-date-input-icon-warning);
   --ic-input-validation-success-icon-color: var(--ic-date-input-icon-success);
 }
+
+@media (forced-colors: active) {
+  .clear-button svg {
+    color: currentcolor;
+  }
+}

--- a/packages/canary-web-components/src/components/ic-time-input/ic-time-input.css
+++ b/packages/canary-web-components/src/components/ic-time-input/ic-time-input.css
@@ -197,6 +197,6 @@ ic-input-validation {
 
 @media (forced-colors: active) {
   .clear-button svg {
-    color: currentColor;
+    color: currentcolor;
   }
 }


### PR DESCRIPTION
## Summary of the changes

Added media query to set clear button svg to currentcolor in HCM for dateinput

Updated time-input to use "currentcolor" all lowercase, to make linter happy :) 

## Related issue
#3929 

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 