### PR TITLE
Classification banner custom text

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -6096,6 +6096,33 @@
           "setter": false
         },
         {
+          "name": "customClassificationText",
+          "type": "string | undefined",
+          "complexType": {
+            "original": "string",
+            "resolved": "string | undefined",
+            "references": {}
+          },
+          "mutable": false,
+          "attr": "custom-classification-text",
+          "reflectToAttr": false,
+          "docs": "The custom text that will appear on the banner. If set, the `additionalSelectors`, `country` and `upTo` props are ignored.",
+          "docsTags": [],
+          "default": "\"\"",
+          "values": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "undefined"
+            }
+          ],
+          "optional": true,
+          "required": false,
+          "getter": false,
+          "setter": false
+        },
+        {
           "name": "inline",
           "type": "boolean | undefined",
           "complexType": {

--- a/packages/react/src/stories/ic-classification-banner.stories.jsx
+++ b/packages/react/src/stories/ic-classification-banner.stories.jsx
@@ -6,6 +6,7 @@ const defaultArgs = {
   additionalSelectors: "",
   classification: "official",
   country: "uk",
+  customClassificationText: "",
   inline: true,
   upTo: false,
 };
@@ -91,6 +92,19 @@ export const AdditionalSelectors = {
   name: "Additional selectors",
 };
 
+export const CustomClassificationStrings = {
+  render: () => (
+    <>
+      <IcClassificationBanner inline="true" customClassificationText="Custom Unknown classification" />
+      <IcClassificationBanner classification="official" inline="true" customClassificationText="Custom Official classification" />
+      <IcClassificationBanner classification="official-sensitive" inline="true" customClassificationText="Custom Official-Sensitive classification" />
+      <IcClassificationBanner classification="secret" inline="true" customClassificationText="Custom Secret classification" />
+      <IcClassificationBanner classification="top-secret" inline="true" customClassificationText="Custom Top Secret classification" />
+    </>
+  ),
+  name: "Custom Classifications",
+};
+
 export const Playground = {
   render: (args) => (
     <IcClassificationBanner
@@ -99,6 +113,7 @@ export const Playground = {
       up-to={args.upTo}
       country={args.country}
       additional-selectors={args.additionalSelectors}
+      custom-classification-text={args.customClassificationText}
     ></IcClassificationBanner>
   ),
 

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -765,6 +765,10 @@ export namespace Components {
          */
         "country"?: string;
         /**
+          * The custom text that will appear on the banner. If set, the `additionalSelectors`, `country` and `upTo` props are ignored.
+         */
+        "customClassificationText"?: string;
+        /**
           * If `true`, the banner will appear inline with the page, instead of sticking to the bottom of the page.
          */
         "inline"?: boolean;
@@ -4521,6 +4525,10 @@ declare namespace LocalJSX {
           * The optional text that will be displayed before classification to specify relevant country/countries.
          */
         "country"?: string;
+        /**
+          * The custom text that will appear on the banner. If set, the `additionalSelectors`, `country` and `upTo` props are ignored.
+         */
+        "customClassificationText"?: string;
         /**
           * If `true`, the banner will appear inline with the page, instead of sticking to the bottom of the page.
          */

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.stories.js
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.stories.js
@@ -4,6 +4,7 @@ const defaultArgs = {
   additionalSelectors: "",
   classification: "official",
   country: "uk",
+  customClassificationText: "",
   inline: true,
   upTo: false,
 };
@@ -99,6 +100,36 @@ export const AdditionalSelectors = {
   name: "Additional selectors",
 };
 
+export const CustomClassificationStrings = {
+  render: () =>
+    html`<ic-classification-banner
+        inline="true"
+        custom-classification-text="Custom Unknown classification"
+      ></ic-classification-banner>
+      <ic-classification-banner
+        classification="official"
+        inline="true"
+        custom-classification-text="Custom Official classification"
+      ></ic-classification-banner>
+      <ic-classification-banner
+        classification="official-sensitive"
+        inline="true"
+        custom-classification-text="Custom Official-Sensitive classification"
+      ></ic-classification-banner>
+      <ic-classification-banner
+        classification="secret"
+        inline="true"
+        custom-classification-text="Custom Secret classification"
+      ></ic-classification-banner>
+      <ic-classification-banner
+        classification="top-secret"
+        inline="true"
+        custom-classification-text="Custom Top Secret classification"
+      ></ic-classification-banner>`,
+
+  name: "Custom Classifications",
+};
+
 export const Playground = {
   render: (args) =>
     html`<ic-classification-banner
@@ -107,6 +138,7 @@ export const Playground = {
       up-to=${args.upTo}
       country=${args.country}
       additional-selectors=${args.additionalSelectors}
+      custom-classification-text=${args.customClassificationText}
     ></ic-classification-banner>`,
 
   args: defaultArgs,

--- a/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.tsx
+++ b/packages/web-components/src/components/ic-classification-banner/ic-classification-banner.tsx
@@ -28,6 +28,10 @@ export class ClassificationBanner {
    */
   @Prop() country?: string = "uk";
   /**
+   * The custom text that will appear on the banner. If set, the `additionalSelectors`, `country` and `upTo` props are ignored.
+   */
+  @Prop() customClassificationText?: string = "";
+  /**
    * If `true`, the banner will appear inline with the page, instead of sticking to the bottom of the page.
    */
   @Prop() inline?: boolean = false;
@@ -40,7 +44,12 @@ export class ClassificationBanner {
     const { inline, upTo } = this;
 
     // In case of unrecognized props, fallback to default
-    let { country, additionalSelectors, classification } = this;
+    let {
+      country,
+      additionalSelectors,
+      classification,
+      customClassificationText,
+    } = this;
     if (!country) country = "";
     if (!additionalSelectors) additionalSelectors = "";
     if (
@@ -48,6 +57,7 @@ export class ClassificationBanner {
       (classification && !classificationText[classification])
     )
       classification = "default";
+    if (!customClassificationText) customClassificationText = "";
 
     return (
       <Host class={{ ["ic-classification-banner-inline"]: !!inline }}>
@@ -64,7 +74,9 @@ export class ClassificationBanner {
             </span>
           ) : null}
           <ic-typography variant="caption-uppercase">
-            {classification === "default"
+            {customClassificationText !== ""
+              ? customClassificationText
+              : classification === "default"
               ? classificationText[classification]
               : `${upTo ? "up to" : ""} 
                ${country} 

--- a/packages/web-components/src/components/ic-classification-banner/readme.md
+++ b/packages/web-components/src/components/ic-classification-banner/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property              | Attribute              | Description                                                                                            | Type                                                                                       | Default     |
-| --------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ | ----------- |
-| `additionalSelectors` | `additional-selectors` | The additional information that will be displayed after the classification.                            | `string \| undefined`                                                                      | `""`        |
-| `classification`      | `classification`       | The classification level to be displayed - also determines the banner and text colour.                 | `"default" \| "official" \| "official-sensitive" \| "secret" \| "top-secret" \| undefined` | `"default"` |
-| `country`             | `country`              | The optional text that will be displayed before classification to specify relevant country/countries.  | `string \| undefined`                                                                      | `"uk"`      |
-| `inline`              | `inline`               | If `true`, the banner will appear inline with the page, instead of sticking to the bottom of the page. | `boolean \| undefined`                                                                     | `false`     |
-| `upTo`                | `up-to`                | If `true`, "Up to" will be displayed before the classification and country.                            | `boolean \| undefined`                                                                     | `false`     |
+| Property                   | Attribute                    | Description                                                                                                                | Type                                                                                       | Default     |
+| -------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------- |
+| `additionalSelectors`      | `additional-selectors`       | The additional information that will be displayed after the classification.                                                | `string \| undefined`                                                                      | `""`        |
+| `classification`           | `classification`             | The classification level to be displayed - also determines the banner and text colour.                                     | `"default" \| "official" \| "official-sensitive" \| "secret" \| "top-secret" \| undefined` | `"default"` |
+| `country`                  | `country`                    | The optional text that will be displayed before classification to specify relevant country/countries.                      | `string \| undefined`                                                                      | `"uk"`      |
+| `customClassificationText` | `custom-classification-text` | The custom text that will appear on the banner. If set, the `additionalSelectors`, `country` and `upTo` props are ignored. | `string \| undefined`                                                                      | `""`        |
+| `inline`                   | `inline`                     | If `true`, the banner will appear inline with the page, instead of sticking to the bottom of the page.                     | `boolean \| undefined`                                                                     | `false`     |
+| `upTo`                     | `up-to`                      | If `true`, "Up to" will be displayed before the classification and country.                                                | `boolean \| undefined`                                                                     | `false`     |
 
 
 ## CSS Custom Properties

--- a/packages/web-components/src/components/ic-classification-banner/test/basic/__snapshots__/ic-classification-banner.spec.ts.snap
+++ b/packages/web-components/src/components/ic-classification-banner/test/basic/__snapshots__/ic-classification-banner.spec.ts.snap
@@ -66,6 +66,21 @@ exports[`ic-classification-banner component should render with additional select
 </ic-classification-banner>
 `;
 
+exports[`ic-classification-banner component should render with custom classification text only if supplied 1`] = `
+<ic-classification-banner additional-selectors="ukic" classification="official" country="uk" custom-classification-text="Custom classification text" up-to="true">
+  <template shadowrootmode="open">
+    <banner aria-label="Protective marking" class="classification-banner official">
+      <span class="offscreen">
+        The protective marking of this page is:
+      </span>
+      <ic-typography variant="caption-uppercase">
+        Custom classification text
+      </ic-typography>
+    </banner>
+  </template>
+</ic-classification-banner>
+`;
+
 exports[`ic-classification-banner component should render with default classification text when no classification set 1`] = `
 <ic-classification-banner>
   <template shadowrootmode="open">

--- a/packages/web-components/src/components/ic-classification-banner/test/basic/ic-classification-banner.spec.ts
+++ b/packages/web-components/src/components/ic-classification-banner/test/basic/ic-classification-banner.spec.ts
@@ -109,4 +109,13 @@ describe("ic-classification-banner component", () => {
 
     expect(page.root).toMatchSnapshot();
   });
+
+  it("should render with custom classification text only if supplied", async () => {
+    const page = await newSpecPage({
+      components: [ClassificationBanner],
+      html: `<ic-classification-banner classification="official" custom-classification-text="Custom classification text" additional-selectors="ukic" up-to=true country="uk"></ic-classification-banner>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Adds the ability to set the text displayed on the classification banner to a custom string via a new `customClassificationText` prop.

When set, the `additionalSelectors`, `country` and `upTo` props are ignored and just the text set as `customClassificationText` is used

The color of the banner is still determined via the `classification` prop

## Related issue
#4293, #3646

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 

### Accessibility 

- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA 


### Testing content extremes

- [x] All prop combinations work without issue. 
- [x] Props/slots can be updated after initial render.