### PR TITLE
fix(root): parse issue urgency dropdown

### DIFF
--- a/.github/workflows/add-issue-urgency.yml
+++ b/.github/workflows/add-issue-urgency.yml
@@ -14,8 +14,9 @@ jobs:
 
       - name: Get issue urgency
         env:
-          URGENCY_STRING: ${{ fromJSON(steps.parse.outputs.data).urgency-low-medium-or-high }}
+          PARSED_ISSUE_DATA: ${{ steps.parse.outputs.data }}
         run: |
+          URGENCY_STRING=$(jq -r '."urgency-low-medium-or-high".text // empty' <<< "$PARSED_ISSUE_DATA")
           case "$URGENCY_STRING" in
             "Low"|"Medium"|"High")
               echo "MATCHED_URGENCY=$URGENCY_STRING" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Restore the issue urgency workflow after the urgency field was changed to an Issue Forms dropdown.

## Problem

The workflow accesses the parsed field using `fromJSON(...).urgency-low-medium-or-high`. GitHub interprets the hyphens as expression syntax, so the workflow fails during template evaluation before the urgency update runs. The failing run reports `A mapping was not expected` at that expression.

The issue-forms parser returns each parsed field as an object whose selected value is available in `.text`.

## Fix

- pass the parser JSON through an environment variable;
- extract `urgency-low-medium-or-high.text` with `jq`;
- preserve the existing Low/Medium/High validation and project-field update.

This also keeps issue-provided content out of direct shell interpolation.

Closes #4493