### PR TITLE
fix(web-components): preserve router link font weight

### DIFF
--- a/packages/react/src/component-tests/IcLink/IcLink.cy.tsx
+++ b/packages/react/src/component-tests/IcLink/IcLink.cy.tsx
@@ -4,7 +4,8 @@
 import React from "react";
 import { IcLink, IcTypography } from "../../components";
 import { mount } from "cypress/react";
-import { HAVE_ATTR } from "../utils/constants";
+import { MemoryRouter, NavLink } from "react-router-dom";
+import { HAVE_ATTR, HAVE_CSS } from "../utils/constants";
 import { setThresholdBasedOnEnv } from "../../../cypress/utils/helpers";
 
 const LINK_SELECTOR = "ic-link";
@@ -237,6 +238,30 @@ describe("IcLink end-to-end, visual regression and a11y tests", () => {
     cy.compareSnapshot({
       name: "/inline",
       testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD + 0.014),
+    });
+  });
+
+  it("should preserve bold font weight for a slotted React Router link", () => {
+    mount(
+      <MemoryRouter>
+        <style>{`a { font: var(--ic-font-body); }`}</style>
+        <div style={{ margin: "16px" }}>
+          <IcLink>
+            <NavLink to="/" slot="router-item">
+              About our coffees
+            </NavLink>
+          </IcLink>
+        </div>
+      </MemoryRouter>
+    );
+
+    cy.checkHydrated(LINK_SELECTOR);
+    cy.get(`${LINK_SELECTOR} a`).should(HAVE_CSS, "font-weight", "700");
+
+    cy.checkA11yWithWait();
+    cy.compareSnapshot({
+      name: "/router-link",
+      testThreshold: setThresholdBasedOnEnv(DEFAULT_TEST_THRESHOLD),
     });
   });
 });

--- a/packages/web-components/src/components/ic-link/ic-link.css
+++ b/packages/web-components/src/components/ic-link/ic-link.css
@@ -8,6 +8,10 @@
   transition: var(--ic-easing-transition-fast);
 }
 
+:host(.ic-link) ::slotted(a) {
+  font-weight: var(--ic-font-weight-bold) !important;
+}
+
 :host(.ic-link) .link:visited,
 :host(.ic-link) ::slotted(a:visited),
 :host(.ic-link) .link:visited:hover,


### PR DESCRIPTION
## Summary of the changes

Keeps the intended bold `ic-link` weight when a React Router `NavLink` is slotted through `router-item` and application-level CSS applies a `font` shorthand to anchors.

Light-DOM author styles can override normal `::slotted(a)` declarations. The router-link font weight is now explicitly protected while the rest of the slotted link typography remains customisable.

## Related issue

Closes #1656

## Validation

- [x] Change is limited to `ic-link.css`
- [x] Only the slotted router-link font weight is made authoritative
- [x] Internal `ic-link` styling is unchanged
- [x] Customer colour, font-family and size styling remains unaffected