### PR TITLE
4565 clear inherited aria-label on ic-navigation-button when attribute is removed

### DIFF
--- a/packages/web-components/src/components/ic-navigation-button/ic-navigation-button.tsx
+++ b/packages/web-components/src/components/ic-navigation-button/ic-navigation-button.tsx
@@ -161,12 +161,14 @@ export class NavigationButton {
   private hostMutationCallback = (mutationList: MutationRecord[]): void => {
     let forceComponentUpdate = false;
     mutationList.forEach(({ attributeName }) => {
-      if (attributeName) {
+      if (attributeName && MUTABLE_ATTRIBUTES.includes(attributeName)) {
         const attribute = this.el.getAttribute(attributeName);
-        if (attribute && MUTABLE_ATTRIBUTES.includes(attributeName)) {
+        if (attribute) {
           this.inheritedAttributes[attributeName] = attribute;
-          forceComponentUpdate = true;
+        } else {
+          delete this.inheritedAttributes[attributeName];
         }
+        forceComponentUpdate = true;
       }
     });
     if (forceComponentUpdate) {


### PR DESCRIPTION
## Summary of the changes
`ic-navigation-button`'s `hostMutationCallback` only updated its cached `inheritedAttributes` when a mutated attribute's new value was truthy. This meant that when a child `ic-badge` cleared its parent's `aria-label`, the stale value was never removed from `inheritedAttributes`, causing the button to permanently display an outdated accessible name/tooltip.

This PR updates the callback to also delete the corresponding key from `inheritedAttributes` when an attribute is removed/cleared, and ensures a re-render is triggered in both cases (set and cleared), so the component correctly falls back to its own `label` prop once the override is gone.

## Related issue
#4565 