### PR TITLE
4496 small text field in data row value slot alignment fix

### DIFF
--- a/packages/web-components/src/components/ic-data-row/ic-data-row.css
+++ b/packages/web-components/src/components/ic-data-row/ic-data-row.css
@@ -38,7 +38,7 @@ slot[name="value"]::slotted(ic-text-field[readonly][hide-label]) {
   margin-top: calc(var(--ic-space-xs) * -1);
 }
 
-slot[name="value"]::slotted(ic-text-field[small][readonly][hide-label]) {
+slot[name="value"]::slotted(ic-text-field[size="small"][readonly][hide-label]) {
   margin-top: calc(var(--ic-space-xxs) * -1);
 }
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Changed from checking for the presence of a non-existing small property within an `IcTextField`, to checking the `size` property for a value of `"small"` to prevent misalignment within an `IcDataRow`.

## Related issue
Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.
#4496