### PR TITLE
chore(root): add new audit exceptions

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -141,6 +141,13 @@
       }
     },
     {
+      "GHSA-5p4m-2wfm-xmqj": {
+        "active": true,
+        "notes": "transitive dependency 'js-yaml' which exists at root level and in some monorepo packages, no fix available yet.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
       "GHSA-6g55-p6wh-862q": {
         "active": true,
         "notes": "sourcemap vulnerability around file reads in 'PostCSS'.",
@@ -172,6 +179,48 @@
       "GHSA-jjmj-jmhj-qwj2": {
         "active": true,
         "notes": "XXS vulnerability in redirects using 'React Router'.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
+      "GHSA-7p8r-x3mc-p8w7": {
+        "active": true,
+        "notes": "Transitive dependency fast-uri, which needs to be fixed in peer dependencies.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
+      "GHSA-mwp4-54f8-5fhr": {
+        "active": true,
+        "notes": "Transitive dependency ip-address, which needs to be fixed in peer dependencies.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
+      "GHSA-4xrf-jv44-h6hh": {
+        "active": true,
+        "notes": "Transitive dependency ip-address, which needs to be fixed in peer dependencies.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
+      "GHSA-22jq-vg5j-6vgg": {
+        "active": true,
+        "notes": "Transitive dependency ip-address, which needs to be fixed in peer dependencies.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
+      "GHSA-fxqj-rqcc-2cmp": {
+        "active": true,
+        "notes": "sourcemap vulnerability around file reads in 'PostCSS'.",
+        "expiry": "27 August 2026"
+      }
+    },
+    {
+      "GHSA-2v37-7h3g-55p8": {
+        "active": true,
+        "notes": "Transitive dependency nanoid, which needs to be fixed in peer dependencies, overflow on infinite loop.",
         "expiry": "27 August 2026"
       }
     }

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@ukic/react",
       "version": "3.29.0",
       "license": "MIT",
+      "dependencies": {
+        "@ukic/web-components": "^3.29.0"
+      },
       "devDependencies": {
         "@ag-grid-community/styles": "^33.0.3",
         "@babel/core": "^7.23.2",
@@ -4655,6 +4658,16 @@
         "third-party-web": "latest"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
@@ -6063,6 +6076,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -6080,6 +6100,33 @@
       "integrity": "sha512-LLCK6qs+wfNgMSMkN8e+fe6ZCyyZLRlg7smNXUJOqqGTA/kakAihS73I8N8wtp5fRy3Op+Z9/Dp31bRe/RXaZg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@ukic/web-components": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-3.29.0.tgz",
+      "integrity": "sha512-x/Wutlz88MyhPpkbcxeCecPVNaRZDKBrozFPylNG9YuVvTFlv5uN62skxY7RsSb0tcqpAxE9JtWPzFF9M7xtCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.11.2",
+        "@stencil/core": "4.26.0",
+        "dompurify": "^3.2.6"
+      },
+      "peerDependencies": {
+        "@ukic/fonts": "^3.1.0"
+      }
+    },
+    "node_modules/@ukic/web-components/node_modules/@stencil/core": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.26.0.tgz",
+      "integrity": "sha512-+0Inu+dJ9/LgWSskcZwx7v17v4GILcwIYxNgD+OuK0U+D5z61WsxWw7yHkYG5OqGPBijsJMVssYRx/Tn+e7F9A==",
+      "license": "MIT",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -8758,6 +8805,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -9537,9 +9593,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -10724,9 +10780,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11311,18 +11367,6 @@
         }
       }
     },
-    "node_modules/lighthouse/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/lighthouse/node_modules/chrome-launcher": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
@@ -11364,38 +11408,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/lighthouse/node_modules/data-uri-to-buffer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
-      "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/lighthouse/node_modules/degenerator": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
-      "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
     "node_modules/lighthouse/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -11409,57 +11421,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lighthouse/node_modules/get-uri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
-      "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "basic-ftp": "^5.3.1",
-        "data-uri-to-buffer": "8.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/lighthouse/node_modules/http-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/lighthouse/node_modules/https-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/lighthouse/node_modules/lighthouse-logger": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
@@ -11469,18 +11430,6 @@
       "dependencies": {
         "debug": "^4.4.1",
         "marky": "^1.2.2"
-      }
-    },
-    "node_modules/lighthouse/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/lighthouse/node_modules/open": {
@@ -11499,81 +11448,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lighthouse/node_modules/pac-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "get-uri": "8.0.1",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "pac-resolver": "9.0.1",
-        "quickjs-wasi": "^2.2.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/lighthouse/node_modules/pac-resolver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
-      "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "degenerator": "7.0.1",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
-    "node_modules/lighthouse/node_modules/proxy-agent": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
-      "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "9.1.0",
-        "proxy-from-env": "^2.0.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/lighthouse/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core": {
@@ -11638,23 +11512,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/lighthouse/node_modules/socks-proxy-agent": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
-      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/lighthouse/node_modules/webdriver-bidi-protocol": {
@@ -12523,9 +12380,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -13513,26 +13370,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent-negotiate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "kerberos": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "kerberos": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -13641,15 +13478,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/quickjs-wasi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
-      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/packages/web-components/package-lock.json
+++ b/packages/web-components/package-lock.json
@@ -6146,9 +6146,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6545,9 +6545,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8710,9 +8710,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Added new entries to audit-ci.json in order to unblock pipelines and enable the release. 

This largely takes the audit additions made in https://github.com/mi6/ic-ui-kit/pull/4592/changes which @evenstensberg is contributing.