### PR TITLE
fix(web-components): #1871 keep focus on selected pagination page

### DIFF
--- a/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
+++ b/packages/web-components/src/components/ic-pagination/ic-pagination.tsx
@@ -26,6 +26,8 @@ import {
   shadow: true,
 })
 export class Pagination {
+  private pageToFocus?: number;
+
   @Element() el: HTMLIcPaginationElement;
 
   @State() endEllipsis: boolean = false;
@@ -254,6 +256,17 @@ export class Pagination {
     );
   }
 
+  componentDidRender(): void {
+    if (this.pageToFocus === undefined) return;
+
+    const selectedItem =
+      this.el.shadowRoot?.querySelector<HTMLIcPaginationItemElement>(
+        `#pagination-item-${this.pageToFocus}`
+      );
+    selectedItem?.shadowRoot?.querySelector<HTMLButtonElement>("button")?.focus();
+    this.pageToFocus = undefined;
+  }
+
   /**
    * Prevents focus lingering on a disabled element. If the currently
    * focused element is one of the back buttons (and we reach the first page),
@@ -294,6 +307,7 @@ export class Pagination {
   @Listen("paginationItemClick")
   paginationItemClickHandler(ev: CustomEvent): void {
     const page = ev.detail.page;
+    this.pageToFocus = page;
     this.currentPage = page;
     this.icPageChange.emit({ value: this.currentPage! });
   }

--- a/packages/web-components/src/components/ic-pagination/test/basic/ic-pagination-focus-retention.spec.tsx
+++ b/packages/web-components/src/components/ic-pagination/test/basic/ic-pagination-focus-retention.spec.tsx
@@ -1,0 +1,33 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { Pagination } from "../../ic-pagination";
+import { PaginationItem } from "../../../ic-pagination-item/ic-pagination-item";
+
+describe("ic-pagination selected page focus", () => {
+  it("keeps focus on the clicked page when the complex page window changes", async () => {
+    const page = await newSpecPage({
+      components: [Pagination, PaginationItem],
+      html: `<ic-pagination type="complex" pages="10" current-page="4"></ic-pagination>`,
+    });
+
+    const pageFive = page.root?.shadowRoot?.querySelector(
+      "#pagination-item-5"
+    ) as HTMLIcPaginationItemElement;
+    const pageFiveButton = pageFive.shadowRoot?.querySelector(
+      "button"
+    ) as HTMLButtonElement;
+
+    pageFiveButton.focus();
+    pageFiveButton.click();
+    await page.waitForChanges();
+
+    const selectedPage = page.root?.shadowRoot?.querySelector(
+      "#pagination-item-5"
+    ) as HTMLIcPaginationItemElement;
+    const selectedButton = selectedPage.shadowRoot?.querySelector(
+      "button"
+    ) as HTMLButtonElement;
+
+    expect(page.rootInstance.currentPage).toBe(5);
+    expect(selectedPage.shadowRoot?.activeElement).toBe(selectedButton);
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Keeps keyboard focus on the page number a user selects in complex `IcPagination`.

When selecting a page near a moving ellipsis/window boundary, updating `currentPage` recalculates the visible page-item arrays. The rendered pagination-item position can then be reused for a different page number, causing focus to appear to jump to the neighbouring page even though the originally clicked page is selected.

This change records the clicked page before the state update and, after the new pagination window renders, restores focus to the native button belonging to that same page.

The existing special focus handling for first/previous and next/last controls at pagination boundaries is unchanged.

## Related issue

Closes #1871

## Testing

- [x] Regression starts complex pagination on page 4 and clicks page 5.
- [x] The visible page window changes after selection.
- [x] `currentPage` updates to 5.
- [x] Focus is restored to page 5's newly rendered button rather than drifting to the reused neighbouring item.
- [x] No public API changes.
- [x] Branch is based directly on upstream `develop`.

Full upstream CI will run when the PR is opened.