### PR TITLE
Exclude dependabot from commitlint check

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -37,6 +37,7 @@ jobs:
           echo "$COMMIT_MESSAGE" | npx commitlint
 
       - name: Validate changed files in commit scope
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: node .github/scripts/scope-check.js


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Update commitlint workflow to exclude dependabot from check - this is the most common reason we can't allow the automated PRs that dependabot raises e.g. https://github.com/mi6/ic-ui-kit/pull/4409

## Related issue
N/A