### PR TITLE
fix(canary-web-components): #2905 hide data table screen-reader text in RTL

### DIFF
--- a/packages/canary-react/src/component-tests/IcDataTable/IcDataTableRtlScreenReaderText.cy.tsx
+++ b/packages/canary-react/src/component-tests/IcDataTable/IcDataTableRtlScreenReaderText.cy.tsx
@@ -1,0 +1,40 @@
+/// <reference types="cypress" />
+
+import React from "react";
+import { mount } from "cypress/react";
+import { IcDataTable } from "../../components";
+
+const columns = [{ key: "name", title: "Name", dataType: "string" as const }];
+const data = [{ name: "Ada" }];
+
+describe("IcDataTable RTL screen-reader text", () => {
+  afterEach(() => {
+    cy.document().then((document) => {
+      document.documentElement.removeAttribute("dir");
+    });
+  });
+
+  it("keeps the sort announcement outside the viewport in RTL", () => {
+    cy.document().then((document) => {
+      document.documentElement.setAttribute("dir", "rtl");
+    });
+
+    mount(
+      <IcDataTable
+        caption="People"
+        columns={columns}
+        data={data}
+        sortable
+      />
+    );
+
+    cy.checkHydrated("ic-data-table");
+    cy.get("ic-data-table")
+      .shadow()
+      .find(".screen-reader-sort-text")
+      .should(($announcement) => {
+        const { left } = $announcement[0].getBoundingClientRect();
+        expect(left).to.be.greaterThan(window.innerWidth);
+      });
+  });
+});

--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.css
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.css
@@ -312,7 +312,7 @@ td.table-density-spacious {
 .screen-reader-sort-text,
 .table-caption {
   position: absolute;
-  left: -100rem;
+  inset-inline-start: -100rem;
 }
 
 .table-cell,
@@ -466,7 +466,7 @@ td.table-density-spacious {
 
 .sr-only {
   position: absolute;
-  left: -9999px;
+  inset-inline-start: -9999px;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary of the changes

Fixes visually hidden `IcDataTable` text becoming reachable on-screen when the document uses a right-to-left writing direction.

The data table hid its sort announcement, caption and internal screen-reader-only live region with physical `left` offsets. Physical positioning does not follow the document writing direction and can expose off-screen content when the page is RTL.

This change replaces those physical offsets with the logical `inset-inline-start` property. It therefore maps to the left side in LTR and the right side in RTL without introducing direction-specific selectors.

## Related issue

Closes #2905

## Testing

- Adds a canary React Cypress regression with `dir="rtl"`.
- Verifies the sort announcement is positioned beyond the RTL viewport rather than becoming visible in the page's scrollable area.
- Keeps the existing off-screen values and accessibility semantics unchanged.
- Also makes the existing data-table `sr-only` live region direction-safe.
- No public API changes.
- Production and Cypress changes are split into `canary-web-components` and `canary-react` commits to match package scope.

Full upstream CI will run when the PR is opened.
