### PR TITLE
fix(web-components): #3879 mark checkbox checkmark decorative

### DIFF
--- a/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
+++ b/packages/web-components/src/components/ic-checkbox/ic-checkbox.tsx
@@ -262,13 +262,14 @@ export class Checkbox {
           ) : (
             checked && (
               <svg
+                aria-hidden="true"
+                focusable="false"
                 class="checkmark"
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
                 fill-rule="evenodd"
                 clip-rule="evenodd"
               >
-                <title>checkmark icon</title>
                 <path d="M21 6.285l-11.16 12.733-6.84-6.018 1.319-1.49 5.341 4.686 9.865-11.196 1.475 1.285z" />
               </svg>
             )

--- a/packages/web-components/src/components/ic-checkbox/test/basic/ic-checkbox-decorative-checkmark.spec.tsx
+++ b/packages/web-components/src/components/ic-checkbox/test/basic/ic-checkbox-decorative-checkmark.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { Checkbox } from "../../ic-checkbox";
+
+describe("ic-checkbox checkmark accessibility", () => {
+  it("marks the visual checkmark as decorative", async () => {
+    const page = await newSpecPage({
+      components: [Checkbox],
+      html: `<ic-checkbox label="Coffee" checked></ic-checkbox>`,
+    });
+
+    const checkmark = page.root?.shadowRoot?.querySelector("svg.checkmark");
+
+    expect(checkmark).not.toBeNull();
+    expect(checkmark?.getAttribute("aria-hidden")).toBe("true");
+    expect(checkmark?.getAttribute("focusable")).toBe("false");
+    expect(checkmark?.querySelector("title")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Marks the visual checkmark SVG in `IcCheckbox` as decorative.

The checked state and accessible name are already exposed by the native checkbox input, so the SVG does not need its own accessible name. The existing `<title>checkmark icon</title>` could cause automated accessibility tools to treat the same state as both meaningful and decorative.

This change:
- adds `aria-hidden="true"` and `focusable="false"` to the visual checkmark;
- removes the SVG `<title>`;
- leaves the native checkbox semantics and visible rendering unchanged;
- adds focused unit coverage for the decorative SVG contract.

## Related issue

Closes #3879

## Testing

- [x] Unit regression verifies the checkmark is `aria-hidden`.
- [x] Unit regression verifies the SVG is not focusable.
- [x] Unit regression verifies no accessible `<title>` remains.
- [x] Native checkbox label/state semantics are unchanged.
- [x] No visual, layout or public API changes.
