### PR TITLE
fix(web-components): #4364 fix select clear button focus colour

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -255,7 +255,7 @@ select:not([disabled]) {
   border-radius: 0.25rem;
 }
 
-.clear-button:focus,
+.clear-button:focus *,
 .clear-button:active * {
   fill: var(--ic-atoms-input-clear-button-focus);
 }


### PR DESCRIPTION
## Summary of the changes

Fixes the `IcSelect` clear icon colour when the clear button receives focus in dark mode.

The focus selector was applying the focus fill token to the `ic-button` host, while the active selector applied it to the SVG descendants. This meant the focused clear icon could remain dark against the focus background.

The focus state now targets the icon descendants as well, using the existing `--ic-atoms-input-clear-button-focus` token. There are no component API, layout, or behaviour changes.

## Related issue

Closes #4364

## Testing

- [x] Change is limited to the clear-button focus selector.
- [x] Active-state styling is unchanged.
- [x] Dark-mode focus uses the existing focus icon token.
- [x] No component API or accessibility semantics changed.
