### PR TITLE
fix(web-components): updated IcAccordion to handle prefers-reduced-motion: reduce

### DIFF
--- a/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
+++ b/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
@@ -131,15 +131,9 @@ export class Accordion {
     property: string,
     delay: string
   ) => {
-    if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      el.style.transitionDuration = `${duration}ms`;
-      el.style.transitionProperty = property;
-      el.style.transitionDelay = delay;
-    } else {
-      el.style.transitionDuration = "0ms";
-      el.style.transitionProperty = "none";
-      el.style.transitionDelay = "0ms";
-    }
+    el.style.transitionDuration = `${duration}ms`;
+    el.style.transitionProperty = property;
+    el.style.transitionTimingFunction = delay;
   };
 
   private setExpandedContentStyle = (
@@ -165,46 +159,86 @@ export class Accordion {
   };
 
   private animateExpandedContent = () => {
-    if (this.expandedContentEl) {
-      const expandedContentEl = this.expandedContentEl;
-      const elementHeight = expandedContentEl.scrollHeight;
-      if (elementHeight > 0 && this.expanded) {
-        expandedContentEl.style.setProperty(
-          this.CONTENT_VISIBILITY_PROPERTY,
-          "visible"
-        );
-        expandedContentEl.style.height = `${elementHeight}px`;
-        this.setAccordionAnimation(
-          expandedContentEl,
-          "300",
-          "height",
-          "ease-out"
-        );
+    const expandedContentEl = this.expandedContentEl;
+    if (!expandedContentEl) return;
 
-        expandedContentEl.addEventListener(
-          "transitionend",
-          (e: TransitionEvent) => {
-            this.setExpandedContentStyle(e, expandedContentEl);
-          }
-        );
-      } else if (!this.expanded) {
-        const expandedContentEl = this.expandedContentEl;
-        expandedContentEl.style.height = `${expandedContentEl.scrollHeight}px`;
-        if (expandedContentEl.scrollHeight > 0 && !this.expanded) {
-          expandedContentEl.style.height = "0";
-          this.setAccordionAnimation(
-            expandedContentEl,
-            "300",
-            "height",
-            "ease-in"
-          );
-          expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
-        }
-        expandedContentEl.addEventListener("transitionend", (e) => {
-          this.hideExpandedContent(e, expandedContentEl);
-        });
-      }
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    if (this.expanded) {
+      this.expandContent(expandedContentEl, prefersReducedMotion);
+      return;
     }
+
+    this.collapseContent(expandedContentEl, prefersReducedMotion);
+  };
+
+  private expandContent = (
+    expandedContentEl: HTMLDivElement,
+    prefersReducedMotion: boolean
+  ) => {
+    const elementHeight = expandedContentEl.scrollHeight;
+    if (elementHeight <= 0) return;
+
+    expandedContentEl.style.setProperty(
+      this.CONTENT_VISIBILITY_PROPERTY,
+      "visible"
+    );
+
+    if (prefersReducedMotion) {
+      expandedContentEl.classList.add(EXPANDED_CONTENT_OPENED_CLASS);
+      expandedContentEl.style.height = "auto";
+      return;
+    }
+
+    expandedContentEl.style.height = `${elementHeight}px`;
+
+    this.setAccordionAnimation(expandedContentEl, "300", "height", "ease-out");
+
+    expandedContentEl.addEventListener(
+      "transitionend",
+      (e: TransitionEvent) => {
+        this.setExpandedContentStyle(e, expandedContentEl);
+      },
+      { once: true }
+    );
+  };
+
+  private collapseContent = (
+    expandedContentEl: HTMLDivElement,
+    prefersReducedMotion: boolean
+  ) => {
+    const elementHeight = expandedContentEl.scrollHeight;
+
+    if (elementHeight <= 0) return;
+
+    // Set the content panel as pixels from "auto" so it can be animated
+    expandedContentEl.style.height = `${elementHeight}px`;
+
+    if (prefersReducedMotion) {
+      expandedContentEl.style.height = "0";
+      expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
+      expandedContentEl.style.setProperty(
+        this.CONTENT_VISIBILITY_PROPERTY,
+        "hidden"
+      );
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      expandedContentEl.style.height = "0";
+    });
+
+    this.setAccordionAnimation(expandedContentEl, "300", "height", "ease-in");
+    expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
+    expandedContentEl.addEventListener(
+      "transitionend",
+      (e) => {
+        this.hideExpandedContent(e, expandedContentEl);
+      },
+      { once: true }
+    );
   };
 
   render() {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
- Updated IcAccordion content panel to set overflow:visible when opened when prefers-reduced-motion: reduce
- 
## Related issue
#4585 

## Checklist

### General 

- [x] All acceptance criteria reviewed and met. 

### Testing

- [ ] Relevant unit tests and visual regression tests added. 
- [ ] Visual testing against Figma component specification completed. 
- [ ] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [ ] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [ ] Accessibility Insights FastPass performed.
- [ ] A11y unit test added and yields no issues.
- [ ] A11y plug-in on Storybook yields no issues. 
- [ ] Manual screen reader testing performed using NVDA and VoiceOver. 
- [ ] Manual keyboard testing for keyboard controls and logical focus order. 
- [ ] Correct roles used and ARIA attributes used correctly where required. 
- [ ] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [ ] Page can be zoomed to 400% with no loss of content. 
- [ ] Screen magnifier used with no issues. 
- [ ] Text resized to 200% with no loss of content.
- [ ] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [ ] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [ ] Windows High Contrast mode tested with no loss of content.
- [ ] System light and dark mode tested with no loss of content.
- [ ] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [ ] Min/max content examples tested with no loss of content or overflow. 
- [ ] All prop combinations work without issue. 
- [ ] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [ ] Controlled and uncontrolled input components tested.
- [ ] Props/slots can be updated after initial render.