### PR TITLE
perf(canary-web-components): #4067 batch data table truncation

### DIFF
--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -447,33 +447,26 @@ export class DataTable {
     }
 
     if (this.truncationPattern) {
-      this.getTypographyElements().forEach(
-        (typographyEl: HTMLIcTypographyElement) => {
+      const typographyElements = this.getTypographyElements().filter(
+        (typographyEl) => {
           const cellContainer = this.getCellContainer(typographyEl);
-          if (
+          return !!(
             cellContainer &&
             !cellContainer.classList.contains(this.TEXT_WRAP_STRING)
-          ) {
-            this.dataTruncation(typographyEl, cellContainer);
-            this.resizeObserver = new ResizeObserver(
-              // This gets triggered twice due to updated data and see more/see less button
-              dynamicDebounce(
-                () => {
-                  this.dataTruncation(typographyEl, cellContainer);
-
-                  if (!this.isNewDebounceDelaySet) {
-                    this.debounceDelay = 200;
-                    this.isNewDebounceDelaySet = true;
-                  }
-                },
-                () => this.debounceDelay
-              ) as ResizeObserverCallback
-            );
-
-            this.resizeObserver.observe(typographyEl);
-          }
+          );
         }
       );
+
+      if (this.truncationPattern === this.TOOLTIP_STRING) {
+        this.updateTruncationTooltip(false, typographyElements);
+      } else {
+        typographyElements.forEach((typographyEl) => {
+          const cellContainer = this.getCellContainer(typographyEl);
+          if (cellContainer) this.dataTruncation(typographyEl, cellContainer);
+        });
+      }
+
+      this.setupTruncationResizeObserver(typographyElements);
     }
 
     if (this.globalRowHeight !== "auto") {
@@ -484,6 +477,51 @@ export class DataTable {
     this.icColumnsLoaded.emit();
     if (this.data && !this.loading && !this.updating) this.icDataLoaded.emit();
   }
+
+  private setupTruncationResizeObserver = (
+    typographyElements: HTMLIcTypographyElement[]
+  ) => {
+    this.resizeObserver?.disconnect();
+
+    if (typographyElements.length === 0) {
+      this.resizeObserver = null;
+      return;
+    }
+
+    const updateTruncation = dynamicDebounce(
+      () => {
+        const resizedTypography = typographyElements.filter((typographyEl) => {
+          const cellContainer = this.getCellContainer(typographyEl);
+          return !!(
+            cellContainer &&
+            !cellContainer.classList.contains(this.TEXT_WRAP_STRING)
+          );
+        });
+
+        if (this.truncationPattern === this.TOOLTIP_STRING) {
+          this.updateTruncationTooltip(false, resizedTypography);
+        } else {
+          resizedTypography.forEach((typographyEl) => {
+            const cellContainer = this.getCellContainer(typographyEl);
+            if (cellContainer) {
+              this.dataTruncation(typographyEl, cellContainer);
+            }
+          });
+        }
+
+        if (!this.isNewDebounceDelaySet) {
+          this.debounceDelay = 200;
+          this.isNewDebounceDelaySet = true;
+        }
+      },
+      () => this.debounceDelay
+    ) as () => void;
+
+    this.resizeObserver = new ResizeObserver(() => updateTruncation());
+    typographyElements.forEach((typographyEl) =>
+      this.resizeObserver?.observe(typographyEl)
+    );
+  };
 
   componentDidUpdate(): void {
     // truncation updates invoked here once new/updated data has
@@ -831,19 +869,56 @@ export class DataTable {
     }
   };
 
+  private applyShowHideTruncation(
+    typographyEl: HTMLIcTypographyElement,
+    cellContainer: HTMLElement,
+    scrollHeight: number,
+    maxLines: number
+  ) {
+    typographyEl.checkMaxLines(scrollHeight);
+    typographyEl.setAttribute("max-lines", `${maxLines}`);
+    typographyEl.setShowHideExpanded(false);
+    cellContainer.style.setProperty(this.ROW_HEIGHT_CSS_VARIABLE, null);
+  }
+
   private createShowHideTruncation(
     typographyEl: HTMLIcTypographyElement,
     cellContainer: HTMLElement,
     descriptionHeight = 0
   ) {
-    typographyEl.checkMaxLines(typographyEl.scrollHeight);
-    typographyEl.setAttribute(
-      "max-lines",
-      `${this.getLines(cellContainer.clientHeight - descriptionHeight)}`
+    this.applyShowHideTruncation(
+      typographyEl,
+      cellContainer,
+      typographyEl.scrollHeight,
+      this.getLines(cellContainer.clientHeight - descriptionHeight)
     );
-    typographyEl.setShowHideExpanded(false);
+  }
 
-    cellContainer.style.setProperty(this.ROW_HEIGHT_CSS_VARIABLE, null);
+  private createShowHideTruncationBatch(
+    targets: {
+      typographyEl: HTMLIcTypographyElement;
+      cellContainer: HTMLElement;
+      descriptionHeight: number;
+    }[]
+  ) {
+    const measurements = targets.map(
+      ({ typographyEl, cellContainer, descriptionHeight }) => ({
+        typographyEl,
+        cellContainer,
+        scrollHeight: typographyEl.scrollHeight,
+        maxLines: this.getLines(cellContainer.clientHeight - descriptionHeight),
+      })
+    );
+
+    measurements.forEach(
+      ({ typographyEl, cellContainer, scrollHeight, maxLines }) =>
+        this.applyShowHideTruncation(
+          typographyEl,
+          cellContainer,
+          scrollHeight,
+          maxLines
+        )
+    );
   }
 
   private getLines = (height: number): number =>
@@ -1959,29 +2034,85 @@ export class DataTable {
   private getTooltip = (typographyEl: HTMLIcTypographyElement) =>
     typographyEl.closest<HTMLIcTooltipElement>(this.TOOLTIP);
 
-  private updateTruncationTooltip = (removeTooltipOnly = false) => {
-    this.getTypographyElements().forEach((typographyEl) => {
+  private updateTruncationTooltip = (
+    removeTooltipOnly = false,
+    typographyElements = this.getTypographyElements()
+  ) => {
+    const candidates: {
+      typographyEl: HTMLIcTypographyElement;
+      cellContainer: HTMLElement;
+    }[] = [];
+
+    typographyElements.forEach((typographyEl) => {
       const tooltip = this.getTooltip(typographyEl);
       const cellContainer = this.getCellContainer(typographyEl);
 
-      if (cellContainer) {
-        if (typographyEl.closest(this.TEXT_WRAP_CLASS)) {
-          this.removeTooltip(cellContainer, typographyEl, tooltip);
-          typographyEl.setAttribute(
-            "style",
-            `${this.LINE_CLAMP_CSS_VARIABLE}: 0`
-          );
-          return;
-        }
+      if (!cellContainer) return;
 
-        this.regenerateTooltip(
-          cellContainer,
-          typographyEl,
-          tooltip,
-          removeTooltipOnly
+      if (typographyEl.closest(this.TEXT_WRAP_CLASS)) {
+        this.removeTooltip(cellContainer, typographyEl, tooltip);
+        typographyEl.setAttribute(
+          "style",
+          `${this.LINE_CLAMP_CSS_VARIABLE}: 0`
         );
+        return;
       }
+
+      if (tooltip) {
+        if (this.tableSorted) {
+          tooltip.setAttribute("target", typographyEl.id);
+          tooltip.setAttribute("label", typographyEl.textContent!);
+        } else {
+          this.removeTooltip(cellContainer, typographyEl, tooltip);
+        }
+        if (removeTooltipOnly) return;
+      }
+
+      candidates.push({ typographyEl, cellContainer });
     });
+
+    const updatedDataTargets = candidates.filter(
+      ({ typographyEl }) =>
+        !typographyEl.getAttribute("style") && this.dataUpdated
+    );
+    this.addLineClampCSSBatch(updatedDataTargets);
+
+    if (this.truncationPattern !== this.TOOLTIP_STRING) return;
+
+    const overflowMeasurements = candidates.map(
+      ({ typographyEl, cellContainer }) => ({
+        typographyEl,
+        cellContainer,
+        overflowing: typographyEl.scrollHeight > cellContainer.clientHeight,
+      })
+    );
+
+    const overflowLineClampTargets = overflowMeasurements
+      .filter(
+        ({ typographyEl, overflowing }) =>
+          overflowing &&
+          (!typographyEl.getAttribute("style") ||
+            typographyEl.style.cssText.includes(
+              `${this.LINE_CLAMP_CSS_VARIABLE}: 0;`
+            ))
+      )
+      .map(({ typographyEl, cellContainer }) => ({
+        typographyEl,
+        cellContainer,
+      }));
+
+    this.addLineClampCSSBatch(overflowLineClampTargets);
+
+    overflowMeasurements.forEach(
+      ({ typographyEl, cellContainer, overflowing }) => {
+        if (
+          overflowing &&
+          !cellContainer.querySelector(this.IC_TOOLTIP_STRING)
+        ) {
+          this.createTruncationTooltip(typographyEl, cellContainer);
+        }
+      }
+    );
   };
 
   private updateScrollOffset = () => {
@@ -2015,9 +2146,10 @@ export class DataTable {
   /** Method to update the row heights on cells with descriptions and tooltip truncation */
   private updateCellHeightsWithDescriptions = () => {
     const isXSDevice = deviceSizeMatches(IC_DEVICE_SIZES.XS);
-    this.el.shadowRoot
-      ?.querySelectorAll(this.CELL_DESCRIPTION_STRING)
-      ?.forEach((description) => {
+    const measurements = Array.from(
+      this.el.shadowRoot?.querySelectorAll(this.CELL_DESCRIPTION_STRING) || []
+    )
+      .map((description) => {
         const cellContainer = description.closest<HTMLElement>(
           `.${this.CELL_CONTAINER_WITH_DESCRIPTION_STRING}`
         );
@@ -2027,99 +2159,104 @@ export class DataTable {
           );
 
         if (
-          typography &&
-          cellContainer &&
-          this.globalRowHeight &&
-          this.globalRowHeight !== "auto"
+          !typography ||
+          !cellContainer ||
+          !this.globalRowHeight ||
+          this.globalRowHeight === "auto"
         ) {
-          const descriptionHeight = this.getDescriptionHeight(description);
-          const descriptionHeightPlusLineHeight =
-            descriptionHeight + this.DEFAULT_LINE_HEIGHT;
-          if (
-            !typography.textContent &&
-            descriptionHeightPlusLineHeight > this.globalRowHeight
-          ) {
+          return null;
+        }
+
+        const descriptionHeight = this.getDescriptionHeight(description);
+        const descriptionHeightPlusLineHeight =
+          descriptionHeight + this.DEFAULT_LINE_HEIGHT;
+        const iconHeight =
+          this.truncationPattern === this.TOOLTIP_STRING &&
+          descriptionHeightPlusLineHeight > this.globalRowHeight &&
+          isXSDevice
+            ? cellContainer.querySelector(".icon")?.clientHeight || 0
+            : 0;
+
+        return {
+          typography,
+          cellContainer,
+          descriptionHeight,
+          descriptionHeightPlusLineHeight,
+          iconHeight,
+        };
+      })
+      .filter(
+        (
+          measurement
+        ): measurement is {
+          typography: HTMLIcTypographyElement;
+          cellContainer: HTMLElement;
+          descriptionHeight: number;
+          descriptionHeightPlusLineHeight: number;
+          iconHeight: number;
+        } => measurement !== null
+      );
+
+    const lineClampTargets: {
+      typographyEl: HTMLIcTypographyElement;
+      cellContainer: HTMLElement;
+    }[] = [];
+    const showHideTargets: {
+      typographyEl: HTMLIcTypographyElement;
+      cellContainer: HTMLElement;
+      descriptionHeight: number;
+    }[] = [];
+
+    measurements.forEach(
+      ({
+        typography,
+        cellContainer,
+        descriptionHeight,
+        descriptionHeightPlusLineHeight,
+        iconHeight,
+      }) => {
+        if (
+          !typography.textContent &&
+          descriptionHeightPlusLineHeight > this.globalRowHeight
+        ) {
+          this.updateRowHeightForDescriptions(
+            descriptionHeight,
+            cellContainer
+          );
+        } else if (this.truncationPattern === this.TOOLTIP_STRING) {
+          if (descriptionHeightPlusLineHeight > this.globalRowHeight) {
             this.updateRowHeightForDescriptions(
-              descriptionHeight,
+              descriptionHeightPlusLineHeight + iconHeight,
               cellContainer
-            );
-          } else if (this.truncationPattern === this.TOOLTIP_STRING) {
-            if (descriptionHeightPlusLineHeight > this.globalRowHeight) {
-              const cellIcon = cellContainer.querySelector(".icon");
-              let rowHeight = descriptionHeightPlusLineHeight;
-              if (cellIcon && isXSDevice) {
-                // recalculate descriptionHeight as when a word break occurs this value changes
-                // Additional spacing given for 300-400% zoom
-                rowHeight += cellIcon.clientHeight;
-              }
-              this.updateRowHeightForDescriptions(rowHeight, cellContainer);
-            }
-            this.addLineClampCSS(typography, cellContainer);
-            // Additional case for show/hide truncation for when a description is present, but the text
-            // isn't overflowing the cell to trigger the show more button to appear.
-          } else if (
-            this.truncationPattern === this.SHOW_HIDE_STRING &&
-            descriptionHeightPlusLineHeight > this.globalRowHeight &&
-            typography.style.getPropertyValue("--truncation-max-lines") !==
-              "initial"
-          ) {
-            this.updateRowHeightForDescriptions(
-              descriptionHeightPlusLineHeight,
-              cellContainer
-            );
-            this.createShowHideTruncation(
-              typography,
-              cellContainer,
-              descriptionHeight
             );
           }
+          lineClampTargets.push({
+            typographyEl: typography,
+            cellContainer,
+          });
+        } else if (
+          this.truncationPattern === this.SHOW_HIDE_STRING &&
+          descriptionHeightPlusLineHeight > this.globalRowHeight &&
+          typography.style.getPropertyValue("--truncation-max-lines") !==
+            "initial"
+        ) {
+          this.updateRowHeightForDescriptions(
+            descriptionHeightPlusLineHeight,
+            cellContainer
+          );
+          showHideTargets.push({
+            typographyEl: typography,
+            cellContainer,
+            descriptionHeight,
+          });
         }
-      });
+      }
+    );
+
+    this.addLineClampCSSBatch(lineClampTargets);
+    this.createShowHideTruncationBatch(showHideTargets);
   };
 
-  private regenerateTooltip(
-    cellContainer: HTMLElement,
-    typographyEl: HTMLIcTypographyElement,
-    tooltip: HTMLIcTooltipElement | null,
-    removeTooltipOnly?: boolean
-  ) {
-    // When sorting the table, instead of regenerating the tooltip,
-    // the tooltip details are updated
-
-    if (tooltip) {
-      if (this.tableSorted) {
-        tooltip.setAttribute("target", typographyEl.id);
-        tooltip.setAttribute("label", typographyEl.textContent!);
-      } else {
-        this.removeTooltip(cellContainer, typographyEl, tooltip);
-      }
-      if (removeTooltipOnly) {
-        return;
-      }
-    }
-
-    // This add line clamp to data only when
-    // the data object has been updated
-    if (!typographyEl.getAttribute("style") && this.dataUpdated) {
-      this.addLineClampCSS(typographyEl, cellContainer);
-    }
-
-    if (
-      typographyEl?.scrollHeight > cellContainer?.clientHeight &&
-      this.truncationPattern === this.TOOLTIP_STRING
-    ) {
-      if (
-        !typographyEl.getAttribute("style") ||
-        typographyEl.style.cssText.includes(
-          `${this.LINE_CLAMP_CSS_VARIABLE}: 0;`
-        )
-      ) {
-        this.addLineClampCSS(typographyEl, cellContainer);
-      }
-      if (!cellContainer.querySelector(this.IC_TOOLTIP_STRING))
-        this.createTruncationTooltip(typographyEl, cellContainer);
-    }
-  }
   private setTableDimensions = () => {
     let tableHostDimensions = {};
 
@@ -2165,10 +2302,7 @@ export class DataTable {
     tooltip?.remove();
   }
 
-  private addLineClampCSS(
-    typographyEl: HTMLIcTypographyElement,
-    cellContainer: HTMLElement
-  ) {
+  private getLineClampValue(cellContainer: HTMLElement): number {
     const descriptionCellHeight = cellContainer.querySelector(
       this.CELL_DESCRIPTION_STRING
     )?.clientHeight;
@@ -2184,14 +2318,47 @@ export class DataTable {
     ) {
       const iconHeight =
         (deviceSizeMatches(IC_DEVICE_SIZES.XS) &&
-          cellContainer?.querySelector(".icon")?.clientHeight) ||
+          cellContainer.querySelector(".icon")?.clientHeight) ||
         0;
       totalHeight = totalHeight - descriptionCellHeight - iconHeight;
     }
 
+    return this.getLines(totalHeight || 0);
+  }
+
+  private applyLineClampCSS(
+    typographyEl: HTMLIcTypographyElement,
+    lineClamp: number
+  ) {
     typographyEl.setAttribute(
       "style",
-      `${this.LINE_CLAMP_CSS_VARIABLE}: ${this.getLines(totalHeight || 0)}`
+      `${this.LINE_CLAMP_CSS_VARIABLE}: ${lineClamp}`
+    );
+  }
+
+  private addLineClampCSSBatch(
+    targets: {
+      typographyEl: HTMLIcTypographyElement;
+      cellContainer: HTMLElement;
+    }[]
+  ) {
+    const measurements = targets.map(({ typographyEl, cellContainer }) => ({
+      typographyEl,
+      lineClamp: this.getLineClampValue(cellContainer),
+    }));
+
+    measurements.forEach(({ typographyEl, lineClamp }) =>
+      this.applyLineClampCSS(typographyEl, lineClamp)
+    );
+  }
+
+  private addLineClampCSS(
+    typographyEl: HTMLIcTypographyElement,
+    cellContainer: HTMLElement
+  ) {
+    this.applyLineClampCSS(
+      typographyEl,
+      this.getLineClampValue(cellContainer)
     );
   }
 

--- a/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table-truncation-performance.spec.ts
+++ b/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table-truncation-performance.spec.ts
@@ -1,0 +1,142 @@
+import { DataTable } from "../../ic-data-table";
+
+type LineClampTarget = {
+  typographyEl: HTMLIcTypographyElement;
+  cellContainer: HTMLElement;
+};
+
+type DataTablePerformanceInternals = {
+  truncationPattern?: "tooltip" | "show-hide";
+  addLineClampCSSBatch: (targets: LineClampTarget[]) => void;
+  setupTruncationResizeObserver: (
+    typographyElements: HTMLIcTypographyElement[]
+  ) => void;
+  updateTruncationTooltip: (
+    removeTooltipOnly?: boolean,
+    typographyElements?: HTMLIcTypographyElement[]
+  ) => void;
+};
+
+describe("ic-data-table truncation performance", () => {
+  it("batches line-clamp layout reads before applying style writes", () => {
+    const dataTable =
+      new DataTable() as unknown as DataTablePerformanceInternals;
+    const order: string[] = [];
+
+    const createTarget = (id: number): LineClampTarget => {
+      const cellContainer = document.createElement("div");
+      const typographyEl = document.createElement(
+        "ic-typography"
+      ) as HTMLIcTypographyElement;
+
+      Object.defineProperty(cellContainer, "clientHeight", {
+        configurable: true,
+        get: () => {
+          order.push(`read-${id}`);
+          return 72;
+        },
+      });
+
+      const setAttribute = typographyEl.setAttribute.bind(typographyEl);
+      jest
+        .spyOn(typographyEl, "setAttribute")
+        .mockImplementation((name: string, value: string) => {
+          order.push(`write-${id}`);
+          setAttribute(name, value);
+        });
+
+      return { typographyEl, cellContainer };
+    };
+
+    dataTable.addLineClampCSSBatch([createTarget(1), createTarget(2)]);
+
+    expect(order).toEqual(["read-1", "read-2", "write-1", "write-2"]);
+  });
+
+  it("uses one resize observer for all truncated typography elements", () => {
+    const dataTable =
+      new DataTable() as unknown as DataTablePerformanceInternals;
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const ResizeObserverMock = jest.fn(() => ({
+      observe,
+      disconnect,
+      unobserve: jest.fn(),
+    }));
+
+    globalThis.ResizeObserver =
+      ResizeObserverMock as unknown as typeof ResizeObserver;
+
+    const typographyElements = [1, 2, 3].map(
+      () =>
+        document.createElement("ic-typography") as HTMLIcTypographyElement
+    );
+
+    try {
+      dataTable.setupTruncationResizeObserver(typographyElements);
+
+      expect(ResizeObserverMock).toHaveBeenCalledTimes(1);
+      expect(observe).toHaveBeenCalledTimes(3);
+      typographyElements.forEach((typographyEl) => {
+        expect(observe).toHaveBeenCalledWith(typographyEl);
+      });
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  it("re-evaluates the full observed set in one debounced resize batch", () => {
+    jest.useFakeTimers();
+
+    const dataTable =
+      new DataTable() as unknown as DataTablePerformanceInternals;
+    dataTable.truncationPattern = "tooltip";
+
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const observe = jest.fn();
+    const ResizeObserverMock = jest.fn((callback: ResizeObserverCallback) => {
+      resizeCallback = callback;
+      return {
+        observe,
+        disconnect: jest.fn(),
+        unobserve: jest.fn(),
+      };
+    });
+
+    globalThis.ResizeObserver =
+      ResizeObserverMock as unknown as typeof ResizeObserver;
+
+    const typographyElements = [1, 2, 3].map(() => {
+      const cellContainer = document.createElement("div");
+      cellContainer.classList.add("cell-container");
+      const typographyEl = document.createElement(
+        "ic-typography"
+      ) as HTMLIcTypographyElement;
+      cellContainer.append(typographyEl);
+      return typographyEl;
+    });
+
+    const updateTruncationTooltip = jest
+      .spyOn(dataTable, "updateTruncationTooltip")
+      .mockImplementation(() => undefined);
+
+    try {
+      dataTable.setupTruncationResizeObserver(typographyElements);
+
+      expect(resizeCallback).toBeDefined();
+      resizeCallback?.([], {} as ResizeObserver);
+      jest.runOnlyPendingTimers();
+
+      expect(updateTruncationTooltip).toHaveBeenCalledTimes(1);
+      expect(updateTruncationTooltip).toHaveBeenCalledWith(
+        false,
+        typographyElements
+      );
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Reduces forced synchronous layout work in `IcDataTable` truncation by separating bulk layout measurement from DOM/style mutation and consolidating per-cell resize observation.

The performance issue had two scaling problems in the truncation path:

- initial truncation created a separate `ResizeObserver` for every typography cell, while only the latest observer reference was retained;
- bulk truncation repeatedly interleaved layout reads such as `clientHeight` / `scrollHeight` with style and DOM writes, which can force the browser to recalculate layout repeatedly as the number of truncated cells grows.

This change:

- replaces the per-cell observers with one shared, debounced `ResizeObserver` observing the truncated typography elements;
- re-evaluates the full observed truncation set when resize notifications are coalesced, so debounce does not drop cells;
- batches line-clamp measurements before applying the resulting styles;
- batches description-cell measurements before row-height, tooltip and show/hide truncation writes;
- batches show/hide truncation measurements before calling the existing typography truncation APIs;
- preserves the existing single-cell truncation helpers for paths that do not process a bulk set;
- removes the old per-cell tooltip regeneration path in favour of the batched flow.

There are no public API changes.

## Related issue

Closes #4067

## Testing

- [x] Added a structural regression verifying line-clamp layout reads for multiple cells occur before style writes.
- [x] Added coverage verifying multiple truncated cells use one `ResizeObserver` rather than one observer per cell.
- [x] Added coverage verifying a debounced resize re-evaluates the complete observed truncation set.
- [x] Audited the final branch against `develop`: one commit, two intended files, zero commits behind.
- [x] TypeScript syntax of the new observer and regression-test logic was checked locally.
- [ ] Full repository tests and browser performance profiling were not run in this environment because the repository dependency tree/network access is unavailable. Upstream CI should run the complete project checks after the PR is opened.

I intentionally avoided a wall-clock performance assertion because it would be environment-sensitive; the regression tests instead protect the mechanisms that prevent the per-cell observer fan-out and read/write layout thrashing.