### PR TITLE
fix(web-components): #1579 constrain SlottedSVG chip icons

### DIFF
--- a/packages/react/src/component-tests/IcChip/IcChipSlottedSvg.cy.tsx
+++ b/packages/react/src/component-tests/IcChip/IcChipSlottedSvg.cy.tsx
@@ -1,0 +1,50 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { IcChip } from "../../components";
+import { SlottedSVG } from "../../react-component-lib/slottedSVG";
+
+const ICON_PATH =
+  "M12,19.2C9.5,19.2 7.29,17.92 6,16C6.03,14 10,12.9 12,12.9C14,12.9 17.97,14 18,16C16.71,17.92 14.5,19.2 12,19.2M12,5A3,3 0 0,1 15,8A3,3 0 0,1 12,11A3,3 0 0,1 9,8A3,3 0 0,1 12,5M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z";
+
+describe("IcChip SlottedSVG sizing", () => {
+  it("constrains a SlottedSVG to the chip icon container", () => {
+    mount(
+      <div style={{ display: "flex", gap: "8px" }}>
+        <IcChip label="Account">
+          <SlottedSVG
+            slot="icon"
+            path={ICON_PATH}
+            viewBox="0 0 24 24"
+            aria-label="Account"
+          />
+        </IcChip>
+        <IcChip label="Neighbour" />
+      </div>
+    );
+
+    cy.checkHydrated("ic-chip");
+
+    cy.get("ic-chip")
+      .eq(0)
+      .then(($chip) => {
+        const chip = $chip[0];
+        const iconContainer = chip.shadowRoot?.querySelector(
+          ".icon"
+        ) as HTMLElement;
+        const svg = chip.querySelector('svg[slot="icon"]') as SVGElement;
+
+        expect(iconContainer).not.to.be.null;
+        expect(svg).not.to.be.null;
+
+        const containerRect = iconContainer.getBoundingClientRect();
+        const svgRect = svg.getBoundingClientRect();
+
+        expect(containerRect.width).to.be.at.most(24);
+        expect(containerRect.height).to.be.at.most(24);
+        expect(svgRect.width).to.be.at.most(containerRect.width);
+        expect(svgRect.height).to.be.at.most(containerRect.height);
+      });
+  });
+});

--- a/packages/react/src/stories/ic-chip-slotted-svg.stories.jsx
+++ b/packages/react/src/stories/ic-chip-slotted-svg.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { IcChip } from "../components";
+import { SlottedSVG } from "../react-component-lib/slottedSVG";
+
+const ACCOUNT_ICON =
+  "M12,19.2C9.5,19.2 7.29,17.92 6,16C6.03,14 10,12.9 12,12.9C14,12.9 17.97,14 18,16C16.71,17.92 14.5,19.2 12,19.2M12,5A3,3 0 0,1 15,8A3,3 0 0,1 12,11A3,3 0 0,1 9,8A3,3 0 0,1 12,5M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z";
+
+export default {
+  title: "Chip",
+  component: IcChip,
+};
+
+const AccountIcon = () => (
+  <SlottedSVG
+    slot="icon"
+    path={ACCOUNT_ICON}
+    viewBox="0 0 24 24"
+    aria-label="account"
+  />
+);
+
+export const SlottedSvg = {
+  render: () => (
+    <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+      <IcChip label="Small" size="small">
+        <AccountIcon />
+      </IcChip>
+      <IcChip label="Medium">
+        <AccountIcon />
+      </IcChip>
+      <IcChip label="Large" size="large">
+        <AccountIcon />
+      </IcChip>
+    </div>
+  ),
+  name: "With SlottedSVG",
+};

--- a/packages/web-components/src/components/ic-chip/ic-chip.css
+++ b/packages/web-components/src/components/ic-chip/ic-chip.css
@@ -161,8 +161,16 @@ ic-tooltip:focus-within {
 }
 
 .icon {
+  flex: 0 0 var(--ic-space-lg);
+  width: var(--ic-space-lg);
+  height: var(--ic-space-lg);
   padding: var(--ic-space-xxxs);
   box-sizing: border-box;
+}
+
+.icon ::slotted(svg) {
+  width: 100%;
+  height: 100%;
 }
 
 .icon,


### PR DESCRIPTION
## Summary of the changes

Fixes `IcChip` layout when an icon is supplied using the React `SlottedSVG` helper.

A `SlottedSVG` without explicit width and height can retain the browser's intrinsic SVG dimensions and push neighbouring chips away. The chip now owns the icon layout boundary instead:

- gives the icon wrapper a fixed 24px flex footprint;
- constrains slotted SVG width and height to the wrapper;
- preserves the existing padding and icon treatment;
- does not change `SlottedSVG` defaults globally.

The React example and regression use the supported `viewBox="0 0 24 24"` approach discussed on the issue, avoiding a potentially breaking global viewBox default.

A dedicated Storybook example is included for small, medium and large chips using the real `SlottedSVG` helper.

## Related issue

Refs #1579.

This addresses the UI Kit component and React Storybook portions of the issue. The separate guidance-site example is outside this repository and is intentionally not marked complete by this PR.

## Testing

- [x] Cypress regression uses the real React `SlottedSVG` helper.
- [x] Verifies the icon wrapper remains within the chip's 24px icon footprint.
- [x] Verifies the slotted SVG cannot exceed its icon wrapper.
- [x] Adds a React Storybook example for small, medium and large chips.
- [x] No public API changes.
- [x] `SlottedSVG` global defaults are unchanged.
- [x] Production and React test/story changes are split by package scope.

Full upstream CI will run when the PR is opened.
