### PR TITLE
fix(web-components): #2035 update radio orientation at runtime

### DIFF
--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -209,6 +209,11 @@ export class RadioGroup {
   };
 
   private checkOrientation() {
+    if (this.initialOrientation === this.RADIO_VERTICAL) {
+      this.currentOrientation = this.RADIO_VERTICAL;
+      return;
+    }
+
     if (this.initialOrientation === this.RADIO_HORIZONTAL) {
       let totalWidth = 0;
       if (Array.isArray(this.radioOptions) && this.radioOptions.length > 0) {

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group-orientation-update.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group-orientation-update.spec.ts
@@ -1,0 +1,25 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { RadioGroup } from "../../ic-radio-group";
+import { RadioOption } from "../../../ic-radio-option/ic-radio-option";
+
+describe("ic-radio-group orientation updates", () => {
+  it("updates from horizontal back to vertical at runtime", async () => {
+    const page = await newSpecPage({
+      components: [RadioGroup, RadioOption],
+      html: `<ic-radio-group label="test label" name="test" orientation="vertical">
+        <ic-radio-option value="one" label="One"></ic-radio-option>
+        <ic-radio-option value="two" label="Two"></ic-radio-option>
+      </ic-radio-group>`,
+    });
+
+    const radioGroup = page.root as HTMLIcRadioGroupElement;
+
+    radioGroup.orientation = "horizontal";
+    await page.waitForChanges();
+    expect(page.rootInstance.currentOrientation).toBe("horizontal");
+
+    radioGroup.orientation = "vertical";
+    await page.waitForChanges();
+    expect(page.rootInstance.currentOrientation).toBe("vertical");
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Fixes `IcRadioGroup` so the `orientation` prop can be changed back to `vertical` after the component has rendered.

The existing orientation watcher was already invoked when the prop changed, but `checkOrientation()` only recalculated state when the requested orientation was `horizontal`. Once the group had become horizontal, changing the prop to `vertical` therefore left `currentOrientation` unchanged.

The component now resets `currentOrientation` immediately when vertical orientation is requested, while preserving the existing horizontal layout checks for available width, more than two options and additional fields.

## Related issue

Closes #2035

## Testing

- Adds a focused Stencil regression covering `vertical` → `horizontal` → `vertical` at runtime.
- Verifies the internal orientation updates without a page refresh.
- Existing horizontal responsive and forced-vertical constraints remain unchanged.
- No public API changes.
- Final branch is one `web-components` commit and is based directly on `develop`.

Full upstream CI will run when the PR is opened.
