### PR TITLE
[#4456] Warn when using 'backBreadcrumbOnly' with only one item

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -2343,7 +2343,7 @@
           "mutable": false,
           "attr": "back-breadcrumb-only",
           "reflectToAttr": false,
-          "docs": "If `true`, display only a single breadcrumb for the parent page with a back icon.",
+          "docs": "If `true`, display only a single breadcrumb for the parent page with a back icon.\nRequires at least two `ic-breadcrumb` children, as the displayed breadcrumb\nshows the title of the parent (second-to-last) page.",
           "docsTags": [],
           "default": "false",
           "values": [

--- a/packages/web-components/src/components.d.ts
+++ b/packages/web-components/src/components.d.ts
@@ -337,7 +337,7 @@ export namespace Components {
     }
     interface IcBreadcrumbGroup {
         /**
-          * If `true`, display only a single breadcrumb for the parent page with a back icon.
+          * If `true`, display only a single breadcrumb for the parent page with a back icon. Requires at least two `ic-breadcrumb` children, as the displayed breadcrumb shows the title of the parent (second-to-last) page.
          */
         "backBreadcrumbOnly": boolean;
         /**
@@ -4235,7 +4235,7 @@ declare namespace LocalJSX {
     }
     interface IcBreadcrumbGroup {
         /**
-          * If `true`, display only a single breadcrumb for the parent page with a back icon.
+          * If `true`, display only a single breadcrumb for the parent page with a back icon. Requires at least two `ic-breadcrumb` children, as the displayed breadcrumb shows the title of the parent (second-to-last) page.
          */
         "backBreadcrumbOnly"?: boolean;
         /**

--- a/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
+++ b/packages/web-components/src/components/ic-breadcrumb-group/ic-breadcrumb-group.tsx
@@ -29,6 +29,8 @@ export class BreadcrumbGroup {
 
   /**
    * If `true`, display only a single breadcrumb for the parent page with a back icon.
+   * Requires at least two `ic-breadcrumb` children, as the displayed breadcrumb
+   * shows the title of the parent (second-to-last) page.
    */
   @Prop() backBreadcrumbOnly = false;
   @Watch("backBreadcrumbOnly")
@@ -120,13 +122,10 @@ export class BreadcrumbGroup {
     }
   };
 
-  private setBackBreadcrumbAttr = () => {
-    if (this.lastParentBreadcrumb) {
-      this.lastParentBreadcrumb.classList.add("show");
-      this.lastParentBreadcrumb.setAttribute(this.SHOW_BACK_ICON, "true");
-    }
-  };
-
+  /**
+   * Returns the second-to-last breadcrumb (the "parent" page), or `null`
+   * if fewer than two breadcrumbs are present.
+   */
   private getLastParentBreadcrumb = (): HTMLIcBreadcrumbElement | null => {
     const allBreadcrumbs = this.el.querySelectorAll<HTMLIcBreadcrumbElement>(
       this.IC_BREADCRUMB
@@ -230,11 +229,21 @@ export class BreadcrumbGroup {
 
   private setLastParentCollapsedBackBreadcrumb = () => {
     this.lastParentBreadcrumb = this.getLastParentBreadcrumb();
-    this.setBackBreadcrumbAttr();
-    if (this.lastParentBreadcrumb) {
-      this.lastParentBreadcrumb.classList.remove("hide");
-      this.lastParentBreadcrumb.classList.add("show");
+
+    if (this.lastParentBreadcrumb === null) {
+      console.warn(
+        "ic-breadcrumb-group: backBreadcrumbOnly requires at least two " +
+          "ic-breadcrumb children. The back breadcrumb displays the title " +
+          "of the parent page, so a minimum of two breadcrumbs is needed."
+      );
+
+      return;
     }
+
+    this.lastParentBreadcrumb.classList.add("show");
+    this.lastParentBreadcrumb.classList.remove("hide");
+
+    this.lastParentBreadcrumb.setAttribute(this.SHOW_BACK_ICON, "true");
   };
 
   private revertLastParentCollapsedBreadcrumb = () => {

--- a/packages/web-components/src/components/ic-breadcrumb-group/readme.md
+++ b/packages/web-components/src/components/ic-breadcrumb-group/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property             | Attribute              | Description                                                                                                                             | Type                             | Default     |
-| -------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------- |
-| `backBreadcrumbOnly` | `back-breadcrumb-only` | If `true`, display only a single breadcrumb for the parent page with a back icon.                                                       | `boolean`                        | `false`     |
-| `collapsed`          | `collapsed`            | If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.                                                     | `boolean`                        | `false`     |
-| `monochrome`         | `monochrome`           | If `true`, the breadcrumb group will display as black in the light theme, and white in the dark theme.                                  | `boolean`                        | `false`     |
-| `theme`              | `theme`                | Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component. | `"dark" \| "inherit" \| "light"` | `"inherit"` |
+| Property             | Attribute              | Description                                                                                                                                                                                                        | Type                             | Default     |
+| -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | ----------- |
+| `backBreadcrumbOnly` | `back-breadcrumb-only` | If `true`, display only a single breadcrumb for the parent page with a back icon. Requires at least two `ic-breadcrumb` children, as the displayed breadcrumb shows the title of the parent (second-to-last) page. | `boolean`                        | `false`     |
+| `collapsed`          | `collapsed`            | If `true`, all breadcrumbs between the first and last breadcrumb will be collapsed.                                                                                                                                | `boolean`                        | `false`     |
+| `monochrome`         | `monochrome`           | If `true`, the breadcrumb group will display as black in the light theme, and white in the dark theme.                                                                                                             | `boolean`                        | `false`     |
+| `theme`              | `theme`                | Sets the theme color to the dark or light theme color. "inherit" will set the color based on the system settings or ic-theme component.                                                                            | `"dark" \| "inherit" \| "light"` | `"inherit"` |
 
 
 ## Dependencies

--- a/packages/web-components/src/components/ic-breadcrumb-group/test/basic/ic-breadcrumb-group.spec.ts
+++ b/packages/web-components/src/components/ic-breadcrumb-group/test/basic/ic-breadcrumb-group.spec.ts
@@ -260,6 +260,23 @@ describe("ic-breadcrumb-group", () => {
     expect(page.rootInstance.getLastParentBreadcrumb()).toBeNull();
   });
 
+  it("should warn when backBreadcrumbOnly is used with fewer than two breadcrumbs", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(jest.fn());
+
+    await newSpecPage({
+      components: [BreadcrumbGroup, Breadcrumb],
+      html: `<ic-breadcrumb-group back-breadcrumb-only="true">
+          <ic-breadcrumb current="true" page-title="Breadcrumb 1" href="/breadcrumb-1"></ic-breadcrumb>
+      </ic-breadcrumb-group>`,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("backBreadcrumbOnly requires at least two")
+    );
+
+    warnSpy.mockRestore();
+  });
+
   //this test has to go last as it changes the device size
   it("should render collapse on already small devices", async () => {
     const myfunc = jest.fn().mockReturnValue(DEVICE_SIZES.S);


### PR DESCRIPTION
## Summary of the changes

Adds a `console.warn()` when `setLastParentCollapsedBackBreadcrumb` is called and no parent can be found. Improves comments within the code to make this behaviour clearer too. Also slightly refactors the function to make the code a little cleaner.

## Related issue

#4456

## Checklist

### General 

- [ ] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [ ] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [ ] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] All prop combinations work without issue. 
- [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [ ] Controlled and uncontrolled input components tested.
- [ ] Props/slots can be updated after initial render.