### PR TITLE
fix(web-components): #2039 update stepper connector on alignment changes

### DIFF
--- a/packages/web-components/src/components/ic-stepper/ic-stepper.tsx
+++ b/packages/web-components/src/components/ic-stepper/ic-stepper.tsx
@@ -35,6 +35,10 @@ export class Stepper {
    * The alignment of the default stepper within its container.
    */
   @Prop() aligned?: IcStepperAlignment = "full-width";
+  @Watch("aligned")
+  handleAlignedChange(): void {
+    this.resizeObserverCallback();
+  }
 
   /**
    * The length of the connector between each step in pixels. Minimum length is 100px.
@@ -280,14 +284,15 @@ export class Stepper {
           }
         }
 
+        const stepConnect = step.shadowRoot?.querySelector(
+          ".step > .step-top > .step-connect"
+        ) as HTMLElement;
+
         if (this.aligned === "left" && this.connectorWidth) {
           step.style.width =
             this.connectorWidth > 100
               ? pxToRem(`${this.connectorWidth + 48}px`)
               : pxToRem("148px");
-          const stepConnect = step.shadowRoot?.querySelector(
-            ".step > .step-top > .step-connect"
-          ) as HTMLElement;
 
           if (stepConnect) {
             stepConnect.style.width =
@@ -295,6 +300,8 @@ export class Stepper {
                 ? pxToRem(`${this.connectorWidth}px`)
                 : pxToRem("100px");
           }
+        } else {
+          stepConnect?.style.removeProperty("width");
         }
 
         if (this.hideStepInfo && stepTitleArea !== null) {

--- a/packages/web-components/src/components/ic-stepper/test/basic/ic-stepper-alignment-update.spec.ts
+++ b/packages/web-components/src/components/ic-stepper/test/basic/ic-stepper-alignment-update.spec.ts
@@ -1,0 +1,39 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { Step } from "../../../ic-step/ic-step";
+import { Stepper } from "../../ic-stepper";
+
+describe("ic-stepper alignment updates", () => {
+  it("removes a fixed connector width when changing to full-width", async () => {
+    const page = await newSpecPage({
+      components: [Stepper, Step],
+      html: `<ic-stepper aligned="left" connector-width="140">
+        <ic-step heading="Create" type="current"></ic-step>
+        <ic-step heading="Review"></ic-step>
+      </ic-stepper>`,
+    });
+
+    Object.defineProperty(page.root, "clientWidth", {
+      configurable: true,
+      value: 500,
+    });
+    Object.defineProperty(page.root, "offsetWidth", {
+      configurable: true,
+      value: 500,
+    });
+
+    page.rootInstance.resizeObserverCallback();
+    await page.waitForChanges();
+
+    const connector = page.root?.querySelector("ic-step")?.shadowRoot?.querySelector(
+      ".step > .step-top > .step-connect"
+    ) as HTMLElement;
+
+    expect(connector.style.width).not.toBe("");
+
+    (page.root as HTMLIcStepperElement).aligned = "full-width";
+    await page.waitForChanges();
+
+    expect(page.rootInstance.alignedFullWidth).toBe(true);
+    expect(connector.style.width).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Fixes `IcStepper` when `aligned` is changed from `left` to `full-width` after initial render.

Left alignment applies a fixed inline width to each step connector. Previously `aligned` was not watched, so changing the prop did not trigger the stepper layout recalculation, and the inline connector width was never removed when returning to full-width alignment.

This change:

- watches `aligned` and reuses the existing resize/layout recalculation path;
- keeps the existing left-aligned connector-width behaviour;
- removes the fixed inline connector width when the stepper is no longer left-aligned, allowing the full-width layout to take over again.

## Related issue

Closes #2039

## Testing

- Adds a focused Stencil regression that renders a left-aligned stepper with a custom connector width.
- Changes `aligned` to `full-width` at runtime.
- Verifies full-width state is recalculated and the stale inline connector width is removed.
- No public API changes.
- Final branch is one `web-components` commit and is based directly on `develop`.

Full upstream CI will run when the PR is opened.
