### PR TITLE
4030 internal issue 3124

### DIFF
--- a/.github/workflows/ic-ui-kit-release-merged.yml
+++ b/.github/workflows/ic-ui-kit-release-merged.yml
@@ -2,6 +2,7 @@ name: Release Merged to Develop
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   pull_request:
@@ -125,7 +126,7 @@ jobs:
           TOKEN: ${{ secrets.PUBLISH_PAT }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #4.0.2
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -143,8 +144,6 @@ jobs:
           git config --global user.email ${{ secrets.EMAIL }}
           git checkout packages/docs/docs.json packages/canary-docs/docs.json
           npx lerna publish --no-commit-hooks -y
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   ic-ui-kit-deploy-storybook-canary:
     needs: [ic-ui-kit-publish, check-updates]


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update publish workflow to use OIDC and upgrade step to node 22 in order for OIDC to work properly

Followed the [npm trusted publishers guide](https://docs.npmjs.com/trusted-publishers). When reviewing it would be worth other npm admins to check that I've correctly set up the trusted publisher on there too as this is only a small change to the workflow.

## Related issue
#4030