### PR TITLE
fix(web-components): #4172 remove stale navigation key listener

### DIFF
--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -284,7 +284,7 @@ export class NavigationGroup {
     switch (this.navigationType) {
       case "top":
         if (key === " " || key === "Enter") {
-          this.toggleDropdown();
+          this.dropdownOpen ? this.hideDropdown() : this.toggleDropdown();
         } else if (!this.inTopNavSideMenu) {
           this.hideDropdown();
         }

--- a/packages/web-components/src/components/ic-navigation-group/test/basic/ic-navigation-group-listener.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-group/test/basic/ic-navigation-group-listener.spec.ts
@@ -1,0 +1,29 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { waitForNavGroupLoad } from "../../../../testspec.setup";
+import { NavigationGroup } from "../../ic-navigation-group";
+
+describe("ic-navigation-group document keydown listener", () => {
+  it("removes the listener when Enter closes a top navigation group", async () => {
+    const page = await newSpecPage({
+      components: [NavigationGroup],
+      html: `<ic-navigation-group label="Group label"></ic-navigation-group>`,
+    });
+    await waitForNavGroupLoad();
+
+    const instance = page.rootInstance;
+    instance.navigationType = "top";
+    instance.dropdownOpen = true;
+
+    document.addEventListener("keydown", instance.handleKeydown);
+
+    instance.handleKeydown(new KeyboardEvent("keydown", { key: "Enter" }));
+    await page.waitForChanges();
+    expect(instance.dropdownOpen).toBe(false);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    await page.waitForChanges();
+    expect(instance.dropdownOpen).toBe(false);
+
+    document.removeEventListener("keydown", instance.handleKeydown);
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Fixes the document-level keydown listener left behind after closing an `IcNavigationGroup` with Enter or Space.

When a top-navigation group is opened by hover, it registers a document `keydown` listener. The Enter/Space path previously closed the dropdown with `toggleDropdown()`, bypassing `hideDropdown()` and therefore leaving that listener registered. A later Enter press elsewhere on the page could then invoke the stale handler and reopen the group.

When the dropdown is already open, Enter/Space now closes it through `hideDropdown()`, which performs the existing listener cleanup. Opening behaviour is unchanged.

A regression test registers the document listener, closes the group with Enter, dispatches another Enter event, and verifies the group remains closed.

## Related issue

Closes #4172

## Testing

- [x] Regression test added for the stale document keydown listener.
- [x] Opening behaviour remains unchanged.
- [x] Existing `hideDropdown()` cleanup path is reused.
- [x] Change is contained to `web-components`.
