### PR TITLE
4246 & 4247 focus issues on dialog

### DIFF
--- a/packages/canary-react/src/component-tests/IcDrawer/IcDrawer.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDrawer/IcDrawer.cy.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-bind */
 /// <reference types="Cypress" />
 
 import React, { ReactElement, useState } from "react";
@@ -1031,8 +1030,7 @@ describe("IcDrawer", () => {
     chevronButton.should(HAVE_FOCUS);
   });
 
-  // Focus trap not currently working in this test - https://github.com/mi6/ic-ui-kit/issues/4247 raised
-  it.skip("should focus interactive content and trap focus - search bar", () => {
+  it("should focus interactive content and trap focus - search bar", () => {
     mount(
       <IcDrawer heading="Test heading" message="Test message" expanded>
         <IcSearchBar slot="message" label="Test search bar" />
@@ -1104,15 +1102,13 @@ describe("IcDrawer", () => {
 
     chevronButton.should(HAVE_FOCUS);
 
-    // Shift + Tab not currently working - https://github.com/mi6/ic-ui-kit/issues/4246 raised
+    cy.realPress(["Shift", "Tab"]);
 
-    // cy.realPress(["Shift", "Tab"]);
+    tab.should(HAVE_FOCUS);
 
-    // tab.should(HAVE_FOCUS);
+    cy.realPress(["Shift", "Tab"]);
 
-    // cy.realPress(["Shift", "Tab"]);
-
-    // chevronButton.should(HAVE_FOCUS);
+    chevronButton.should(HAVE_FOCUS);
   });
 
   it("should focus interactive content and trap focus - text field", () => {

--- a/packages/canary-web-components/src/components/ic-drawer/ic-drawer.tsx
+++ b/packages/canary-web-components/src/components/ic-drawer/ic-drawer.tsx
@@ -17,7 +17,6 @@ import closeIcon from "../../assets/close-icon.svg";
 
 import {
   focusElement,
-  handleFocusTrapTabKeyPress,
   isSlotUsed,
   refreshInteractiveElementsOnSlotChange,
   removeInteractiveElementSlotChangeListener,
@@ -71,7 +70,6 @@ export class Drawer {
   private contentAreaSlot?: HTMLSlotElement | null;
   private drawerPanelEl?: HTMLDivElement;
   private focusAttemptCount = 0;
-  private focusedElementIndex = 0;
   private hostMutationObserver: MutationObserver | null = null;
   private innerDrawerPanelEl?: HTMLDivElement;
   private innerPanelResizeObserver?: ResizeObserver;
@@ -176,23 +174,6 @@ export class Drawer {
   handleKeyDown(ev: KeyboardEvent): void {
     if (this.expanded) {
       switch (ev.key) {
-        case "Tab": {
-          const tabKeyPressHandlerResult = handleFocusTrapTabKeyPress(
-            this.el,
-            this.focusAttemptCount,
-            this.focusedElementIndex,
-            this.interactiveElementList,
-            ev.shiftKey
-          );
-          this.focusAttemptCount =
-            tabKeyPressHandlerResult.newFocusAttemptCount;
-          this.focusedElementIndex =
-            tabKeyPressHandlerResult.newFocusedElementIndex;
-          if (tabKeyPressHandlerResult.preventDefault) {
-            ev.preventDefault();
-          }
-          break;
-        }
         case "Escape":
           this.handleDrawerExpanded(false, ev);
           break;
@@ -491,13 +472,11 @@ export class Drawer {
         if (this.interactiveElementList.length > 0) {
           const focusElementResult = focusElement(
             this.focusAttemptCount,
-            this.focusedElementIndex,
+            0,
             this.interactiveElementList
           );
           if (focusElementResult) {
             this.focusAttemptCount = focusElementResult.newFocusAttemptCount;
-            this.focusedElementIndex =
-              focusElementResult?.newFocusedElementIndex;
           }
         }
       }, this.TRANSITION_DURATION);
@@ -513,8 +492,23 @@ export class Drawer {
           this.chevronButton?.setFocus();
         }
       }, this.TRANSITION_DURATION);
+    }
+  };
 
-      this.focusedElementIndex = 0; // Reset to first element in case drawer is reopened
+  private focusLast = () => {
+    if (this.interactiveElementList.length > 0) {
+      focusElement(
+        this.focusAttemptCount,
+        this.interactiveElementList.length - 1,
+        this.interactiveElementList,
+        true
+      );
+    }
+  };
+
+  private focusFirst = () => {
+    if (this.interactiveElementList.length > 0) {
+      focusElement(this.focusAttemptCount, 0, this.interactiveElementList);
     }
   };
 
@@ -560,6 +554,7 @@ export class Drawer {
             !expanded ? this.handleDrawerExpanded(false, ev) : undefined
           }
         >
+          <div tabindex={expanded ? 0 : -1} onFocus={this.focusLast} />
           {this.isChevronTrigger() && this.renderChevronButton()}
           <div
             ref={(el) => (this.innerDrawerPanelEl = el)}
@@ -622,6 +617,7 @@ export class Drawer {
               )}
             </div>
           </div>
+          <div tabindex={expanded ? 0 : -1} onFocus={this.focusFirst} />
         </div>
       </Host>
     );

--- a/packages/canary-web-components/src/components/ic-drawer/test/basic/__snapshots__/ic-drawer.spec.tsx.snap
+++ b/packages/canary-web-components/src/components/ic-drawer/test/basic/__snapshots__/ic-drawer.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`ic-drawer should apply custom chevron button aria-label to chevron butt
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-22" label="Test aria-label" placement="bottom" silent="" target="ic-button-with-tooltip-22">
@@ -46,6 +47,7 @@ exports[`ic-drawer should apply custom chevron button aria-label to chevron butt
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -56,6 +58,7 @@ exports[`ic-drawer should apply custom close button aria-label to close button 1
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="controlled drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <div class="inner-drawer-panel" style="min-width: 0px;">
         <div class="drawer-header">
           <div class="heading-area">
@@ -97,6 +100,7 @@ exports[`ic-drawer should apply custom close button aria-label to close button 1
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -107,6 +111,7 @@ exports[`ic-drawer should render as expanded 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div aria-labelledby="drawer-heading" class="drawer-panel medium" id="drawer-panel" role="dialog" tabindex="-1">
+      <div tabindex="0"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-8" label="Close drawer" placement="bottom" silent="" target="ic-button-with-tooltip-8">
@@ -148,6 +153,7 @@ exports[`ic-drawer should render as expanded 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="0"></div>
     </div>
   </template>
 </ic-drawer>
@@ -158,6 +164,7 @@ exports[`ic-drawer should render at the bottom 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-6" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-6">
@@ -202,6 +209,7 @@ exports[`ic-drawer should render at the bottom 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -212,6 +220,7 @@ exports[`ic-drawer should render at the top 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-4" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-4">
@@ -256,6 +265,7 @@ exports[`ic-drawer should render at the top 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -266,6 +276,7 @@ exports[`ic-drawer should render large 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel large" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-12" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-12">
@@ -307,6 +318,7 @@ exports[`ic-drawer should render large 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -317,6 +329,7 @@ exports[`ic-drawer should render on the left 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-2" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-2">
@@ -358,6 +371,7 @@ exports[`ic-drawer should render on the left 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -368,6 +382,7 @@ exports[`ic-drawer should render on the right 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-0" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-0">
@@ -409,6 +424,7 @@ exports[`ic-drawer should render on the right 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -419,6 +435,7 @@ exports[`ic-drawer should render small 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel small" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-10" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-10">
@@ -460,6 +477,7 @@ exports[`ic-drawer should render small 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -470,6 +488,7 @@ exports[`ic-drawer should render with boundary prop set to 'parent' 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-14" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-14">
@@ -511,6 +530,7 @@ exports[`ic-drawer should render with boundary prop set to 'parent' 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -521,6 +541,7 @@ exports[`ic-drawer should render with hidden close button when trigger prop is s
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="controlled drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <div class="inner-drawer-panel" style="min-width: 0px;">
         <div class="drawer-header">
           <div class="heading-area">
@@ -552,6 +573,7 @@ exports[`ic-drawer should render with hidden close button when trigger prop is s
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -562,6 +584,7 @@ exports[`ic-drawer should render with slotted content 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-28" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-28">
@@ -599,6 +622,7 @@ exports[`ic-drawer should render with slotted content 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
   <svg slot="heading-adornment" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -634,6 +658,7 @@ exports[`ic-drawer should render with theme prop set to 'dark' 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary ic-theme-dark" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-20" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-20">
@@ -675,6 +700,7 @@ exports[`ic-drawer should render with theme prop set to 'dark' 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -685,6 +711,7 @@ exports[`ic-drawer should render with theme prop set to 'light' 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <ic-button class="chevron-btn ic-button-size-medium ic-button-variant-icon-tertiary ic-theme-light" exportparts="button">
         <template shadowrootmode="open">
           <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-18" label="Open drawer" placement="bottom" silent="" target="ic-button-with-tooltip-18">
@@ -726,6 +753,7 @@ exports[`ic-drawer should render with theme prop set to 'light' 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>
@@ -736,6 +764,7 @@ exports[`ic-drawer should render with trigger prop set to 'controlled' 1`] = `
   <template shadowrootmode="open">
     <div class="overlay"></div>
     <div class="controlled drawer-panel medium" id="drawer-panel" tabindex="-1">
+      <div tabindex="-1"></div>
       <div class="inner-drawer-panel" style="min-width: 0px;">
         <div class="drawer-header">
           <div class="heading-area">
@@ -777,6 +806,7 @@ exports[`ic-drawer should render with trigger prop set to 'controlled' 1`] = `
           </div>
         </div>
       </div>
+      <div tabindex="-1"></div>
     </div>
   </template>
 </ic-drawer>

--- a/packages/canary-web-components/src/components/ic-drawer/test/basic/ic-drawer.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-drawer/test/basic/ic-drawer.spec.tsx
@@ -265,7 +265,7 @@ describe("ic-drawer", () => {
     expect(page.rootInstance.marginResizeObserver).toBe(resizeObserverCallback);
   });
 
-  it("should handle Tab key press correctly - focussing the next interactive element", async () => {
+  it("should focus last interactive element when focusLast is called", async () => {
     const page = await newSpecPage({
       components: [Button, Drawer],
       html: `<ic-drawer heading="Test heading" message="Test message" expanded="true"></ic-drawer>`,
@@ -274,26 +274,37 @@ describe("ic-drawer", () => {
     jest.advanceTimersByTime(DELAY_MS);
     await page.waitForChanges();
 
-    Object.defineProperty(helpers, "handleFocusTrapTabKeyPress", {
-      value: jest.fn().mockReturnValue({
-        newFocusAttemptCount: 1,
-        newFocusedElementIndex: 2,
-        preventDefault: true,
-      }),
+    const interactiveElements = page.rootInstance.interactiveElementList;
+
+    const firstEl = interactiveElements[0];
+
+    const focusSpy = jest.spyOn(firstEl, "focus");
+
+    page.rootInstance.focusFirst();
+    await page.waitForChanges();
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("should focus first interactive element when focusFirst is called", async () => {
+    const page = await newSpecPage({
+      components: [Button, Drawer],
+      html: `<ic-drawer heading="Test heading" message="Test message" expanded="true"></ic-drawer>`,
     });
 
-    const tabPress = new KeyboardEvent("keydown", {
-      key: "Tab",
-      shiftKey: false,
-    });
-    const preventDefaultSpy = jest.spyOn(tabPress, "preventDefault");
+    jest.advanceTimersByTime(DELAY_MS);
+    await page.waitForChanges();
 
-    document.dispatchEvent(tabPress);
+    const interactiveElements = page.rootInstance.interactiveElementList;
 
-    expect(helpers.handleFocusTrapTabKeyPress).toHaveBeenCalled();
-    expect(preventDefaultSpy).toHaveBeenCalled();
-    expect(page.rootInstance.focusAttemptCount).toBe(1);
-    expect(page.rootInstance.focusedElementIndex).toBe(2);
+    const firstEl = interactiveElements[0];
+
+    const focusSpy = jest.spyOn(firstEl, "focus");
+
+    page.rootInstance.focusFirst();
+    await page.waitForChanges();
+
+    expect(focusSpy).toHaveBeenCalled();
   });
 
   it("should handle Escape key press correctly - collapsing the drawer", async () => {
@@ -621,7 +632,6 @@ describe("ic-drawer", () => {
       0,
       page.rootInstance.interactiveElementList
     );
-    expect(page.rootInstance.focusedElementIndex).toBe(1);
   });
 
   it("should focus the trigger element correctly when collapsed (trigger prop set to 'controlled')", async () => {

--- a/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
+++ b/packages/web-components/src/components/ic-dialog/ic-dialog.tsx
@@ -17,7 +17,6 @@ import {
   isSlotUsed,
   checkResizeObserver,
   focusElement,
-  handleFocusTrapTabKeyPress,
   onComponentRequiredPropUndefined,
   refreshInteractiveElementsOnSlotChange,
   slottedInteractiveElements,
@@ -44,7 +43,6 @@ export class Dialog {
   private dialogEl?: HTMLDialogElement;
   private dialogHeight: number = 0;
   private focusAttemptCount = 0;
-  private focusedElementIndex = 0;
   private interactiveElementList: HTMLElement[] = [];
   private resizeObserver: ResizeObserver | null = null;
   private resizeTimeout: number;
@@ -185,23 +183,6 @@ export class Dialog {
   handleKeyboard(ev: KeyboardEvent): void {
     if (this.dialogRendered) {
       switch (ev.key) {
-        case "Tab": {
-          const tabKeyPressHandlerResult = handleFocusTrapTabKeyPress(
-            this.el,
-            this.focusAttemptCount,
-            this.focusedElementIndex,
-            this.interactiveElementList,
-            ev.shiftKey
-          );
-          this.focusAttemptCount =
-            tabKeyPressHandlerResult.newFocusAttemptCount;
-          this.focusedElementIndex =
-            tabKeyPressHandlerResult.newFocusedElementIndex;
-          if (tabKeyPressHandlerResult.preventDefault) {
-            ev.preventDefault();
-          }
-          break;
-        }
         case "Escape":
           if (!ev.repeat) {
             this.open = false;
@@ -332,6 +313,23 @@ export class Dialog {
     }
   };
 
+  private focusLast = () => {
+    if (this.interactiveElementList.length > 0) {
+      focusElement(
+        this.focusAttemptCount,
+        this.interactiveElementList.length - 1,
+        this.interactiveElementList,
+        true
+      );
+    }
+  };
+
+  private focusFirst = () => {
+    if (this.interactiveElementList.length > 0) {
+      focusElement(this.focusAttemptCount, 0, this.interactiveElementList);
+    }
+  };
+
   private setInitialFocus = () => {
     this.sourceElement = document.activeElement as HTMLElement;
 
@@ -346,23 +344,22 @@ export class Dialog {
       return;
     }
 
-    this.focusedElementIndex = this.interactiveElementList.findIndex(
-      (element) => element.hasAttribute(this.DATA_GETS_FOCUS)
+    let focusedElementIndex = this.interactiveElementList.findIndex((element) =>
+      element.hasAttribute(this.DATA_GETS_FOCUS)
     );
 
-    if (this.focusedElementIndex === -1) {
-      this.focusedElementIndex = 0;
+    if (focusedElementIndex === -1) {
+      focusedElementIndex = 0;
     }
 
-    if (this.interactiveElementList[this.focusedElementIndex]) {
+    if (this.interactiveElementList[focusedElementIndex]) {
       const focusElementResult = focusElement(
         this.focusAttemptCount,
-        this.focusedElementIndex,
+        focusedElementIndex,
         this.interactiveElementList
       );
       if (focusElementResult) {
         this.focusAttemptCount = focusElementResult.newFocusAttemptCount;
-        this.focusedElementIndex = focusElementResult.newFocusedElementIndex;
       }
     }
   };
@@ -376,25 +373,35 @@ export class Dialog {
       this.el.shadowRoot?.querySelectorAll("ic-button") || []
     );
 
-    const interactiveElements = slottedInteractiveElements(this.el);
+    const slottedElements = slottedInteractiveElements(this.el);
 
-    if (interactiveElements.length > 0) {
-      if (interactiveElements[0].slot !== this.DIALOG_CONTROLS) {
-        interactiveElements[0].setAttribute(this.DATA_GETS_FOCUS, "");
+    if (slottedElements.length > 0) {
+      if (slottedElements[0].slot !== this.DIALOG_CONTROLS) {
+        slottedElements[0].setAttribute(this.DATA_GETS_FOCUS, "");
       } else if (!this.destructive) {
-        interactiveElements[interactiveElements.length - 1].setAttribute(
+        slottedElements[slottedElements.length - 1].setAttribute(
           this.DATA_GETS_FOCUS,
           ""
         );
       }
     }
 
-    for (let i = 0; i < interactiveElements.length; i++) {
-      this.interactiveElementList.splice(
-        1 + i,
-        0,
-        interactiveElements[i] as HTMLElement
-      );
+    // insert the slotted interactive elements after the close button in the focus order
+    if (slottedElements.length > 0 && this.interactiveElementList.length > 0) {
+      if (this.interactiveElementList[0].classList.contains("close-icon")) {
+        // if there is a close button, insert slotted interactive elements after it in the focus order
+        this.interactiveElementList = [
+          this.interactiveElementList[0],
+          ...slottedElements,
+          ...this.interactiveElementList.slice(1),
+        ] as HTMLElement[];
+      } else {
+        // if there is no close button, slotted interactive elements should be first in the focus order
+        this.interactiveElementList = [
+          ...slottedElements,
+          ...this.interactiveElementList,
+        ] as HTMLElement[];
+      }
     }
   };
 
@@ -427,6 +434,7 @@ export class Dialog {
         aria-describedby="dialog-alert dialog-content"
         ref={(el) => (this.dialogEl = el)}
       >
+        <div tabindex="0" onFocus={this.focusLast} />
         <div class="heading-area">
           <div class="heading-content">
             <div class="label">
@@ -495,6 +503,7 @@ export class Dialog {
             )}
           </div>
         )}
+        <div tabindex="0" onFocus={this.focusFirst} />
       </dialog>
     );
   };

--- a/packages/web-components/src/components/ic-dialog/test/basic/__snapshots__/ic-dialog.spec.ts.snap
+++ b/packages/web-components/src/components/ic-dialog/test/basic/__snapshots__/ic-dialog.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`ic-dialog component should render 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog heading" hide-default-controls="true">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -35,6 +36,7 @@ exports[`ic-dialog component should render 1`] = `
           <slot></slot>
         </div>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -44,6 +46,7 @@ exports[`ic-dialog component should render as large size 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-large" heading="Dialog heading" hide-default-controls="true" size="large">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog large">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -75,6 +78,7 @@ exports[`ic-dialog component should render as large size 1`] = `
           <slot></slot>
         </div>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -84,6 +88,7 @@ exports[`ic-dialog component should render as large size and disableWidthConstra
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-large" disable-width-constraint="true" heading="Dialog heading" hide-default-controls="true" size="large">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog disable-width-constraint large">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -101,8 +106,8 @@ exports[`ic-dialog component should render as large size and disableWidthConstra
         </div>
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon-tertiary" data-gets-focus exportparts="button">
           <template shadowrootmode="open">
-            <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-162" label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-162">
-              <button aria-describedby="ic-tooltip-ic-button-with-tooltip-162" aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
+            <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-146" label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-146">
+              <button aria-describedby="ic-tooltip-ic-button-with-tooltip-146" aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -115,6 +120,7 @@ exports[`ic-dialog component should render as large size and disableWidthConstra
           <slot></slot>
         </div>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -124,6 +130,7 @@ exports[`ic-dialog component should render as medium size 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-medium" heading="Dialog heading" hide-default-controls="true" size="medium">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog medium">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -155,6 +162,7 @@ exports[`ic-dialog component should render as medium size 1`] = `
           <slot></slot>
         </div>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -164,6 +172,7 @@ exports[`ic-dialog component should render with a label 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog heading" hide-default-controls="true" label="Dialog label">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -197,6 +206,7 @@ exports[`ic-dialog component should render with a label 1`] = `
           <slot></slot>
         </div>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -206,6 +216,7 @@ exports[`ic-dialog component should render with no buttons 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog heading" hide-default-controls="true">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -230,6 +241,7 @@ exports[`ic-dialog component should render with no buttons 1`] = `
           <slot></slot>
         </div>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
   Dialog content
@@ -240,6 +252,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog heading">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -289,6 +302,7 @@ exports[`ic-dialog component should render with slotted content 1`] = `
           Confirm
         </ic-button>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
   <ic-text-field label="What is your favourite coffee?" value="">
@@ -320,6 +334,7 @@ exports[`ic-dialog component should render with slotted controls 1`] = `
 <ic-dialog class="ic-dialog-size-small" heading="Dialog heading" open="">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -354,6 +369,7 @@ exports[`ic-dialog component should render with slotted controls 1`] = `
       <div class="dialog-controls">
         <slot name="dialog-controls"></slot>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
   <ic-button class="ic-button-size-medium ic-button-variant-primary" data-gets-focus exportparts="button" onclick="alert('Confirmed!')" slot="dialog-controls" variant="primary">
@@ -371,6 +387,7 @@ exports[`ic-dialog component should render with the close button 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog with close button test">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -388,8 +405,8 @@ exports[`ic-dialog component should render with the close button 1`] = `
         </div>
         <ic-button class="close-icon ic-button-size-medium ic-button-variant-icon-tertiary" exportparts="button">
           <template shadowrootmode="open">
-            <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-140" label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-140">
-              <button aria-describedby="ic-tooltip-ic-button-with-tooltip-140" aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
+            <ic-tooltip id="ic-tooltip-ic-button-with-tooltip-124" label="Dismiss" placement="bottom" silent="" target="ic-button-with-tooltip-124">
+              <button aria-describedby="ic-tooltip-ic-button-with-tooltip-124" aria-label="Dismiss" class="button" part="button" tabindex="0" type="button">
                 <slot></slot>
               </button>
             </ic-tooltip>
@@ -420,6 +437,7 @@ exports[`ic-dialog component should render with the close button 1`] = `
           Confirm
         </ic-button>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -429,6 +447,7 @@ exports[`ic-dialog component should render with two default buttons 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog heading">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -478,6 +497,7 @@ exports[`ic-dialog component should render with two default buttons 1`] = `
           Confirm
         </ic-button>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>
@@ -487,6 +507,7 @@ exports[`ic-dialog component should render without the close button 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small" heading="Dialog hide close button test" hide-close-button="true">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -526,6 +547,7 @@ exports[`ic-dialog component should render without the close button 1`] = `
           Confirm
         </ic-button>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
 </ic-dialog>

--- a/packages/web-components/src/components/ic-dialog/test/basic/ic-dialog.spec.ts
+++ b/packages/web-components/src/components/ic-dialog/test/basic/ic-dialog.spec.ts
@@ -36,6 +36,10 @@ const setupDialogMethods = (page: SpecPage) => {
 };
 
 describe("ic-dialog component", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should render", async () => {
     const page = await newSpecPage({
       components: [Dialog, Button],
@@ -474,88 +478,6 @@ describe("ic-dialog component", () => {
     expect(page.rootInstance.dialogRendered).toBe(false);
   });
 
-  it("should trigger handleFocusTrapTabKeyPress helper function when tab pressed", async () => {
-    const page = await newSpecPage({
-      components: [Dialog, TextField, Button],
-      html: `<ic-dialog heading="Dialog heading">
-        <ic-text-field label="What is your favourite coffee?">
-        </ic-text-field>
-        <ic-button>Click Me</ic-button>
-      </ic-dialog>`,
-    });
-
-    setupDialogMethods(page);
-    const dialog = document.querySelector("ic-dialog");
-
-    dialog?.setAttribute("open", "true");
-
-    await page.waitForChanges();
-
-    //delay for setTimeout in code
-    await waitForTimeout(DIALOG_DELAY_MS);
-
-    const handleFocusTrapTabKeyPressSpy = jest.spyOn(
-      helpers,
-      "handleFocusTrapTabKeyPress"
-    );
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-    await page.waitForChanges();
-
-    expect(page.rootInstance.dialogRendered).toBe(true);
-    expect(handleFocusTrapTabKeyPressSpy).toHaveBeenCalled();
-  });
-
-  it("should update the index of the focused element correctly", async () => {
-    const page = await newSpecPage({
-      components: [Dialog, TextField, Button],
-      html: `<ic-dialog heading="Dialog heading">
-        <ic-text-field label="What is your favourite coffee?">
-        </ic-text-field>
-        <ic-button>Click Me</ic-button>
-      </ic-dialog>`,
-    });
-
-    setupDialogMethods(page);
-    const dialog = document.querySelector("ic-dialog");
-
-    dialog?.setAttribute("open", "true");
-
-    await page.waitForChanges();
-
-    //delay for setTimeout in code
-    await waitForTimeout(DIALOG_DELAY_MS);
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-TEXT-FIELD");
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Tab", shiftKey: true })
-    );
-    await page.waitForChanges();
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-BUTTON");
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "Tab" })
-    );
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-TEXT-FIELD");
-  });
-
   // helpers.ts coverage
   it("should not move focus if the focused element index is not found", async () => {
     const page = await newSpecPage({
@@ -600,6 +522,7 @@ describe("ic-dialog component", () => {
         <ic-button>Click Me</ic-button>
       </ic-dialog>`,
     });
+    const focusElementSpy = jest.spyOn(helpers, "focusElement");
 
     setupDialogMethods(page);
     const dialog = document.querySelector("ic-dialog");
@@ -611,22 +534,16 @@ describe("ic-dialog component", () => {
     //delay for setTimeout in code
     await waitForTimeout(DIALOG_DELAY_MS);
 
+    expect(focusElementSpy).toHaveBeenCalled();
+
+    const returnValue = focusElementSpy.mock.results[0].value;
+
+    expect(returnValue).toBeDefined();
     expect(
       page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
+        returnValue.newFocusedElementIndex
       ].nodeName
     ).toBe("IC-ACCORDION-GROUP");
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-    await page.waitForChanges();
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-ACCORDION");
   });
 
   it("should render with an accordion as first focussable element", async () => {
@@ -641,6 +558,7 @@ describe("ic-dialog component", () => {
         <ic-button>Click Me</ic-button>
       </ic-dialog>`,
     });
+    const focusElementSpy = jest.spyOn(helpers, "focusElement");
 
     setupDialogMethods(page);
     const dialog = document.querySelector("ic-dialog");
@@ -652,22 +570,16 @@ describe("ic-dialog component", () => {
     //delay for setTimeout in code
     await waitForTimeout(DIALOG_DELAY_MS);
 
+    expect(focusElementSpy).toHaveBeenCalled();
+
+    const returnValue = focusElementSpy.mock.results[0].value;
+
+    expect(returnValue).toBeDefined();
     expect(
       page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
+        returnValue.newFocusedElementIndex
       ].nodeName
     ).toBe("IC-ACCORDION");
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-    await page.waitForChanges();
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-BUTTON");
   });
 
   it("should render with a ic-search-bar as first focussable element", async () => {
@@ -678,6 +590,7 @@ describe("ic-dialog component", () => {
         <ic-button>Click Me</ic-button>
       </ic-dialog>`,
     });
+    const focusElementSpy = jest.spyOn(helpers, "focusElement");
 
     setupDialogMethods(page);
     const dialog = document.querySelector("ic-dialog");
@@ -689,22 +602,14 @@ describe("ic-dialog component", () => {
     //delay for setTimeout in code
     await waitForTimeout(DIALOG_DELAY_MS);
 
+    expect(focusElementSpy).toHaveBeenCalled();
+
+    const returnValue = focusElementSpy.mock.results[0].value;
+
+    expect(returnValue).toBeDefined();
     expect(
       page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-SEARCH-BAR");
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-    await page.waitForChanges();
-
-    // the focussed element does not change in these tests as event does not get handled in the same
-    // way as it would in a real browser, which would focus the next element
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
+        returnValue.newFocusedElementIndex
       ].nodeName
     ).toBe("IC-SEARCH-BAR");
   });
@@ -806,13 +711,73 @@ describe("ic-dialog component", () => {
     expect(page.rootInstance.dialogHeight).toBe(100);
   });
 
-  it("should focus additional field of radio when tab pressed", async () => {
+  it("should focus last interactive element when focusLast is called", async () => {
     const page = await newSpecPage({
-      components: [Dialog, Button, RadioGroup, RadioOption, TextField],
+      components: [Dialog],
+      html: `<ic-dialog heading="Dialog heading">
+        <ic-button id="first">First</ic-button>
+        <ic-button id="last">Last</ic-button>
+      </ic-dialog>`,
+    });
+
+    setupDialogMethods(page);
+    const dialog = document.querySelector("ic-dialog");
+    dialog?.setAttribute("open", "true");
+
+    await waitForTimeout(DIALOG_DELAY_MS);
+
+    const interactiveElements = page.rootInstance.interactiveElementList;
+
+    const lastEl = interactiveElements[interactiveElements.length - 1];
+    console.log("Last element:", lastEl?.nodeName);
+
+    const focusSpy = jest.spyOn(lastEl, "focus");
+
+    page.rootInstance.focusLast();
+    await page.waitForChanges();
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("should focus first interactive element when focusFirst is called", async () => {
+    const page = await newSpecPage({
+      components: [Dialog],
+      html: `<ic-dialog heading="Dialog heading">
+        <ic-button id="first">First</ic-button>
+        <ic-button id="last">Last</ic-button>
+      </ic-dialog>`,
+    });
+
+    setupDialogMethods(page);
+    const dialog = document.querySelector("ic-dialog");
+    dialog?.setAttribute("open", "true");
+
+    await waitForTimeout(DIALOG_DELAY_MS);
+
+    const interactiveElements = page.rootInstance.interactiveElementList;
+
+    const firstEl = interactiveElements[0];
+
+    const focusSpy = jest.spyOn(firstEl, "focus");
+
+    page.rootInstance.focusFirst();
+    await page.waitForChanges();
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("should skip focus over elements correctly", async () => {
+    const page = await newSpecPage({
+      components: [Dialog, TextField, Button, RadioGroup, RadioOption],
       html: `<ic-dialog heading="Dialog heading">
         <ic-radio-group label="This is a label" name="1">
           <ic-radio-option
             value="valueName1"
+            label="Unselected / Default"
+          >
+          </ic-radio-option>
+          <ic-radio-option
+            value="valueName2"
             label="Selected / Default"
             additional-field-display="dynamic"
             selected
@@ -825,7 +790,7 @@ describe("ic-dialog component", () => {
             </ic-text-field>
           </ic-radio-option>
           <ic-radio-option
-            value="valueName2"
+            value="valueName3"
             label="Unselected / Disabled"
             disabled
           ></ic-radio-option>
@@ -833,6 +798,7 @@ describe("ic-dialog component", () => {
         <ic-button>Click Me</ic-button>
       </ic-dialog>`,
     });
+    const focusElementSpy = jest.spyOn(helpers, "focusElement");
 
     setupDialogMethods(page);
     const dialog = document.querySelector("ic-dialog");
@@ -844,110 +810,16 @@ describe("ic-dialog component", () => {
     //delay for setTimeout in code
     await waitForTimeout(DIALOG_DELAY_MS);
 
+    expect(focusElementSpy).toHaveBeenCalledTimes(2);
+
+    const returnValue = focusElementSpy.mock.results[0].value;
+
+    expect(returnValue).toBeDefined();
     expect(
       page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
+        returnValue.newFocusedElementIndex
       ].nodeName
     ).toBe("INPUT");
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-
-    await page.waitForChanges();
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-TEXT-FIELD");
-
-    //check that next tab does not focus the disabled radio
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-
-    await page.waitForChanges();
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-BUTTON");
-
-    // check that shift + tab returns to previous text field
-    const tabKeyEvent = keyboardEvent("Tab");
-    tabKeyEvent.shiftKey = true;
-    page.win.document.dispatchEvent(new KeyboardEvent("keydown", tabKeyEvent));
-
-    await page.waitForChanges();
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-TEXT-FIELD");
-  });
-
-  it("should test wrap around of tab key navigation", async () => {
-    const page = await newSpecPage({
-      components: [Dialog, TextField],
-      html: `<ic-dialog heading="Dialog heading">
-      </ic-dialog>`,
-    });
-
-    setupDialogMethods(page);
-    const dialog = document.querySelector("ic-dialog");
-
-    dialog?.setAttribute("open", "true");
-
-    await page.waitForChanges();
-
-    //delay for setTimeout in code
-    await waitForTimeout(DIALOG_DELAY_MS);
-
-    expect(page.rootInstance.focusedElementIndex).toBe(2);
-
-    page.win.document.dispatchEvent(
-      new KeyboardEvent("keydown", keyboardEvent("Tab"))
-    );
-
-    await page.waitForChanges();
-    expect(page.rootInstance.focusedElementIndex).toBe(0);
-
-    const tabKeyEvent = keyboardEvent("Tab");
-    tabKeyEvent.shiftKey = true;
-    page.win.document.dispatchEvent(new KeyboardEvent("keydown", tabKeyEvent));
-
-    await page.waitForChanges();
-    expect(page.rootInstance.focusedElementIndex).toBe(2);
-  });
-
-  it("should skip focus over elements correctly", async () => {
-    const page = await newSpecPage({
-      components: [Dialog, TextField, Button],
-      html: `<ic-dialog heading="Dialog heading">
-        <ic-text-field label="What is your favourite coffee?" disabled="true">
-        </ic-text-field>
-        <ic-button>Click Me</ic-button>
-      </ic-dialog>`,
-    });
-
-    setupDialogMethods(page);
-    const dialog = document.querySelector("ic-dialog");
-
-    dialog?.setAttribute("open", "true");
-
-    await page.waitForChanges();
-
-    //delay for setTimeout in code
-    await waitForTimeout(DIALOG_DELAY_MS);
-
-    expect(
-      page.rootInstance.interactiveElementList[
-        page.rootInstance.focusedElementIndex
-      ].nodeName
-    ).toBe("IC-BUTTON");
 
     // helpers.ts coverage
     const shouldSkipElementResult = helpers.shouldSkipElement(

--- a/packages/web-components/src/components/ic-popover-menu/test/basic/__snapshots__/ic-popover-menu.spec.ts.snap
+++ b/packages/web-components/src/components/ic-popover-menu/test/basic/__snapshots__/ic-popover-menu.spec.ts.snap
@@ -143,6 +143,7 @@ exports[`ic-popover-menu should render on a dialog 1`] = `
 <ic-dialog class="ic-dialog-hidden ic-dialog-size-small">
   <template shadowrootmode="open">
     <dialog aria-describedby="dialog-alert dialog-content" aria-labelledby="dialog-label dialog-heading" class="dialog small">
+      <div tabindex="0"></div>
       <div class="heading-area">
         <div class="heading-content">
           <div class="label">
@@ -173,6 +174,7 @@ exports[`ic-popover-menu should render on a dialog 1`] = `
           Confirm
         </ic-button>
       </div>
+      <div tabindex="0"></div>
     </dialog>
   </template>
   <ic-button id="anchorEl"></ic-button>

--- a/packages/web-components/src/utils/helpers.ts
+++ b/packages/web-components/src/utils/helpers.ts
@@ -747,17 +747,14 @@ export const focusElement = (
     return;
   }
 
-  let newFocusedElementIndex = focusedElementIndex;
-
   if (shouldSkipElement(element)) {
-    newFocusedElementIndex = getFocusIndexBasedOnShiftKey(
-      newFocusedElementIndex,
-      shiftKey
-    );
-    newFocusedElementIndex = getLoopedNextFocusIndexIfLastElement(
-      newFocusedElementIndex,
-      interactiveElementList
-    );
+    const nextIndex = shiftKey
+      ? focusedElementIndex - 1
+      : focusedElementIndex + 1;
+    const newFocusedElementIndex =
+      nextIndex < 0
+        ? interactiveElementList.length - 1
+        : nextIndex % interactiveElementList.length;
     return focusElement(
       newFocusAttemptCount,
       newFocusedElementIndex,
@@ -777,112 +774,12 @@ export const focusElement = (
       default:
         element.focus();
     }
-    return { newFocusAttemptCount, newFocusedElementIndex };
-  }
-};
-
-/**
- * Gets the index of the currently focused element. Used for focus trapping.
- * @param el - host element of the component
- * @param interactiveElementList - list of interactive elements
- */
-export const getFocusedElementIndex = (
-  el: HTMLElement,
-  interactiveElementList: HTMLElement[]
-) => {
-  for (let i = 0; i < interactiveElementList.length; i++) {
-    if (
-      (interactiveElementList[i] as HTMLElement) ===
-      (el.shadowRoot?.activeElement || document.activeElement)
-    ) {
-      return i;
-    }
-  }
-  return null;
-};
-
-/**
- * Gets the next focusable element index based on whether the shift key is pressed. Used for focus trapping.
- * @param focusedElementIndex - current focused element index
- * @param shiftKey - whether the shift key is pressed
- */
-export const getFocusIndexBasedOnShiftKey = (
-  focusedElementIndex: number,
-  shiftKey: boolean
-) => (shiftKey ? (focusedElementIndex -= 1) : (focusedElementIndex += 1));
-
-/**
- * Gets the next focusable element index, looping back to the start or end if necessary. Used for focus trapping.
- * @param focusedElementIndex - current focused element index
- * @param interactiveElementList - list of interactive elements
- */
-export const getLoopedNextFocusIndexIfLastElement = (
-  focusedElementIndex: number,
-  interactiveElementList: HTMLElement[]
-): number => {
-  if (focusedElementIndex > interactiveElementList.length - 1) {
-    return 0;
-  } else if (focusedElementIndex < 0) {
-    return interactiveElementList.length - 1;
-  }
-  return focusedElementIndex;
-};
-
-/**
- * Handles tab key press for focus trapping.
- * @param el - host element of the component
- * @param focusAttemptCount - number of focus attempts that have been made
- * @param focusedElementIndex - current focused element index
- * @param interactiveElementList - list of interactive elements
- * @param shiftKey - whether the shift key is pressed
- */
-export function handleFocusTrapTabKeyPress(
-  el: HTMLElement,
-  focusAttemptCount: number,
-  focusedElementIndex: number,
-  interactiveElementList: HTMLElement[],
-  shiftKey: boolean
-): {
-  newFocusAttemptCount: number;
-  newFocusedElementIndex: number;
-  preventDefault: boolean;
-} {
-  let newFocusAttemptCount = focusAttemptCount;
-
-  let newFocusedElementIndex =
-    getFocusedElementIndex(el, interactiveElementList) || focusedElementIndex;
-
-  if (interactiveElementList[focusedElementIndex]?.tagName === IC_SEARCH_BAR) {
     return {
       newFocusAttemptCount,
-      newFocusedElementIndex,
-      preventDefault: false,
+      newFocusedElementIndex: focusedElementIndex,
     };
   }
-
-  newFocusedElementIndex = getFocusIndexBasedOnShiftKey(
-    newFocusedElementIndex,
-    shiftKey
-  );
-  newFocusedElementIndex = getLoopedNextFocusIndexIfLastElement(
-    newFocusedElementIndex,
-    interactiveElementList
-  );
-
-  newFocusAttemptCount = 0;
-  const focusElementResult = focusElement(
-    newFocusAttemptCount,
-    newFocusedElementIndex,
-    interactiveElementList,
-    shiftKey
-  );
-  if (focusElementResult) {
-    newFocusedElementIndex = focusElementResult.newFocusedElementIndex;
-    newFocusAttemptCount = focusElementResult.newFocusAttemptCount;
-  }
-
-  return { newFocusAttemptCount, newFocusedElementIndex, preventDefault: true };
-}
+};
 
 /**
  * Sets up listener and mutation observer to refresh interactive elements on slot changes. Used for focus trapping.


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Changed how focus trapping is handled, instead of manually controlling what is focused within a focus trapped component, use native DOM focus instead and trap focus using focus guard elements at the beginning and end.

## Related issue
#4246
#4247 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.