### PR TITLE
[ic-pagination-bar]: itemsPerPage incorrect value on totalItems update fix

### DIFF
--- a/packages/canary-docs/docs.json
+++ b/packages/canary-docs/docs.json
@@ -4249,12 +4249,18 @@
       "events": [
         {
           "event": "icItemsPerPageChange",
-          "detail": "{ value: number; }",
+          "detail": "IcItemsPerPageChangeEventDetail",
           "bubbles": true,
           "complexType": {
-            "original": "{ value: number }",
-            "resolved": "{ value: number; }",
-            "references": {}
+            "original": "IcItemsPerPageChangeEventDetail",
+            "resolved": "IcItemsPerPageChangeEventDetail",
+            "references": {
+              "IcItemsPerPageChangeEventDetail": {
+                "location": "import",
+                "path": "./ic-pagination-bar.types",
+                "id": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts::IcItemsPerPageChangeEventDetail"
+              }
+            }
           },
           "cancelable": true,
           "composed": true,
@@ -6197,6 +6203,11 @@
     },
     "src/components/ic-pagination-bar/ic-pagination-bar.types.ts::IcPageChangeEventDetail": {
       "declaration": "export interface IcPageChangeEventDetail {\n  value: number;\n  fromItemsPerPage?: boolean;\n}",
+      "docstring": "",
+      "path": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts"
+    },
+    "src/components/ic-pagination-bar/ic-pagination-bar.types.ts::IcItemsPerPageChangeEventDetail": {
+      "declaration": "export interface IcItemsPerPageChangeEventDetail {\n  value: number;\n  isUserAction?: boolean;\n}",
       "docstring": "",
       "path": "src/components/ic-pagination-bar/ic-pagination-bar.types.ts"
     },

--- a/packages/canary-react/src/component-tests/IcPaginationBar/IcPaginationBar.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcPaginationBar/IcPaginationBar.cy.tsx
@@ -814,6 +814,76 @@ describe("IcPaginationBar visual regression and a11y tests", () => {
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
     });
   });
+  it("should set items per page dropdown to All if totalItems is updated from 100 to 0", () => {
+    mount(<IcPaginationBar totalItems={100} showItemsPerPageControl />);
+
+    cy.checkHydrated(PAGINATION_BAR);
+
+    cy.get(PAGINATION_BAR).invoke("prop", "totalItems", 0);
+
+    cy.wait(250);
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "All");
+  });
+  it("should set items per page dropdown to 100 if selectedItemsPerPage is 100, totalItems is initially set to 30 and then updated to 200", () => {
+    mount(
+      <IcPaginationBar
+        totalItems={30}
+        selectedItemsPerPage={100}
+        showItemsPerPageControl
+      />
+    );
+
+    cy.checkHydrated(PAGINATION_BAR);
+
+    cy.get(PAGINATION_BAR).invoke("prop", "totalItems", 200);
+
+    cy.wait(250);
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "100");
+  });
+  it("should set the items per page dropdown to 10 if selectedItemsPerPage is 100, totalItems is initially set to 211 and then updated to 30", () => {
+    mount(
+      <IcPaginationBar
+        totalItems={211}
+        selectedItemsPerPage={100}
+        showItemsPerPageControl
+      />
+    );
+
+    cy.checkHydrated(PAGINATION_BAR);
+
+    cy.get(PAGINATION_BAR).invoke("prop", "totalItems", 30);
+
+    cy.wait(250);
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "10");
+  });
+  it("should set items per page dropdown to 10 if totalItems is 50 and selectedItemsPerPage is 100", () => {
+    mount(
+      <IcPaginationBar
+        totalItems={50}
+        selectedItemsPerPage={100}
+        showItemsPerPageControl
+      />
+    );
+
+    cy.checkHydrated(PAGINATION_BAR);
+
+    cy.findShadowEl(PAGINATION_BAR, "ic-select")
+      .shadow()
+      .find(".select-input")
+      .should("contain.text", "10");
+  });
 });
 
 describe("IcPaginationBar visual regression tests in high contrast mode", () => {

--- a/packages/canary-web-components/src/components.d.ts
+++ b/packages/canary-web-components/src/components.d.ts
@@ -10,14 +10,14 @@ import { IcThemeMode } from "@ukic/web-components";
 import { IcDataTableColumnObject, IcDataTableDataType, IcDataTableDensityOptions, IcDataTableRowHeights, IcDataTableSortOrderOptions, IcDataTableTruncationTypes, IcDensityUpdateEventDetail, IcSortEventDetail } from "./components/ic-data-table/ic-data-table.types";
 import { IcDateFormat, IcDisableTimeSelection, IcInformationStatusOrEmpty, IcPaginationBarOptions, IcPositionTopOrRight, IcSizes, IcThemeMode as IcThemeMode1, IcTimeFormat, IcWeekDays } from "./utils/types";
 import { IcPaginationAlignmentOptions, IcPaginationLabelTypes, IcPaginationTypes } from "@ukic/web-components/dist/types/components/ic-pagination/ic-pagination.types";
-import { IcPageChangeEventDetail } from "./components/ic-pagination-bar/ic-pagination-bar.types";
+import { IcItemsPerPageChangeEventDetail, IcPageChangeEventDetail } from "./components/ic-pagination-bar/ic-pagination-bar.types";
 import { IcTreeItemOptions } from "./components/ic-tree-view/ic-tree-view.types";
 export { IcCardSizes } from "./components/ic-card-horizontal/ic-card-horizontal.types";
 export { IcThemeMode } from "@ukic/web-components";
 export { IcDataTableColumnObject, IcDataTableDataType, IcDataTableDensityOptions, IcDataTableRowHeights, IcDataTableSortOrderOptions, IcDataTableTruncationTypes, IcDensityUpdateEventDetail, IcSortEventDetail } from "./components/ic-data-table/ic-data-table.types";
 export { IcDateFormat, IcDisableTimeSelection, IcInformationStatusOrEmpty, IcPaginationBarOptions, IcPositionTopOrRight, IcSizes, IcThemeMode as IcThemeMode1, IcTimeFormat, IcWeekDays } from "./utils/types";
 export { IcPaginationAlignmentOptions, IcPaginationLabelTypes, IcPaginationTypes } from "@ukic/web-components/dist/types/components/ic-pagination/ic-pagination.types";
-export { IcPageChangeEventDetail } from "./components/ic-pagination-bar/ic-pagination-bar.types";
+export { IcItemsPerPageChangeEventDetail, IcPageChangeEventDetail } from "./components/ic-pagination-bar/ic-pagination-bar.types";
 export { IcTreeItemOptions } from "./components/ic-tree-view/ic-tree-view.types";
 export namespace Components {
     interface IcCardHorizontal {
@@ -874,7 +874,7 @@ declare global {
     };
     interface HTMLIcPaginationBarElementEventMap {
         "icPageChange": IcPageChangeEventDetail;
-        "icItemsPerPageChange": { value: number };
+        "icItemsPerPageChange": IcItemsPerPageChangeEventDetail;
     }
     interface HTMLIcPaginationBarElement extends Components.IcPaginationBar, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIcPaginationBarElementEventMap>(type: K, listener: (this: HTMLIcPaginationBarElement, ev: IcPaginationBarCustomEvent<HTMLIcPaginationBarElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1483,7 +1483,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the items per page option is changed.
          */
-        "onIcItemsPerPageChange"?: (event: IcPaginationBarCustomEvent<{ value: number }>) => void;
+        "onIcItemsPerPageChange"?: (event: IcPaginationBarCustomEvent<IcItemsPerPageChangeEventDetail>) => void;
         /**
           * Emitted when a page is navigated to via the 'go to' input. The `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring.
          */

--- a/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.stories.js
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.stories.js
@@ -45,7 +45,7 @@ export const ItemsPerPageControl = {
       ></ic-pagination-bar>
     </div>
     <script>
-      const paginationBar = document.querySelector("ic-pagination-bar");
+      var paginationBar = document.querySelector("ic-pagination-bar");
       paginationBar.itemsPerPageOptions = [
         { label: "50", value: "50" },
         { label: "100", value: "100" },

--- a/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.types.ts
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/ic-pagination-bar.types.ts
@@ -2,3 +2,8 @@ export interface IcPageChangeEventDetail {
   value: number;
   fromItemsPerPage?: boolean;
 }
+
+export interface IcItemsPerPageChangeEventDetail {
+  value: number;
+  isUserAction?: boolean;
+}

--- a/packages/canary-web-components/src/components/ic-pagination-bar/readme.md
+++ b/packages/canary-web-components/src/components/ic-pagination-bar/readme.md
@@ -30,10 +30,10 @@
 
 ## Events
 
-| Event                  | Description                                                                                                                                                                                                                                       | Type                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `icItemsPerPageChange` | Emitted when the items per page option is changed.                                                                                                                                                                                                | `CustomEvent<{ value: number; }>`      |
-| `icPageChange`         | Emitted when a page is navigated to via the 'go to' input. The `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring. | `CustomEvent<IcPageChangeEventDetail>` |
+| Event                  | Description                                                                                                                                                                                                                                       | Type                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `icItemsPerPageChange` | Emitted when the items per page option is changed.                                                                                                                                                                                                | `CustomEvent<IcItemsPerPageChangeEventDetail>` |
+| `icPageChange`         | Emitted when a page is navigated to via the 'go to' input. The `detail` property contains `value` (i.e. the page number) and a `fromItemsPerPage` flag to indicate if the event was triggered by the `icItemsPerPageChange` event also occurring. | `CustomEvent<IcPageChangeEventDetail>`         |
 
 
 ## Dependencies


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
- Added logic to correctly set itemsPerPage when totalItems is updated
- Added `isUserAction` to IcItemsPerPageChange due to event trigger when totalItems updates itermPerPage selection

## Related issue
#3939 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 

### Accessibility 

N/A

### Resize/zoom behaviour 

N/A

### System modes

- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

N/A