### PR TITLE
Add build step to performance tests

### DIFF
--- a/.github/workflows/run-lhci-performance-tests-manual.yml
+++ b/.github/workflows/run-lhci-performance-tests-manual.yml
@@ -55,6 +55,7 @@ jobs:
         id: lhci_performance_tests
         run: |
             npm run build
+            npm run build:performance-tests
             node packages/react/scripts/lhci-run-per-route.js --batch ${{ matrix.batch }} --total-batches 4
 
       - name: Upload lighthouse performance reports

--- a/.github/workflows/run-lhci-performance-tests-scheduled.yml
+++ b/.github/workflows/run-lhci-performance-tests-scheduled.yml
@@ -37,6 +37,7 @@ jobs:
         id: lhci_performance_tests
         run: |
             npm run build
+            npm run build:performance-tests
             node packages/react/scripts/lhci-run-per-route.js --batch ${{ matrix.batch }} --total-batches 4
 
       - name: Upload lighthouse performance reports

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "test-cypress:ci:all": "npm run build:all && npm run test-cypress:headless && npm run test-cypress:canary:headless",
     "test-cypress:ci:canary": "npm run build:all && npm run test-cypress:canary:headless",
     "test-cypress:headless": "lerna run cypress:ci --scope=@ukic/react --stream",
-    "test-lhci-perf:ci": "npm run build && npm run test-lhci-perf:headless",
+    "build:performance-tests": "lerna run build:perf --scope=@ukic/react --stream",
+    "test-lhci-perf:ci": "npm run build && npm run build:performance-tests && npm run test-lhci-perf:headless",
     "test-lhci-perf:headless": "lerna run test:performance-lhci --scope=@ukic/react --stream"
   },
   "config": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,6 +41,7 @@
     "rollup": "rollup -c",
     "storybook": "storybook dev -p 6007",
     "test:performance-lhci": "npm run perf:lhci",
+    "build:perf": "vite build --config vite.config.perf.ts",
     "tsc": "tsc -p ."
   },
   "dependencies": {

--- a/packages/react/vite.config.perf.ts
+++ b/packages/react/vite.config.perf.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [],
+  build: {
+    outDir: resolve(__dirname, 'dist-perf'),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: resolve(__dirname, 'src/performance-tests/index.tsx'),
+      output: {
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name][extname]'
+      }
+    }
+  },
+  root: '.',
+  publicDir: false,
+})


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
The [action for the scheduled performance tests](https://github.com/mi6/ic-ui-kit/actions/runs/25839464857) has failed due to not being able to find the url. This is because it couldn't find the `dist-perf` folder to serve. I tried deleting that folder locally and I got the same error.

I've added in a vite config file that creates the dist-perf, and the correct build steps to the package.json and workflows so it should work now. It works when I run it locally.

## Related issue
https://github.com/mi6/ic-ui-kit/issues/4204