### PR TITLE
fix(root): restore issue urgency workflow

### DIFF
--- a/.github/workflows/add-issue-urgency.yml
+++ b/.github/workflows/add-issue-urgency.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get issue urgency
         env:
-          URGENCY_STRING: ${{ fromJSON(steps.parse.outputs.data).urgency-low-medium-or-high }}
+          URGENCY_STRING: ${{ fromJSON(steps.parse.outputs.data).urgency-low-medium-or-high.text }}
         run: |
           case "$URGENCY_STRING" in
             "Low"|"Medium"|"High")


### PR DESCRIPTION
## Summary of the changes

Fixes the `Add issue urgency` workflow after the issue templates were converted to GitHub Issue Forms dropdowns.

The failing run linked in #4493 completes the issue-body parser step and fails in `Get issue urgency`. During the Issue Forms conversion, the workflow changed from reading the parsed field's `.text` value to passing the entire parsed field object into `URGENCY_STRING`.

This restores the scalar dropdown value:

`fromJSON(steps.parse.outputs.data).urgency-low-medium-or-high.text`

The existing strict validation for `Low`, `Medium` and `High`, token generation, and project-field update remain unchanged.

## Related issue

Closes #4493

## Validation

- [x] Failure isolated to `Get issue urgency` in the workflow run linked by the issue.
- [x] Restores the field access used before the Issue Forms conversion.
- [x] Keeps accepted urgency values restricted to `Low`, `Medium` and `High`.
- [x] One-line workflow-only change.
- [x] Branch is based directly on `develop`.
