### PR TITLE
fix(web-components): fix ctrl-a not working on searchable select input

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -27,6 +27,7 @@ import {
   removeDisabledFalse,
   checkSlotInChildMutations,
   isSlotUsed,
+  isMacDevice,
 } from "../../utils/helpers";
 import { IC_INHERITED_ARIA } from "../../utils/constants";
 import {
@@ -845,8 +846,15 @@ export class Select {
     } else {
       if (!isArrowKey || this.noOptions === null) {
         if (event.key !== " " || this.pressedCharacters.length <= 0) {
-          // Keyboard events get passed onto ic-menu
-          this.menu?.handleKeyboardOpen(event);
+          // Keyboard events get passed onto ic-menu except in the case of ctrl-a on a searchable select
+          const isCtrlA =
+            event.key === "a" &&
+            ((isMacDevice() && event.metaKey) ||
+              (!isMacDevice() && event.ctrlKey));
+
+          if (!(this.searchable && isCtrlA)) {
+            this.menu?.handleKeyboardOpen(event);
+          }
         }
         if (!this.multiple) {
           this.handleCharacterKeyDown(event.key);


### PR DESCRIPTION
## Summary of the changes
fix ctrl-a not working on searchable select input

## Related issue
fix #3909

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.