### PR TITLE
Fix LHCI report deploy race

### DIFF
--- a/.github/workflows/run-lhci-performance-tests-manual.yml
+++ b/.github/workflows/run-lhci-performance-tests-manual.yml
@@ -64,3 +64,5 @@ jobs:
         with:
           folder: ./packages/react/lhci-reports
           target-folder: ./branches/${{ steps.extract_branch.outputs.branch }}/lhci-reports/batch-${{ matrix.batch }}
+          force: false
+          attempt-limit: 10

--- a/.github/workflows/run-lhci-performance-tests-scheduled.yml
+++ b/.github/workflows/run-lhci-performance-tests-scheduled.yml
@@ -46,3 +46,5 @@ jobs:
         with:
           folder: ./packages/react/lhci-reports
           target-folder: ./branches/develop/lhci-reports/batch-${{ matrix.batch }}
+          force: false
+          attempt-limit: 10


### PR DESCRIPTION
## Summary
- configure the LHCI report deploy action to rebase instead of force-pushing
- increase deploy rebase attempts for the four performance-test batches
- apply the same settings to manual and scheduled performance workflows

## Why
The performance-test matrix uploads each batch's Lighthouse reports to the same Pages branch. When multiple batch jobs deploy at the same time, force-push deployments can race and fail even though the LHCI tests themselves passed. Allowing rebases with more attempts makes the deploy step tolerate concurrent batch updates.

Fixes #4506.

## Checks
- git diff --check
- ruby -e 'require yaml; ARGV.each { |f| YAML.load_file(f); puts ok