### PR TITLE
fix(web-components): #4034 align clickable card underline with link

### DIFF
--- a/packages/react/src/component-tests/IcCardVertical/IcCardVerticalLinkUnderline.cy.tsx
+++ b/packages/react/src/component-tests/IcCardVertical/IcCardVerticalLinkUnderline.cy.tsx
@@ -1,0 +1,52 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { IcCardVertical, IcLink } from "../../components";
+
+describe("IcCardVertical clickable heading underline", () => {
+  it("matches IcLink underline styling on hover", () => {
+    mount(
+      <>
+        <IcLink href="#">Reference link</IcLink>
+        <IcCardVertical heading="Clickable card" clickable />
+      </>
+    );
+
+    cy.checkHydrated("ic-link");
+    cy.checkHydrated("ic-card-vertical");
+
+    cy.get("ic-link")
+      .shadow()
+      .find(".link")
+      .realHover()
+      .then(($link) => {
+        const linkStyle = getComputedStyle($link[0]);
+        const expected = {
+          borderBottomWidth: linkStyle.borderBottomWidth,
+          marginBottom: linkStyle.marginBottom,
+          textDecorationThickness: linkStyle.textDecorationThickness,
+          textUnderlineOffset: linkStyle.textUnderlineOffset,
+        };
+
+        cy.get("ic-card-vertical").shadow().find(".card").realHover();
+        cy.get("ic-card-vertical")
+          .shadow()
+          .find(".card-title")
+          .should(($title) => {
+            const cardStyle = getComputedStyle($title[0]);
+
+            expect(cardStyle.borderBottomWidth).to.equal(
+              expected.borderBottomWidth
+            );
+            expect(cardStyle.marginBottom).to.equal(expected.marginBottom);
+            expect(cardStyle.textDecorationThickness).to.equal(
+              expected.textDecorationThickness
+            );
+            expect(cardStyle.textUnderlineOffset).to.equal(
+              expected.textUnderlineOffset
+            );
+          });
+      });
+  });
+});

--- a/packages/web-components/src/components/ic-card-vertical/ic-card-vertical.css
+++ b/packages/web-components/src/components/ic-card-vertical/ic-card-vertical.css
@@ -124,19 +124,19 @@ button {
 .card.clickable.focussed .card-title {
   display: inline-block;
   border-bottom: 0.25rem solid !important;
-  margin-bottom: 0 !important;
+  margin-bottom: -0.25rem !important;
   text-decoration: none;
 }
 
-@supports (text-underline-offset: 25%) {
+@supports (text-underline-offset: 10%) {
   .card.clickable:hover .card-title,
   .card.clickable:focus .card-title,
   .card.clickable.focussed .card-title {
     text-decoration-line: underline;
     text-decoration-thickness: 25%;
-    text-underline-offset: 25%;
+    text-underline-offset: 10%;
     border-bottom: 0 !important;
-    margin-bottom: 0.25rem !important;
+    margin-bottom: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Summary of the changes

Aligns the clickable `IcCardVertical` heading hover/focus underline with the existing `IcLink` implementation.

The issue was narrowed during design review to making Safari match the other supported browsers. The card had its own underline geometry which had drifted from `IcLink`: its fallback margin and `text-underline-offset` values were different.

Rather than adding Safari-specific CSS, this change reuses the same underline behaviour already used by `IcLink`:
- 0.25rem border fallback with the same negative margin;
- the same `@supports (text-underline-offset: 10%)` feature query;
- 25% text-decoration thickness with 10% underline offset;
- no extra margin in the supported path.

A Cypress regression renders an `IcLink` and clickable card together, hovers both with real pointer events, and verifies their border, margin, underline thickness and underline offset match.

## Related issue

Closes #4034

## Testing

- [x] Browser-level regression compares the card heading directly with `IcLink`.
- [x] Real hover events are used.
- [x] Fallback and modern underline geometry are aligned with `IcLink`.
- [x] No public API changes.
- [x] Production and Cypress changes are split into `web-components` and `react` commits.
