### PR TITLE
4253 internal issue 3155   normalizecss is being injected at the root level of an app when using accordion

### DIFF
--- a/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
+++ b/packages/web-components/src/components/ic-radio-option/ic-radio-option.css
@@ -1,5 +1,3 @@
-@import "../../global/normalize.css";
-
 :host {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Removed normalise.css import from ic-radio-options.css

## Related issue
#4253 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.