### PR TITLE
[#4267] emit time value updates only when milliseconds are completed

### DIFF
--- a/packages/canary-web-components/src/components/ic-time-input/ic-time-input.tsx
+++ b/packages/canary-web-components/src/components/ic-time-input/ic-time-input.tsx
@@ -633,19 +633,35 @@ export class TimeInput {
     const inputEvent = event as InputEvent;
     const input = event.target as HTMLInputElement;
     if (input === this.millisecondInputEl && this.isSSSFormat()) {
-      this.setInputValue(input);
-      this.setPreventInput(input, false);
       this.setFitToValueStyling(input);
-      if (input.value.length === 3) {
-        this.moveToNextInput(input);
-        this.setPreventInput(input, true);
-      } else {
-        this.setPreventInput(input, false);
+
+      switch (input.value.length) {
+        case 0: {
+          this.setInputValue(input, true);
+          this.setValidationMessage();
+          break;
+        }
+
+        case 1:
+        case 2: {
+          this.setPreventInput(input, false);
+          break;
+        }
+
+        case 3: {
+          this.setInputValue(input);
+          this.moveToNextInput(input);
+          this.setPreventInput(input, true);
+          break;
+        }
+
+        default: {
+          console.warn(
+            `Unexpected millisecond input length: ${input.value.length}`
+          );
+        }
       }
-      if (input.value.length === 0) {
-        this.setInputValue(input, true);
-        this.setValidationMessage();
-      }
+
       this.notifyScreenReader(input);
     } else if (input !== this.hourInputEl) {
       if (

--- a/packages/canary-web-components/src/components/ic-time-input/test/basic/ic-time-input.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-time-input/test/basic/ic-time-input.spec.tsx
@@ -169,6 +169,27 @@ describe("ic-time-input component", () => {
     expect(spySetPreventInput).toHaveBeenCalled();
   });
 
+  it("should not call setInputValue for millisecond input until all 3 digits are typed", async () => {
+    const { componentInstance, millisecondInput } = await createTimeInputEnv(
+      MILLISECOND_FORMAT
+    );
+    const spySetInputValue = jest.spyOn(componentInstance, "setInputValue");
+
+    millisecondInput.value = "1";
+    componentInstance.handleInput(handleEvent(millisecondInput));
+    expect(spySetInputValue).not.toHaveBeenCalled();
+
+    spySetInputValue.mockClear();
+    millisecondInput.value = "12";
+    componentInstance.handleInput(handleEvent(millisecondInput));
+    expect(spySetInputValue).not.toHaveBeenCalled();
+
+    spySetInputValue.mockClear();
+    millisecondInput.value = "123";
+    componentInstance.handleInput(handleEvent(millisecondInput));
+    expect(spySetInputValue).toHaveBeenCalledWith(millisecondInput);
+  });
+
   it("should call setInputValue and moveToNextInput when formatting is true and event is ArrowRight key", async () => {
     const { componentInstance, hourInput } = await createTimeInputEnv();
 


### PR DESCRIPTION
## Summary of the changes

Updates the input handling of `ic-time-input` so that values are only emitted when the milliseconds has been fully filled in. Refactors the code block slightly to reduce repetition. Have verified the fix in Storybook and added a test - there are a few other bits of behaviour that feel a bit unintuitive, I may raise issues about them if I find time.

## Related issue

Fixes #4267

## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [ ] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] All prop combinations work without issue. 
- [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [ ] Controlled and uncontrolled input components tested.
- [ ] Props/slots can be updated after initial render.