### PR TITLE
fix(web-components): #2047 update reverseOrder at runtime

### DIFF
--- a/packages/react/src/component-tests/IcPageHeader/IcPageHeaderReverseOrder.cy.tsx
+++ b/packages/react/src/component-tests/IcPageHeader/IcPageHeaderReverseOrder.cy.tsx
@@ -1,0 +1,52 @@
+/// <reference types="Cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { IcPageHeader } from "../../components";
+
+const PAGE_HEADER = "ic-page-header";
+const ACTIONS = `${PAGE_HEADER} > [slot="actions"]`;
+
+type PageHeaderElement = HTMLElement & { reverseOrder: boolean };
+
+const expectActionOrder = (expected: string[]) => {
+  cy.get(ACTIONS).should(($actions) => {
+    const labels = $actions
+      .toArray()
+      .map((action) => action.textContent?.trim());
+
+    expect(labels).to.deep.equal(expected);
+  });
+};
+
+describe("IcPageHeader reverseOrder updates", () => {
+  it("updates action order immediately when reverseOrder changes", () => {
+    cy.viewport(1024, 500);
+
+    mount(
+      <IcPageHeader heading="Page heading">
+        <button slot="actions" type="button">
+          First action
+        </button>
+        <button slot="actions" type="button">
+          Second action
+        </button>
+      </IcPageHeader>
+    );
+
+    cy.checkHydrated(PAGE_HEADER);
+    expectActionOrder(["First action", "Second action"]);
+
+    cy.get(PAGE_HEADER).then(($header) => {
+      ($header[0] as PageHeaderElement).reverseOrder = true;
+    });
+
+    expectActionOrder(["Second action", "First action"]);
+
+    cy.get(PAGE_HEADER).then(($header) => {
+      ($header[0] as PageHeaderElement).reverseOrder = false;
+    });
+
+    expectActionOrder(["First action", "Second action"]);
+  });
+});

--- a/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
+++ b/packages/web-components/src/components/ic-page-header/ic-page-header.tsx
@@ -1,4 +1,12 @@
-import { Component, Host, h, Prop, Element, State } from "@stencil/core";
+import {
+  Component,
+  Host,
+  h,
+  Prop,
+  Element,
+  State,
+  Watch,
+} from "@stencil/core";
 
 import { IcAlignment, IcSizesNoLarge, IcThemeMode } from "../../utils/types";
 
@@ -53,6 +61,16 @@ export class PageHeader {
    * If `true`, the reading pattern and tab order will change in the action area for viewport widths of above 576px and when actions have not wrapped.
    */
   @Prop() reverseOrder?: boolean = false;
+  @Watch("reverseOrder")
+  reverseOrderChangedHandler(): void {
+    if (!isSlotUsed(this.el, "actions")) return;
+
+    if (this.reverseOrder) {
+      this.applyReverseOrder();
+    } else if (this.areButtonsReversed) {
+      this.reverseActionContent();
+    }
+  }
 
   /**
    * The size of the page header component.
@@ -108,6 +126,14 @@ export class PageHeader {
     this.resizeObserver.observe(this.el);
   };
 
+  private reverseActionContent = (): void => {
+    this.actionContent = [...this.actionContent].reverse();
+    this.actionContent.forEach((btn: string | Node) => {
+      this.el.append(btn);
+    });
+    this.areButtonsReversed = !this.areButtonsReversed;
+  };
+
   private applyReverseOrder = (): void => {
     const currSize = getCurrentDeviceSize();
     if (currSize !== this.deviceSize) {
@@ -138,14 +164,6 @@ export class PageHeader {
       actionAreaHeight = 0;
     }
 
-    const appendActionContent = () => {
-      this.actionContent = this.actionContent.reverse();
-      this.actionContent.forEach((btn: string | Node) => {
-        this.el.append(btn);
-      });
-      this.areButtonsReversed = !this.areButtonsReversed;
-    };
-
     if (
       (this.deviceSize > DEVICE_SIZES.S &&
         actionAreaHeight <= max &&
@@ -154,7 +172,7 @@ export class PageHeader {
         this.deviceSize <= DEVICE_SIZES.S) &&
         this.areButtonsReversed)
     ) {
-      appendActionContent();
+      this.reverseActionContent();
     }
   };
 


### PR DESCRIPTION
## Summary of the changes

Fixes `IcPageHeader` so changing `reverseOrder` at runtime updates the action order immediately instead of waiting for a window resize.

The existing implementation recalculated action order only from `ResizeObserver`, so changing the prop had no visible effect until a resize occurred.

This change:

- watches `reverseOrder` and recalculates immediately when it changes;
- reuses the existing breakpoint and wrapping logic when reverse ordering is enabled;
- restores the original action order immediately when reverse ordering is disabled;
- extracts the existing reorder operation into a single helper;
- avoids mutating the stored action array in place.

Initial rendering, responsive breakpoints, wrapped-action behaviour and the public API remain unchanged.

## Related issue

Closes #2047.

## Testing

- [x] Adds Cypress regression coverage at desktop width.
- [x] Verifies `false` -> `true` reverses the actions without resizing.
- [x] Verifies `true` -> `false` restores the original order without resizing.
- [x] Existing `ResizeObserver` behaviour remains in place for responsive layout changes.
- [x] No public API or visual design changes.
- [x] Production and Cypress changes are split by package scope.

Full upstream CI will run when the PR is opened.
