### PR TITLE
Create update roadmap action

### DIFF
--- a/.github/workflows/update-design-system-roadmap.yml
+++ b/.github/workflows/update-design-system-roadmap.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  ic-ui-kit-update-roadmap-design-system:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
+    name: "Trigger design system update roadmap workflow"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 #v3.0.0
+        with:
+          token: ${{ secrets.PUBLISH_PAT }}
+          repository: mi6/ic-design-system
+          event-type: design-system-roadmap-update
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION



<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Create a new github action to trigger the update roadmap workflow in design system. 
Current method doesn't work because the changelog only gets updated when develop is merged into main, and the design system was running the action before that point.

## Related issue
N/A
