### PR TITLE
refactor: add source import aliases

### DIFF
--- a/packages/canary-web-components/src/components/ic-calendar/ic-day-button.tsx
+++ b/packages/canary-web-components/src/components/ic-calendar/ic-day-button.tsx
@@ -1,8 +1,8 @@
 import { h, FunctionalComponent } from "@stencil/core";
-import { stringEnumToArray } from "../../utils/helpers";
-import { IcDayNames, IcDateInputMonths } from "../../utils/types";
+import { stringEnumToArray } from "src/utils/helpers";
+import { IcDayNames, IcDateInputMonths } from "src/utils/types";
 
-import "../../../../web-components/src/components/ic-typography/ic-typography";
+import "web-components/src/components/ic-typography/ic-typography";
 
 export type DayButtonProps = {
   focussed: boolean;

--- a/packages/canary-web-components/stencil.config.ts
+++ b/packages/canary-web-components/stencil.config.ts
@@ -59,6 +59,8 @@ export const config: Config = {
   testing: {
     browserArgs: ["--no-sandbox", "--disable-setuid-sandbox"],
     moduleNameMapper: {
+      "^src/(.*)$": "<rootDir>/src/$1",
+      "^web-components/(.*)$": "<rootDir>/../web-components/$1",
       "\\.svg": "<rootDir>/mocks/svgMock.ts",
       "lit-html": "<rootDir>/mocks/empty.js",
     },

--- a/packages/canary-web-components/tsconfig.json
+++ b/packages/canary-web-components/tsconfig.json
@@ -9,7 +9,12 @@
     "allowJs": true,
     "strict": true,
     "strictPropertyInitialization": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"],
+      "web-components/*": ["../web-components/*"]
+    }
   },
   "include": ["src", "./node.d.ts"],
   "exclude": [

--- a/packages/web-components/src/components/ic-badge/ic-badge.types.ts
+++ b/packages/web-components/src/components/ic-badge/ic-badge.types.ts
@@ -1,4 +1,4 @@
-import { IcStatusVariants } from "../../utils/types";
+import { IcStatusVariants } from "src/utils/types";
 
 export type IcBadgeTypes = "dot" | "text" | "icon";
 

--- a/packages/web-components/stencil.config.ts
+++ b/packages/web-components/stencil.config.ts
@@ -141,6 +141,7 @@ export const config: Config = {
   testing: {
     browserArgs: ["--no-sandbox", "--disable-setuid-sandbox"],
     moduleNameMapper: {
+      "^src/(.*)$": "<rootDir>/src/$1",
       "\\.svg": "<rootDir>/mocks/svgMock.ts",
     },
     coverageThreshold: {

--- a/packages/web-components/tsconfig.json
+++ b/packages/web-components/tsconfig.json
@@ -8,7 +8,11 @@
     "jsxFactory": "h",
     "strict": true,
     "strictPropertyInitialization": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
   },
   "include": ["src", "./node.d.ts"],
   "exclude": ["node_modules", "src/testa11y.setup.ts"]


### PR DESCRIPTION
## Summary of the changes

Adds explicit source import aliases for the two Stencil packages so deeply nested files can use readable package-root imports instead of climbing the directory tree.

- Adds `src/*` -> `src/*` TypeScript path resolution in `web-components` and `canary-web-components`.
- Mirrors the aliases in Stencil's Jest `moduleNameMapper` so unit tests resolve the same imports as the compiler.
- Adds a `web-components/*` sibling-source alias in `canary-web-components`, where canary components intentionally consume stable component source.
- Migrates representative imports so the aliases are exercised by the normal build/test pipeline.
- No component API, rendering, styling, accessibility, or runtime behaviour changes.

The branch is based directly on the current upstream `develop` head and contains one commit per affected package scope, in line with the contribution guide.

## Related issue

Closes #4630.

## Testing

The alias mappings were smoke-tested with TypeScript 5.8 for both package-local `src/*` imports and the canary sibling-source alias. Existing Stencil build and unit-test CI will additionally exercise the changed imports.

## Checklist

- [x] No docs changes required.
- [x] Issue requirements reviewed and addressed.
- [x] Existing build/unit coverage exercises the aliased imports.
- [x] No visual, accessibility, Storybook API or behavioural changes requiring additional regression coverage.
