### PR TITLE
3780 ic tree view ic tree item increase unit test code coverage

### DIFF
--- a/packages/canary-web-components/src/components/ic-tree-item/test/basic/__snapshots__/ic-tree-item.spec.ts.snap
+++ b/packages/canary-web-components/src/components/ic-tree-item/test/basic/__snapshots__/ic-tree-item.spec.ts.snap
@@ -12,6 +12,18 @@ exports[`ic-tree-item component should render 1`] = `
 </ic-tree-item>
 `;
 
+exports[`ic-tree-item component should render as an anchor when href is set and not disabled 1`] = `
+<ic-tree-item href="/test" id="ic-tree-item-11" label="Link Item">
+  <template shadowrootmode="open">
+    <a aria-disabled="false" aria-live="polite" class="tree-item-content" href="/test" hreflang="" tabindex="0">
+      <ic-typography class="tree-item-label">
+        Link Item
+      </ic-typography>
+    </a>
+  </template>
+</ic-tree-item>
+`;
+
 exports[`ic-tree-item component should render custom ids 1`] = `
 <ic-tree-item id="item-1" label="Item 1" tree-item-id="item-1">
   <template shadowrootmode="open">

--- a/packages/canary-web-components/src/components/ic-tree-view/test/basic/__snapshots__/ic-tree-view.spec.ts.snap
+++ b/packages/canary-web-components/src/components/ic-tree-view/test/basic/__snapshots__/ic-tree-view.spec.ts.snap
@@ -55,6 +55,116 @@ exports[`ic-tree-view component should render with slotted heading 1`] = `
 </ic-tree-view>
 `;
 
+exports[`ic-tree-view component should render with tree item data instead of slotted tree items 1`] = `
+<ic-tree-view aria-label="Heading" context-id="ic-tree-view-12" heading="Heading">
+  <template shadowrootmode="open">
+    <div class="heading-area-container">
+      <ic-typography class="tree-view-header" variant="subtitle-large">
+        Heading
+      </ic-typography>
+    </div>
+    <slot></slot>
+  </template>
+  <ic-tree-item context-id="ic-tree-view-12" id="ic-tree-item-23">
+    <template shadowrootmode="open">
+      <div aria-disabled="false" aria-live="polite" class="tree-item-content" tabindex="0">
+        <ic-typography class="tree-item-label">
+          Item 1
+        </ic-typography>
+      </div>
+    </template>
+  </ic-tree-item>
+  <ic-tree-item context-id="ic-tree-view-12" id="ic-tree-item-24">
+    <template shadowrootmode="open">
+      <div aria-disabled="false" aria-live="polite" class="tree-item-content" tabindex="0">
+        <ic-typography class="tree-item-label">
+          Item 2
+        </ic-typography>
+      </div>
+    </template>
+  </ic-tree-item>
+  <ic-tree-item class="ic-tree-item-disabled" context-id="ic-tree-view-12" id="ic-tree-item-25">
+    <template shadowrootmode="open">
+      <div aria-disabled="true" aria-live="polite" class="tree-item-content" tabindex="-1">
+        <ic-typography class="tree-item-label">
+          Item 3
+        </ic-typography>
+      </div>
+    </template>
+  </ic-tree-item>
+</ic-tree-view>
+`;
+
+exports[`ic-tree-view component should render with tree item data with children and icons 1`] = `
+<ic-tree-view aria-label="Heading" context-id="ic-tree-view-13" heading="Heading">
+  <template shadowrootmode="open">
+    <div class="heading-area-container">
+      <ic-typography class="tree-view-header" variant="subtitle-large">
+        Heading
+      </ic-typography>
+    </div>
+    <slot></slot>
+  </template>
+  <ic-tree-item context-id="ic-tree-view-13" id="ic-tree-item-26">
+    <template shadowrootmode="open">
+      <div aria-disabled="false" aria-live="polite" class="tree-item-content" tabindex="0">
+        <span aria-hidden="true" class="arrow-dropdown">
+          svg
+        </span>
+        <ic-typography class="tree-item-label">
+          Item 1
+        </ic-typography>
+      </div>
+    </template>
+    <ic-tree-item context-id="ic-tree-view-13" id="ic-tree-item-29">
+      <template shadowrootmode="open">
+        <div aria-disabled="false" aria-live="polite" class="ic-tree-item-single tree-item-content" tabindex="0" style="padding-left: calc(var(--ic-space-xs) + 48px);">
+          <ic-typography class="tree-item-label">
+            Item 1.1
+          </ic-typography>
+        </div>
+      </template>
+    </ic-tree-item>
+    <ic-tree-item context-id="ic-tree-view-13" id="ic-tree-item-30">
+      <template shadowrootmode="open">
+        <div aria-disabled="false" aria-live="polite" class="ic-tree-item-single tree-item-content" tabindex="0" style="padding-left: calc(var(--ic-space-xs) + 48px);">
+          <ic-typography class="tree-item-label">
+            Item 1.2
+          </ic-typography>
+        </div>
+      </template>
+    </ic-tree-item>
+  </ic-tree-item>
+  <ic-tree-item context-id="ic-tree-view-13" id="ic-tree-item-27">
+    <template shadowrootmode="open">
+      <div aria-disabled="false" aria-live="polite" class="ic-tree-item-single tree-item-content" tabindex="0">
+        <div class="icon-container">
+          <slot name="icon"></slot>
+        </div>
+        <ic-typography class="tree-item-label">
+          Item 2
+        </ic-typography>
+      </div>
+    </template>
+    <div slot="icon">
+      <svg fill="#000000" height="24px" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
+        <path d="M0 0h24v24H0V0z" fill="none"></path>
+        <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
+      </svg>
+    </div>
+  </ic-tree-item>
+  <ic-tree-item class="ic-tree-item-disabled" context-id="ic-tree-view-13" id="ic-tree-item-28">
+    <template shadowrootmode="open">
+      <div aria-disabled="true" aria-live="polite" class="ic-tree-item-single tree-item-content" tabindex="-1">
+        <ic-typography class="tree-item-label">
+          Item 3
+        </ic-typography>
+      </div>
+    </template>
+  </ic-tree-item>
+</ic-tree-view>
+`;
+
 exports[`ic-tree-view component should render with tree items 1`] = `
 <ic-tree-view aria-label="Heading" context-id="ic-tree-view-2" heading="Heading">
   <template shadowrootmode="open">

--- a/packages/canary-web-components/src/components/ic-tree-view/test/basic/ic-tree-view.spec.ts
+++ b/packages/canary-web-components/src/components/ic-tree-view/test/basic/ic-tree-view.spec.ts
@@ -3,6 +3,20 @@ import { TreeView } from "../../ic-tree-view";
 import { TreeItem } from "../../../ic-tree-item/ic-tree-item";
 import { IcTypography as Typography } from "@ukic/web-components/dist/components/ic-typography";
 
+const parent = { tagName: "IC-TREE-VIEW", expanded: true };
+
+const mockTreeItem = (
+  disabled: boolean,
+  setFocus?: jest.Mock,
+  overrides = {}
+) => ({
+  parentElement: parent,
+  offsetHeight: 10,
+  disabled: disabled,
+  setFocus,
+  ...overrides,
+});
+
 describe("ic-tree-view component", () => {
   it("should render", async () => {
     const page = await newSpecPage({
@@ -81,6 +95,247 @@ describe("ic-tree-view component", () => {
     expect(treeItem.selected).toBeFalsy();
   });
 
+  it("should call watchTruncateTreeItemsHandler when truncateTreeItems changes", async () => {
+    const page = await newSpecPage({
+      components: [TreeView],
+      html: `<ic-tree-view heading="Heading"></ic-tree-view>`,
+    });
+
+    const mockTreeItem1 = {
+      truncateTreeItem: false,
+      previousTruncateTreeItem: undefined,
+    };
+    const mockTreeItem2 = {
+      truncateTreeItem: false,
+      previousTruncateTreeItem: undefined,
+    };
+    page.rootInstance.treeItems = [mockTreeItem1, mockTreeItem2];
+
+    page.rootInstance.smallDevice = true;
+    page.rootInstance.truncateTreeItems = true;
+    await page.waitForChanges();
+
+    expect(mockTreeItem1.truncateTreeItem).toBe(true);
+    expect(mockTreeItem2.truncateTreeItem).toBe(true);
+    expect(mockTreeItem1.previousTruncateTreeItem).toBe(false);
+    expect(mockTreeItem2.previousTruncateTreeItem).toBe(false);
+  });
+
+  it("should test getNextItemToSelect", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading">
+          <ic-tree-item label="Item 1"></ic-tree-item>
+          <ic-tree-item label="Item 2"></ic-tree-item>
+          <ic-tree-item label="Item 3"></ic-tree-item>
+      </ic-tree-view>`,
+    });
+
+    page.rootInstance.treeItems = [
+      mockTreeItem(false),
+      mockTreeItem(false),
+      mockTreeItem(true),
+    ];
+    await page.waitForChanges();
+    const nextItem = page.rootInstance.getNextItemToSelect(1, true);
+    expect(nextItem).toBe(2);
+
+    const previousItem = page.rootInstance.getNextItemToSelect(2, false);
+    expect(previousItem).toBe(1);
+
+    const moveToDisabledItem = page.rootInstance.getNextItemToSelect(2, true);
+    expect(moveToDisabledItem).toBe(2);
+  });
+
+  it("should test handleKeyDown - ArrowDown", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading">
+          <ic-tree-item label="Item 1"></ic-tree-item>
+          <ic-tree-item label="Item 2"></ic-tree-item>
+          <ic-tree-item label="Item 3"></ic-tree-item>
+      </ic-tree-view>`,
+    });
+
+    const setFocus1 = jest.fn();
+    const setFocus2 = jest.fn();
+    const setFocus3 = jest.fn();
+
+    page.rootInstance.treeItems = [
+      mockTreeItem(false, setFocus1),
+      mockTreeItem(false, setFocus2),
+      mockTreeItem(false, setFocus3),
+    ];
+
+    Object.defineProperty(document, "activeElement", {
+      value: page.rootInstance.treeItems[0],
+      configurable: true,
+    });
+
+    const event = { key: "ArrowDown", preventDefault: jest.fn() } as any;
+    await page.rootInstance.handleKeyDown(event);
+    expect(setFocus2).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    Object.defineProperty(document, "activeElement", {
+      value: page.rootInstance.treeItems[2],
+      configurable: true,
+    });
+    const eventLast = { key: "ArrowDown", preventDefault: jest.fn() } as any;
+    await page.rootInstance.handleKeyDown(eventLast);
+    expect(setFocus3).toHaveBeenCalled();
+    expect(eventLast.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("should test handleKeyDown - ArrowUp", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading">
+          <ic-tree-item label="Item 1"></ic-tree-item>
+          <ic-tree-item label="Item 2"></ic-tree-item>
+          <ic-tree-item label="Item 3"></ic-tree-item>
+      </ic-tree-view>`,
+    });
+
+    const setFocus1 = jest.fn();
+    const setFocus2 = jest.fn();
+    const setFocus3 = jest.fn();
+
+    page.rootInstance.treeItems = [
+      mockTreeItem(false, setFocus1),
+      mockTreeItem(false, setFocus2),
+      mockTreeItem(false, setFocus3),
+    ];
+
+    Object.defineProperty(document, "activeElement", {
+      value: page.rootInstance.treeItems[2],
+      configurable: true,
+    });
+
+    const event = { key: "ArrowUp", preventDefault: jest.fn() } as any;
+    await page.rootInstance.handleKeyDown(event);
+    expect(setFocus2).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    Object.defineProperty(document, "activeElement", {
+      value: page.rootInstance.treeItems[0],
+      configurable: true,
+    });
+    const eventFirst = { key: "ArrowUp", preventDefault: jest.fn() } as any;
+    await page.rootInstance.handleKeyDown(eventFirst);
+    expect(setFocus1).toHaveBeenCalled();
+    expect(eventFirst.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("should test handleKeyDown - ArrowRight", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading">
+            <ic-tree-item label="Item 1"></ic-tree-item>
+            <ic-tree-item label="Item 2"></ic-tree-item>
+            <ic-tree-item label="Item 3"></ic-tree-item>
+        </ic-tree-view>`,
+    });
+
+    const updateAriaLabel = jest.fn();
+    page.rootInstance.treeItems = [
+      mockTreeItem(false, undefined, {
+        isParent: true,
+        expanded: false,
+        hasParentExpanded: false,
+        updateAriaLabel,
+        children: [],
+      }),
+      mockTreeItem(false, undefined, {
+        isParent: false,
+        expanded: false,
+        hasParentExpanded: false,
+        updateAriaLabel,
+        children: [],
+      }),
+      mockTreeItem(false, undefined, {
+        isParent: false,
+        expanded: false,
+        hasParentExpanded: false,
+        updateAriaLabel,
+        children: [],
+      }),
+    ];
+    Object.defineProperty(document, "activeElement", {
+      value: page.rootInstance.treeItems[0],
+      configurable: true,
+    });
+    const event = { key: "ArrowRight", preventDefault: jest.fn() } as any;
+    await page.rootInstance.handleKeyDown(event);
+    expect(page.rootInstance.treeItems[0].expanded).toBe(true);
+    expect(page.rootInstance.treeItems[0].hasParentExpanded).toBe(true);
+    expect(updateAriaLabel).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    const setFocusChild = jest.fn();
+    page.rootInstance.treeItems[0].expanded = true;
+    page.rootInstance.treeItems[0].children = [{ setFocus: setFocusChild }];
+    await page.rootInstance.handleKeyDown(event);
+    expect(setFocusChild).toHaveBeenCalled();
+  });
+
+  it("should test handleKeyDown - ArrowLeft", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading">
+            <ic-tree-item label="Item 1"></ic-tree-item>
+            <ic-tree-item label="Item 2"></ic-tree-item>
+            <ic-tree-item label="Item 3"></ic-tree-item>
+        </ic-tree-view>`,
+    });
+
+    const updateAriaLabel = jest.fn();
+    page.rootInstance.treeItems = [
+      mockTreeItem(false, undefined, {
+        isParent: true,
+        expanded: true,
+        hasParentExpanded: true,
+        updateAriaLabel,
+        children: [],
+      }),
+      mockTreeItem(false, undefined, {
+        isParent: false,
+        expanded: false,
+        hasParentExpanded: false,
+        updateAriaLabel,
+        children: [],
+      }),
+      mockTreeItem(false, undefined, {
+        isParent: false,
+        expanded: false,
+        hasParentExpanded: false,
+        updateAriaLabel,
+        children: [],
+      }),
+    ];
+
+    Object.defineProperty(document, "activeElement", {
+      value: page.rootInstance.treeItems[0],
+      configurable: true,
+    });
+    const event = { key: "ArrowLeft", preventDefault: jest.fn() } as any;
+    await page.rootInstance.handleKeyDown(event);
+    expect(page.rootInstance.treeItems[0].expanded).toBe(false);
+    expect(page.rootInstance.treeItems[0].hasParentExpanded).toBe(false);
+    expect(updateAriaLabel).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    const setFocusParent = jest.fn();
+    page.rootInstance.treeItems[0].isParent = false;
+    page.rootInstance.treeItems[0].expanded = false;
+    page.rootInstance.treeItems[0].parentElement = {
+      tagName: "IC-TREE-ITEM",
+      setFocus: setFocusParent,
+    };
+    await page.rootInstance.handleKeyDown(event);
+    expect(setFocusParent).toHaveBeenCalled();
+  });
+
   it("should test child items are added after initial load", async () => {
     const page = await newSpecPage({
       components: [TreeView, TreeItem],
@@ -104,5 +359,98 @@ describe("ic-tree-view component", () => {
       },
     ]);
     expect(page.rootInstance.treeItems.length).toBe(3);
+  });
+
+  it("should render with tree item data instead of slotted tree items", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading"></ic-tree-view>`,
+    });
+
+    page.rootInstance.treeItemData = [
+      { label: "Item 1" },
+      { label: "Item 2" },
+      { label: "Item 3", disabled: true },
+    ];
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it("should render with tree item data with children and icons", async () => {
+    const page = await newSpecPage({
+      components: [TreeView, TreeItem],
+      html: `<ic-tree-view heading="Heading"></ic-tree-view>`,
+    });
+
+    page.rootInstance.treeItemData = [
+      {
+        label: "Item 1",
+        children: [{ label: "Item 1.1" }, { label: "Item 1.2" }],
+      },
+      {
+        label: "Item 2",
+        icon: '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>',
+      },
+      { label: "Item 3", disabled: true },
+    ];
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it("should truncate heading and remove truncated heading", async () => {
+    const page = await newSpecPage({
+      components: [TreeView],
+      html: `<ic-tree-view heading="Heading"></ic-tree-view>`,
+    });
+    page.rootInstance.truncateHeading = true;
+
+    const heading = document.createElement("div");
+    heading.className = "tree-view-header";
+    Object.defineProperty(heading, "scrollHeight", { value: 40 });
+
+    const headingContainer = document.createElement("div");
+    headingContainer.className = "heading-area-container";
+    Object.defineProperty(headingContainer, "clientHeight", { value: 20 });
+
+    if (page.root && page.root.shadowRoot) {
+      page.root.shadowRoot.querySelector = jest.fn((selector) => {
+        if (selector === ".tree-view-header") return heading;
+        if (selector === ".heading-area-container") return headingContainer;
+        return null;
+      });
+    }
+
+    page.rootInstance.truncateHeading = true;
+    page.rootInstance.componentDidRender();
+
+    expect(heading.classList.contains("ic-text-overflow")).toBe(true);
+
+    page.rootInstance.removeHeadingTruncation();
+    expect(heading.classList.contains("ic-text-overflow")).toBe(false);
+  });
+
+  it("should restore previousTruncateHeading and previousTruncateTreeItems when smallDevice is false in watchSmallDeviceHandler", async () => {
+    const page = await newSpecPage({
+      components: [TreeView],
+      html: `<ic-tree-view heading="Heading"></ic-tree-view>`,
+    });
+    page.rootInstance.previousTruncateHeading = true;
+    page.rootInstance.previousTruncateTreeItems = true;
+    page.rootInstance.truncateHeading = false;
+    page.rootInstance.truncateTreeItems = false;
+    page.rootInstance.smallDevice = false;
+
+    const treeItem = {
+      previousTruncateTreeItem: true,
+      truncateTreeItem: false,
+    };
+    page.rootInstance.treeItems = [treeItem];
+    page.rootInstance.watchSmallDeviceHandler();
+    page.rootInstance.watchTruncateTreeItemsHandler();
+    expect(page.rootInstance.truncateHeading).toBe(true);
+    expect(page.rootInstance.truncateTreeItems).toBe(true);
+    expect(treeItem.truncateTreeItem).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update code coverage of tree view and tree item in unit tests. Forgot to take screenshot before moving back to the canary package but all 4 percentages for both components are now over 80%, passing code coverage.

## Related issue
#3780

## Checklist

### Testing

- [x] Relevant unit tests and visual regression tests added. 