### PR TITLE
Emit event when tooltip shown

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -23936,7 +23936,22 @@
           ]
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "event": "icTooltipShow",
+          "detail": "void",
+          "bubbles": true,
+          "complexType": {
+            "original": "void",
+            "resolved": "void",
+            "references": {}
+          },
+          "cancelable": true,
+          "composed": true,
+          "docs": "Emitted when the tooltip becomes visible.",
+          "docsTags": []
+        }
+      ],
       "listeners": [],
       "styles": [
         {

--- a/packages/react/src/stories/ic-tooltip.stories.jsx
+++ b/packages/react/src/stories/ic-tooltip.stories.jsx
@@ -394,6 +394,37 @@ export const PositioningStrategy = {
   name: "Positioning strategy",
 };
 
+export const IcShowTooltipEvent = {
+  render: () => (
+    <>
+      <IcTooltip
+        label="This is a description of the button"
+        id="ic-tooltip-test-button-event"
+        onIcTooltipShow={(ev) => console.log("tooltip shown")}
+      >
+        <button
+          aria-describedby="ic-tooltip-test-button-event"
+        >
+          Default
+        </button>
+      </IcTooltip>
+      <IcTooltip
+        label="This is a description of the button"
+        id="ic-tooltip-test-button-event-1"
+        onIcTooltipShow={() => console.log("tooltip shown")}
+      >
+        <IcButton
+          aria-describedby="ic-tooltip-test-button-event-1"
+        >
+          Default
+        </IcButton>
+      </IcTooltip>
+    </>
+  ),
+
+  name: "IcShowTooltip event",
+};
+
 export const Playground = {
   render: (args) => (
     <div

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -3027,6 +3027,10 @@ export interface IcToggleButtonGroupCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLIcToggleButtonGroupElement;
 }
+export interface IcTooltipCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLIcTooltipElement;
+}
 export interface IcTopNavigationCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLIcTopNavigationElement;
@@ -3837,7 +3841,18 @@ declare global {
         prototype: HTMLIcToggleButtonGroupElement;
         new (): HTMLIcToggleButtonGroupElement;
     };
+    interface HTMLIcTooltipElementEventMap {
+        "icTooltipShow": void;
+    }
     interface HTMLIcTooltipElement extends Components.IcTooltip, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLIcTooltipElementEventMap>(type: K, listener: (this: HTMLIcTooltipElement, ev: IcTooltipCustomEvent<HTMLIcTooltipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLIcTooltipElementEventMap>(type: K, listener: (this: HTMLIcTooltipElement, ev: IcTooltipCustomEvent<HTMLIcTooltipElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLIcTooltipElement: {
         prototype: HTMLIcTooltipElement;
@@ -6807,6 +6822,10 @@ declare namespace LocalJSX {
           * The number of lines to display before truncating the text.
          */
         "maxLines"?: number;
+        /**
+          * Emitted when the tooltip becomes visible.
+         */
+        "onIcTooltipShow"?: (event: IcTooltipCustomEvent<void>) => void;
         /**
           * The position of the tooltip in relation to the parent element.
          */

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.stories.js
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.stories.js
@@ -301,6 +301,38 @@ export const PositioningStrategy = {
   name: "Positioning strategy",
 };
 
+export const IcShowTooltipEvent = {
+  render: () =>
+    html`<script>
+        document
+          .querySelector("#ic-tooltip-event-1")
+          .addEventListener("icTooltipShow", tooltipShowHandler);
+        document
+          .querySelector("#ic-tooltip-event-2")
+          .addEventListener("icTooltipShow", tooltipShowHandler);
+        function tooltipShowHandler() {
+          console.log("tooltip shown");
+        }
+      </script>
+      <ic-tooltip
+        label="This is a description of the button"
+        id="ic-tooltip-event-1"
+        ><button aria-describedby="ic-tooltip-event-1">
+          Default
+        </button></ic-tooltip
+      >
+      <ic-tooltip
+        label="This is a description of the button"
+        id="ic-tooltip-event-2"
+        ><ic-button aria-describedby="ic-tooltip-event-2">
+          Default
+        </ic-button></ic-tooltip
+      > `,
+
+  name: "IcShowTooltip event",
+  height: "100px",
+};
+
 export const Playground = {
   render: (args) =>
     html`<div style="margin: 250px">

--- a/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
+++ b/packages/web-components/src/components/ic-tooltip/ic-tooltip.tsx
@@ -1,6 +1,8 @@
 import {
   Component,
   Element,
+  Event,
+  EventEmitter,
   Host,
   Prop,
   h,
@@ -106,6 +108,11 @@ export class Tooltip {
   }
 
   @State() popperProps: Partial<Options> = {};
+
+  /**
+   * Emitted when the tooltip becomes visible.
+   */
+  @Event() icTooltipShow: EventEmitter<void>;
 
   /**
    * @internal This method allows props to be added to the PopperJS createPopper instance outside of tooltip
@@ -223,6 +230,7 @@ export class Tooltip {
         ],
         ...this.popperProps,
       });
+      this.icTooltipShow.emit();
     } else {
       console.warn(`Tooltip can't display without prop 'label' set`);
     }

--- a/packages/web-components/src/components/ic-tooltip/readme.md
+++ b/packages/web-components/src/components/ic-tooltip/readme.md
@@ -19,6 +19,13 @@
 | `theme`              | `theme`             | Sets the tooltip to the dark or light theme colors. "inherit" will set the color based on the system settings or ic-theme component. | `"dark" \| "inherit" \| "light" \| undefined`                                                                                                                                     | `"inherit"` |
 
 
+## Events
+
+| Event           | Description                               | Type                |
+| --------------- | ----------------------------------------- | ------------------- |
+| `icTooltipShow` | Emitted when the tooltip becomes visible. | `CustomEvent<void>` |
+
+
 ## Methods
 
 ### `displayTooltip(show: boolean, persistTooltip?: boolean) => Promise<void>`

--- a/packages/web-components/src/components/ic-tooltip/test/basic/__snapshots__/ic-tooltip.spec.ts.snap
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/__snapshots__/ic-tooltip.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ic-tooltip component should render correctly when on a dialog 1`] = `
+exports[`ic-tooltip component should render correctly when in a drawer 1`] = `
 <ic-tooltip class="ic-tooltip ic-tooltip-in-container" label="tooltip">
   <template shadowrootmode="open">
     <div aria-hidden="false" class="ic-tooltip-container" data-show role="tooltip" style="position: absolute; left: 0; top: 0; margin: 0;">
@@ -14,7 +14,7 @@ exports[`ic-tooltip component should render correctly when on a dialog 1`] = `
 </ic-tooltip>
 `;
 
-exports[`ic-tooltip component should render correctly when in a drawer 1`] = `
+exports[`ic-tooltip component should render correctly when on a dialog 1`] = `
 <ic-tooltip class="ic-tooltip ic-tooltip-in-container" label="tooltip">
   <template shadowrootmode="open">
     <div aria-hidden="false" class="ic-tooltip-container" data-show role="tooltip" style="position: absolute; left: 0; top: 0; margin: 0;">

--- a/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
+++ b/packages/web-components/src/components/ic-tooltip/test/basic/ic-tooltip.spec.ts
@@ -316,4 +316,20 @@ describe("ic-tooltip component", () => {
 
     expect(page.rootInstance.updateTooltipEvents).toHaveBeenCalled();
   });
+
+  it("should emit icTooltipShow event when tooltip is shown", async () => {
+    const page = await newSpecPage({
+      components: [Tooltip],
+      html: `<ic-tooltip target="test-button" label="tooltip"><button id="test-button">Click</button></ic-tooltip>`,
+    });
+
+    const eventSpy = jest.fn();
+
+    page.root!.addEventListener("icTooltipShow", eventSpy);
+
+    await page.rootInstance.show(page.rootInstance.popperInstance);
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Adds a new `icTooltipShow` event which is emitted when a tooltip is made visible.

Added as have a requirement to run some logic when the tooltip is shown

## Related issue
N/A

## Checklist

### General 

- [x] Changes to docs package checked and committed.

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
