### PR TITLE
Fix console error in toast component

### DIFF
--- a/packages/web-components/src/components/ic-toast/ic-toast.tsx
+++ b/packages/web-components/src/components/ic-toast/ic-toast.tsx
@@ -259,7 +259,8 @@ export class Toast {
       );
       return null;
     } else {
-      window.setTimeout(() => this.interactiveElements[0].setFocus(), 200);
+      this.interactiveElements[0] &&
+        window.setTimeout(() => this.interactiveElements[0].setFocus(), 200);
       return document.activeElement as HTMLElement;
     }
   }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
An error was appearing in the console when a toast was displayed: 
<img width="567" height="45" alt="image" src="https://github.com/user-attachments/assets/087c0808-28f2-4d01-a692-e399ccfcb553" />

Added a check to ensure the method is only called if an element exists

## Related issue
N\A


