### PR TITLE
Add back node token

### DIFF
--- a/.github/workflows/ic-ui-kit-release-merged.yml
+++ b/.github/workflows/ic-ui-kit-release-merged.yml
@@ -144,6 +144,8 @@ jobs:
           git config --global user.email ${{ secrets.EMAIL }}
           git checkout packages/docs/docs.json packages/canary-docs/docs.json
           npx lerna publish --no-commit-hooks -y
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   ic-ui-kit-deploy-storybook-canary:
     needs: [ic-ui-kit-publish, check-updates]


### PR DESCRIPTION
OIDC not working due to needing lerna v9, adding this back in to get the release working again.