### PR TITLE
fix(web-components): updated IcAccordion to handle prefers-reduced-motion: reduce

### DIFF
--- a/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
+++ b/packages/web-components/src/components/ic-accordion/ic-accordion.tsx
@@ -131,15 +131,9 @@ export class Accordion {
     property: string,
     delay: string
   ) => {
-    if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      el.style.transitionDuration = `${duration}ms`;
-      el.style.transitionProperty = property;
-      el.style.transitionDelay = delay;
-    } else {
-      el.style.transitionDuration = "0ms";
-      el.style.transitionProperty = "none";
-      el.style.transitionDelay = "0ms";
-    }
+    el.style.transitionDuration = `${duration}ms`;
+    el.style.transitionProperty = property;
+    el.style.transitionTimingFunction = delay;
   };
 
   private setExpandedContentStyle = (
@@ -165,46 +159,86 @@ export class Accordion {
   };
 
   private animateExpandedContent = () => {
-    if (this.expandedContentEl) {
-      const expandedContentEl = this.expandedContentEl;
-      const elementHeight = expandedContentEl.scrollHeight;
-      if (elementHeight > 0 && this.expanded) {
-        expandedContentEl.style.setProperty(
-          this.CONTENT_VISIBILITY_PROPERTY,
-          "visible"
-        );
-        expandedContentEl.style.height = `${elementHeight}px`;
-        this.setAccordionAnimation(
-          expandedContentEl,
-          "300",
-          "height",
-          "ease-out"
-        );
+    const expandedContentEl = this.expandedContentEl;
+    if (!expandedContentEl) return;
 
-        expandedContentEl.addEventListener(
-          "transitionend",
-          (e: TransitionEvent) => {
-            this.setExpandedContentStyle(e, expandedContentEl);
-          }
-        );
-      } else if (!this.expanded) {
-        const expandedContentEl = this.expandedContentEl;
-        expandedContentEl.style.height = `${expandedContentEl.scrollHeight}px`;
-        if (expandedContentEl.scrollHeight > 0 && !this.expanded) {
-          expandedContentEl.style.height = "0";
-          this.setAccordionAnimation(
-            expandedContentEl,
-            "300",
-            "height",
-            "ease-in"
-          );
-          expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
-        }
-        expandedContentEl.addEventListener("transitionend", (e) => {
-          this.hideExpandedContent(e, expandedContentEl);
-        });
-      }
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    if (this.expanded) {
+      this.expandContent(expandedContentEl, prefersReducedMotion);
+      return;
     }
+
+    this.collapseContent(expandedContentEl, prefersReducedMotion);
+  };
+
+  private expandContent = (
+    expandedContentEl: HTMLDivElement,
+    prefersReducedMotion: boolean
+  ) => {
+    const elementHeight = expandedContentEl.scrollHeight;
+    if (elementHeight <= 0) return;
+
+    expandedContentEl.style.setProperty(
+      this.CONTENT_VISIBILITY_PROPERTY,
+      "visible"
+    );
+
+    if (prefersReducedMotion) {
+      expandedContentEl.classList.add(EXPANDED_CONTENT_OPENED_CLASS);
+      expandedContentEl.style.height = "auto";
+      return;
+    }
+
+    expandedContentEl.style.height = `${elementHeight}px`;
+
+    this.setAccordionAnimation(expandedContentEl, "300", "height", "ease-out");
+
+    expandedContentEl.addEventListener(
+      "transitionend",
+      (e: TransitionEvent) => {
+        this.setExpandedContentStyle(e, expandedContentEl);
+      },
+      { once: true }
+    );
+  };
+
+  private collapseContent = (
+    expandedContentEl: HTMLDivElement,
+    prefersReducedMotion: boolean
+  ) => {
+    const elementHeight = expandedContentEl.scrollHeight;
+
+    if (elementHeight <= 0) return;
+
+    // Set the content panel as pixels from "auto" so it can be animated
+    expandedContentEl.style.height = `${elementHeight}px`;
+
+    if (prefersReducedMotion) {
+      expandedContentEl.style.height = "0";
+      expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
+      expandedContentEl.style.setProperty(
+        this.CONTENT_VISIBILITY_PROPERTY,
+        "hidden"
+      );
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      expandedContentEl.style.height = "0";
+    });
+
+    this.setAccordionAnimation(expandedContentEl, "300", "height", "ease-in");
+    expandedContentEl.classList.remove(EXPANDED_CONTENT_OPENED_CLASS);
+    expandedContentEl.addEventListener(
+      "transitionend",
+      (e) => {
+        this.hideExpandedContent(e, expandedContentEl);
+      },
+      { once: true }
+    );
   };
 
   render() {

--- a/packages/web-components/src/components/ic-accordion/test/basic/ic-accordion.spec.ts
+++ b/packages/web-components/src/components/ic-accordion/test/basic/ic-accordion.spec.ts
@@ -195,7 +195,7 @@ describe("ic-accordion snapshots", () => {
       page.rootInstance.setAccordionAnimation(div, "300", "height", "ease-out");
       expect(div.style.transitionDuration).toBe("300ms");
       expect(div.style.transitionProperty).toBe("height");
-      expect(div.style.transitionDelay).toBe("ease-out");
+      expect(div.style.transitionTimingFunction).toBe("ease-out");
     });
 
     it("it should call setAccordionAnimation if scroll height > 0 and expanded = true", async () => {
@@ -454,6 +454,50 @@ describe("ic-accordion snapshots", () => {
       page.rootInstance.expandedContentEl.dispatchEvent(event);
 
       expect(hideExpandedContentSpy).toHaveBeenCalled();
+    });
+
+    it("should toggle '.expanded-content-opened' to ic-accordion content (i.e. '.expanded-content') when open/closed and prefers-reduced-motion: reduce", async () => {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: jest.fn().mockImplementation((query) => ({
+          matches: query === "(prefers-reduced-motion: reduce)",
+          media: query,
+          onchange: null,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        })),
+      });
+
+      const page = await newSpecPage({
+        components: [Accordion],
+        html: `
+        <ic-accordion heading="Accordion 1" >
+          <ic-typography variant="body">
+            This is an example of the main body text.
+          </ic-typography>
+        </ic-accordion>`,
+      });
+
+      await page.rootInstance.toggleExpanded();
+      await page.waitForChanges();
+
+      const expandedContent = page.root?.shadowRoot?.querySelector(
+        ".expanded-content"
+      ) as HTMLElement;
+
+      expect(
+        expandedContent.classList.contains("expanded-content-opened")
+      ).toBe(true);
+
+      await page.rootInstance.toggleExpanded();
+      await page.waitForChanges();
+
+      expect(
+        expandedContent.classList.contains("expanded-content-opened")
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Updated the `ic-accordion` content panel (`.expanded-content`) to append (`.expanded-content-opened`) when opened and prefers-reduced-motion is set to "reduce". This was not working previously as the functionality to append `.expanded-content-opened` relied on transitionend. When "prefers-reduced-motion: reduce" is set, transitions are not triggered meaning the content panel did not have `overflow: visible`. This caused an issue clicking ic-select within the accordion panel as ic-menu was being cut off. 

## Related issue
#4585 

## Checklist

### General 

- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 

### Accessibility 

- [x] Correct roles used and ARIA attributes used correctly where required. 

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on.  
