### PR TITLE
fix(web-components): improve ic-input reflow behaviour

### DIFF
--- a/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
+++ b/packages/web-components/src/components/ic-input-component-container/ic-input-component-container.css
@@ -32,6 +32,7 @@ ic-input-component-container {
 
 ic-input-component-container.ic-input-component-container-full-width {
   width: 100%;
+  max-width: none;
 }
 
 ic-input-component-container.ic-input-component-container-disabled,
@@ -199,5 +200,13 @@ ic-input-component-container:focus {
   ic-input-component-container.ic-input-component-container-disabled,
   ic-input-component-container.ic-input-component-container-disabled:hover {
     border: var(--ic-border-width) dashed GrayText;
+  }
+}
+
+/* Breakpoint value chosen as it's a small amount bigger than the input's default width */
+@media screen AND (max-width: 22rem) {
+  ic-input-component-container {
+    max-width: var(--input-width, 20rem);
+    width: 100%;
   }
 }

--- a/packages/web-components/src/components/ic-input-validation/ic-input-validation.css
+++ b/packages/web-components/src/components/ic-input-validation/ic-input-validation.css
@@ -1,5 +1,5 @@
 ic-input-validation {
-  width: var(--input-width, 20rem);
+  max-width: var(--input-width, 20rem);
   display: flex;
 }
 
@@ -9,6 +9,7 @@ ic-input-validation.ic-input-validation-with-status {
 
 ic-input-validation.ic-input-validation-full-width {
   width: 100%;
+  max-width: none;
 }
 
 ic-input-validation span.status-icon {

--- a/packages/web-components/src/components/ic-menu/ic-menu.css
+++ b/packages/web-components/src/components/ic-menu/ic-menu.css
@@ -299,3 +299,11 @@
     --ic-typography-color: GrayText;
   }
 }
+
+/* Breakpoint value chosen as it's a small amount bigger than the menu's default width */
+@media screen AND (max-width: 22rem) {
+  :host {
+    max-width: var(--menu-width, var(--input-width, 20rem));
+    width: 100%;
+  }
+}

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.css
@@ -201,3 +201,11 @@ input[type="search"].truncate-value {
     fill: GrayText;
   }
 }
+
+/* Breakpoint value chosen as it's a small amount bigger than the search bar's default width */
+@media screen AND (max-width: 22rem) {
+  .menu-container {
+    max-width: var(--menu-width, var(--input-width, 20rem));
+    width: 100%;
+  }
+}


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Set width of ic-input (used in textfield and select) to 100% at screen widths below 364px so it doesn't overflow.

For testing: open textfield/select/datepicker storybooks and reduce window width to 320px. Compare against develop and hopefully you'll agree that this solves the overflow issue seen in the ticket without impacting display at more regular widths :) 

## Related issue
#4071

## Checklist

### General 

- [x] All acceptance criteria reviewed and met. 


### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 