### PR TITLE
fix(web-components): #4446 restore search bar focus on Escape

### DIFF
--- a/packages/react/src/component-tests/IcSearchBar/IcSearchBarEscapeFocus.cy.tsx
+++ b/packages/react/src/component-tests/IcSearchBar/IcSearchBarEscapeFocus.cy.tsx
@@ -1,0 +1,34 @@
+/// <reference types="cypress" />
+
+import { mount } from "cypress/react";
+import React from "react";
+import { IcSearchBar } from "../../components";
+import { HAVE_FOCUS, NOT_EXIST } from "../utils/constants";
+
+const SEARCH_SELECTOR = "ic-search-bar";
+const SEARCH_INPUT = 'input[inputmode="search"]';
+const MENU_OPTION = "li[role='option']";
+
+const options = [
+  { label: "Espresso", value: "espresso" },
+  { label: "Double Espresso", value: "doubleespresso" },
+];
+
+describe("IcSearchBar Escape focus regression", () => {
+  it("returns focus to the input when Escape closes the options menu", () => {
+    mount(<IcSearchBar label="Search" options={options} />);
+
+    cy.checkHydrated(SEARCH_SELECTOR);
+    cy.findShadowEl(SEARCH_SELECTOR, SEARCH_INPUT).type("Es");
+
+    cy.realPress("ArrowDown");
+    cy.findShadowEl(SEARCH_SELECTOR, MENU_OPTION)
+      .eq(0)
+      .should(HAVE_FOCUS);
+
+    cy.realPress("Escape");
+
+    cy.findShadowEl(SEARCH_SELECTOR, MENU_OPTION).should(NOT_EXIST);
+    cy.findShadowEl(SEARCH_SELECTOR, SEARCH_INPUT).should(HAVE_FOCUS);
+  });
+});

--- a/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
+++ b/packages/web-components/src/components/ic-search-bar/ic-search-bar.tsx
@@ -511,6 +511,9 @@ export class SearchBar {
     this.icKeydown.emit({ event });
     if (this.menu && this.open) {
       this.menu.handleKeyboardOpen(event);
+      if (event.key === "Escape") {
+        this.inputEl?.focus();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary of the changes

Fixes keyboard focus when Escape closes the Search Bar options menu.

When focus has moved from the search input into an option, pressing Escape closes the menu but previously left focus outside the component. The search bar now restores focus to its native input during the same keydown that closes the menu.

This keeps keyboard and screen-reader users in the search interaction and matches the expected behaviour described in the issue.

## Related issue

Closes #4446

## Testing

- Adds Cypress regression coverage for the reported sequence: type a query, move focus to an option with ArrowDown, then press Escape.
- Verifies the options menu closes.
- Verifies focus returns to the native search input.
- Production and Cypress changes are split into `web-components` and `react` commits to match the repository's commit-scope rules.
- Upstream CI will run the full checks when the PR is opened.

## Checklist

- [x] Acceptance criteria reviewed and addressed.
- [x] Keyboard regression coverage added.
- [x] No public API changes.
- [x] No visual or styling changes.
