### PR TITLE
4501 small data list no heading margin fix

### DIFF
--- a/packages/web-components/src/components/ic-data-list/ic-data-list.css
+++ b/packages/web-components/src/components/ic-data-list/ic-data-list.css
@@ -40,6 +40,10 @@
   margin-bottom: var(--ic-space-xs);
 }
 
+:host(.ic-data-list-small) .divider.divider-no-heading {
+  margin-top: 0;
+}
+
 @media (forced-colors: active) {
   .divider {
     background-color: canvastext;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Prevented unnecessary margin being applied to `IcDataList` components which are small and have no heading.

## Related issue
Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.
#4501