### PR TITLE
Allow release in scope check

### DIFF
--- a/.github/scripts/scope-check.js
+++ b/.github/scripts/scope-check.js
@@ -55,6 +55,7 @@ function validateScope(commitMessage, changedFiles, scopeToPathMap) {
   if (scope === "root") {
     const forbiddenPrefixes = Object.values(scopeToPathMap).filter(Boolean);
     for (const file of changedFiles) {
+      if (file.endsWith("CHANGELOG.md")) continue;
       if (forbiddenPrefixes.some(prefix => file.startsWith(prefix))) {
         console.error(`❌ File "${file}" is inside a package folder but scope is "root".`);
         process.exit(1);
@@ -62,6 +63,7 @@ function validateScope(commitMessage, changedFiles, scopeToPathMap) {
     }
   } else {
     for (const file of changedFiles) {
+      if (file.endsWith("CHANGELOG.md")) continue;
       if (!file.startsWith(allowedPrefix)) {
         console.error(`❌ File "${file}" changed in commit, but does not match scope "${scope}" (expected path prefix: "${allowedPrefix}")`);
         process.exit(1);


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update scope-check.js file to allow the release commit which includes changes to each package changelog.

It currently fails every develop -> main PR because it includes a chore(release) commit, we thought the release part was the issue, but it's actually because this commit includes changes to every package and it wants the commit to be split so each has their own commit per package. We don't want to do that as it's just for changelogs, so I've updated the script to just skip over the file if it's a changelog and hopefully it won't error anymore.

## Related issue
N/A