### PR TITLE
test(react): skip all tests that include AG Grid to fix failing CI pipeline

### DIFF
--- a/packages/react/src/component-tests/AgGridWrapper/AgGridWrapper.cy.tsx
+++ b/packages/react/src/component-tests/AgGridWrapper/AgGridWrapper.cy.tsx
@@ -18,7 +18,7 @@ describe("Visual regression and a11y tests", () => {
     cy.task("generateReport");
   });
 
-  it("should render", () => {
+  it.skip("should render", () => {
     mount(<AGGridLight />);
 
     cy.get("span.ag-header-expand-icon-collapsed").eq(1).click();
@@ -30,7 +30,7 @@ describe("Visual regression and a11y tests", () => {
     });
   });
 
-  it("should render dark", () => {
+  it.skip("should render dark", () => {
     mount(<AGGridDark />);
 
     cy.get("span.ag-header-expand-icon-collapsed").eq(1).click();

--- a/packages/react/src/component-tests/IcChip/IcChip.cy.tsx
+++ b/packages/react/src/component-tests/IcChip/IcChip.cy.tsx
@@ -208,7 +208,7 @@ describe("IcChip visual regression and a11y tests", () => {
     });
   });
 
-  it("should render as truncated in an AG Grid when there is not enough space", () => {
+  it.skip("should render as truncated in an AG Grid when there is not enough space", () => {
     mount(<InAGGrid />);
 
     cy.checkHydrated(CHIP_SELECTOR);

--- a/packages/react/src/component-tests/IcTypography/IcTypography.cy.tsx
+++ b/packages/react/src/component-tests/IcTypography/IcTypography.cy.tsx
@@ -200,7 +200,7 @@ describe("IcTypography visual regression and a11y tests", () => {
   });
 });
 
-it("should render as truncated in an AG Grid when there is not enough space", () => {
+it.skip("should render as truncated in an AG Grid when there is not enough space", () => {
   mount(<InAGGrid />);
 
   cy.checkHydrated(TYPOGRAPHY_SELECTOR);


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
A recent minor version update to the AG Grid dependency has caused a side effect of visual regression tests containing AG Grid to fail. Despite multiple attempts to regenerate the images,
these tests still fail. The agreed way forward is to skip all Cypress visual regression tests containing AG Grid and investigate the issue further at another time

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
