### PR TITLE
fix(web-components): update footer links when grouping changes

### DIFF
--- a/packages/web-components/src/components/ic-footer-link/ic-footer-link.tsx
+++ b/packages/web-components/src/components/ic-footer-link/ic-footer-link.tsx
@@ -76,9 +76,13 @@ export class FooterLink {
   private inferConfig(e: HTMLElement): FooterConfig {
     if (e.parentElement !== null) {
       if (e.parentElement.classList.contains("ic-footer")) {
+        const footer = e.parentElement as HTMLIcFooterElement;
         return {
-          small: e.parentElement.classList.contains("ic-footer-small"),
-          grouped: e.parentElement.classList.contains("ic-footer-grouped"),
+          small: footer.classList.contains("ic-footer-small"),
+          grouped:
+            typeof footer.groupLinks === "boolean"
+              ? footer.groupLinks
+              : footer.classList.contains("ic-footer-grouped"),
         };
       } else {
         return this.inferConfig(e.parentElement);

--- a/packages/web-components/src/components/ic-footer/ic-footer.tsx
+++ b/packages/web-components/src/components/ic-footer/ic-footer.tsx
@@ -8,6 +8,7 @@ import {
   Listen,
   Prop,
   State,
+  Watch,
 } from "@stencil/core";
 import { IC_DEVICE_SIZES } from "../../utils/constants";
 import {
@@ -87,6 +88,11 @@ export class Footer {
    *  @internal Triggers on page resize and triggers style changes in footer links and link groups
    */
   @Event() footerResized: EventEmitter<void>;
+
+  @Watch("groupLinks")
+  groupLinksChangedHandler(): void {
+    this.footerResized.emit();
+  }
 
   disconnectedCallback(): void {
     if (this.resizeObserver !== null) {

--- a/packages/web-components/src/components/ic-footer/test/basic/ic-footer-group-links.spec.ts
+++ b/packages/web-components/src/components/ic-footer/test/basic/ic-footer-group-links.spec.ts
@@ -1,0 +1,32 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { FooterLink } from "../../../ic-footer-link/ic-footer-link";
+import { Footer } from "../../ic-footer";
+
+describe("ic-footer groupLinks updates", () => {
+  it("updates slotted footer link styling when groupLinks changes", async () => {
+    const page = await newSpecPage({
+      components: [Footer, FooterLink],
+      html: `<ic-footer>
+        <ic-footer-link slot="link" href="/">Link</ic-footer-link>
+      </ic-footer>`,
+    });
+
+    const footer = page.root as HTMLIcFooterElement;
+    const footerLink = footer.querySelector("ic-footer-link");
+
+    expect(footerLink).not.toBeNull();
+    expect(footerLink?.classList.contains("footer-link-ungrouped-sparse")).toBe(
+      true
+    );
+
+    footer.groupLinks = true;
+    await page.waitForChanges();
+
+    expect(footerLink?.classList.contains("footer-link-grouped-sparse")).toBe(
+      true
+    );
+    expect(
+      footerLink?.classList.contains("footer-link-ungrouped-sparse")
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Fixes `IcFooter` link styling when `groupLinks` is changed after initial render.

`IcFooterLink` caches whether it belongs to a grouped footer and previously refreshed that state only on initial load or resize. Changing `groupLinks` therefore updated the footer but left already-rendered links using stale grouped/ungrouped classes.

This change:
- reuses the existing internal `footerResized` refresh signal when `groupLinks` changes;
- reads the live `IcFooter.groupLinks` prop when footer links refresh their configuration, while retaining the existing host-class check as a fallback;
- adds a regression test that toggles `groupLinks` at runtime and verifies the slotted link moves from ungrouped to grouped styling without a resize.

No public API or visual design changes.

## Related issue

Closes #2007

## Testing

- [x] Unit regression covers `groupLinks` changing after initial render.
- [x] Existing initial grouped/ungrouped behaviour is preserved.
- [x] Change is contained to `web-components`.
- [x] Branch is based directly on `develop`.
