### PR TITLE
fix(web-components): #4393 match page header tab height without href

### DIFF
--- a/packages/react/src/component-tests/IcPageHeader/IcNavigationItemTabHeight.cy.tsx
+++ b/packages/react/src/component-tests/IcPageHeader/IcNavigationItemTabHeight.cy.tsx
@@ -1,0 +1,40 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { IcNavigationItem, IcPageHeader } from "../../components";
+
+const NAVIGATION_ITEM = "ic-navigation-item";
+
+describe("IcNavigationItem page header tab height", () => {
+  it("matches the tab height when href is omitted", () => {
+    mount(
+      <IcPageHeader heading="Page heading">
+        <IcNavigationItem slot="tabs" label="Linked tab" href="#" />
+        <IcNavigationItem slot="tabs" label="Router tab" />
+      </IcPageHeader>
+    );
+
+    cy.checkHydrated("ic-page-header");
+    cy.get(NAVIGATION_ITEM).should("have.length", 2);
+
+    cy.get(NAVIGATION_ITEM)
+      .eq(0)
+      .shadow()
+      .find("a.link")
+      .then(($linkedTab) => {
+        const linkedTabHeight = $linkedTab[0].getBoundingClientRect().height;
+        expect(linkedTabHeight).to.be.greaterThan(0);
+
+        cy.get(NAVIGATION_ITEM)
+          .eq(1)
+          .shadow()
+          .find("div.link")
+          .should(($routerTab) => {
+            expect($routerTab[0].getBoundingClientRect().height).to.equal(
+              linkedTabHeight
+            );
+          });
+      });
+  });
+});

--- a/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
+++ b/packages/web-components/src/components/ic-navigation-item/ic-navigation-item.css
@@ -528,7 +528,7 @@ svg {
   border-radius: 0;
 }
 
-:host(.navigation-item-page-header).link,
+:host(.navigation-item-page-header) .link,
 :host(.navigation-item-page-header) a,
 :host(.navigation-item-page-header) ::slotted(a) {
   height: 2.5rem !important;
@@ -655,7 +655,7 @@ svg {
   .navigation-item-side-nav-slotted-text,
   :host(.navigation-item-side-nav.navigation-item-selected) .link::before,
   :host(.navigation-item-side-nav) ::slotted(a.active)::before,
-  :host(.navigation-item-page-header).link,
+  :host(.navigation-item-page-header) .link,
   :host(.navigation-item-page-header) a,
   :host(.navigation-item-page-header) ::slotted(a),
   :host(.navigation-item-page-header.navigation-item-selected.with-transition)


### PR DESCRIPTION
## Summary of the changes

Fixes `IcNavigationItem` height when it is used in an `IcPageHeader` tabs slot without an `href`, such as when routing is handled by a framework.

The page-header rule intended to style the internal `.link` element used `:host(.navigation-item-page-header).link`. That selector targets a host carrying the `link` class, but the no-`href` fallback renders a `<div class="link">` inside the component. Linked tabs render an `<a>` and were already covered by the adjacent selector.

The selector now correctly targets `:host(.navigation-item-page-header) .link`, so linked and router-style tabs receive the same 2.5rem height. The equivalent reduced-motion selector is corrected at the same time.

## Related issue

Closes #4393

## Testing

- Adds Cypress regression coverage rendering page-header tabs with and without `href` side by side.
- Verifies the linked `<a class="link">` and no-`href` `<div class="link">` have identical rendered height.
- Production and Cypress changes are split into `web-components` and `react` commits to match the repository's commit-scope rules.
- Upstream CI will run the full checks when the PR is opened.

## Checklist

- [x] Acceptance criteria reviewed and addressed.
- [x] Browser-level regression coverage added.
- [x] No public API changes.
- [x] Reduced-motion selector kept consistent with the corrected selector.
