### PR TITLE
docs(canary-web-components): #3945 prevent date-picker story duplication

### DIFF
--- a/packages/canary-web-components/src/components/ic-date-picker/story-data.ts
+++ b/packages/canary-web-components/src/components/ic-date-picker/story-data.ts
@@ -1,8 +1,16 @@
 /* eslint-disable */
 export const DATE_PICKER_LABEL = "When would you like to collect your coffee?";
 
+const STORY_DATE_PICKER_SELECTOR =
+  'ic-date-picker[data-story-date-picker="true"]';
+
 export const createDatePickerElement = () => {
+  document
+    .querySelectorAll(STORY_DATE_PICKER_SELECTOR)
+    .forEach((datePicker) => datePicker.remove());
+
   const datePicker = document.createElement("ic-date-picker");
+  datePicker.dataset.storyDatePicker = "true";
   datePicker.label = DATE_PICKER_LABEL;
   return datePicker;
 };

--- a/packages/canary-web-components/src/components/ic-date-picker/test/basic/story-data.spec.ts
+++ b/packages/canary-web-components/src/components/ic-date-picker/test/basic/story-data.spec.ts
@@ -1,0 +1,32 @@
+import { Default, Sizes } from "../../story-data";
+
+describe("ic-date-picker Storybook render helpers", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("removes the previously attached story picker before rerendering", () => {
+    const unrelatedPicker = document.createElement("ic-date-picker");
+    const firstRender = Default();
+
+    document.body.append(unrelatedPicker, firstRender);
+
+    const secondRender = Default();
+
+    expect(firstRender.isConnected).toBe(false);
+    expect(unrelatedPicker.isConnected).toBe(true);
+    expect(secondRender.dataset.storyDatePicker).toBe("true");
+  });
+
+  it("preserves all date pickers created by a multi-picker story", () => {
+    const firstRender = Sizes();
+    document.body.append(firstRender);
+
+    expect(firstRender.querySelectorAll("ic-date-picker")).toHaveLength(3);
+
+    const secondRender = Sizes();
+
+    expect(firstRender.querySelectorAll("ic-date-picker")).toHaveLength(0);
+    expect(secondRender.querySelectorAll("ic-date-picker")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Prevents canary web-component Date Picker stories from accumulating duplicate `ic-date-picker` elements when Storybook rerenders a story, including when switching the toolbar theme.

The Date Picker stories create DOM nodes through `createDatePickerElement()`. Storybook can invoke the story renderer again when globals such as theme change, leaving the previously created element attached before the next one is returned.

This follows the same cleanup approach previously used for the Data Table Storybook issue in #3927 / #3936, but centralises it in the shared Date Picker factory:
- story-created date pickers are marked with a private data attribute;
- previously attached marked pickers are removed before the next story render;
- unrelated date pickers are not removed;
- multi-picker stories still create all of their pickers because their new container is detached while it is being assembled.

## Related issue

Closes #3945

## Testing

- [x] Regression verifies a rerender removes the previously attached story picker.
- [x] Regression verifies unrelated date pickers are preserved.
- [x] Regression verifies multi-picker stories still render all three pickers.
- [x] Story-only change; no production component API or behaviour changes.
- [x] Branch is based directly on upstream `develop`.

Full upstream CI will run when the PR is opened.