### PR TITLE
fix(web-components): recalculate navigation group height on expand

### DIFF
--- a/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
+++ b/packages/web-components/src/components/ic-navigation-group/ic-navigation-group.tsx
@@ -130,20 +130,22 @@ export class NavigationGroup {
     }
   }
 
-  componentDidLoad(): void {
-    this.allGroupedNavigationItemHeights = `${Array.from(
-      this.el.querySelectorAll(IC_NAVIGATION_ITEM)
-    ).reduce(
+  private getGroupedNavigationItemsHeight = (): string =>
+    `${Array.from(this.el.querySelectorAll(IC_NAVIGATION_ITEM)).reduce(
       (childrenHeights, { offsetHeight }) => childrenHeights + offsetHeight,
       0
     )}px`;
 
+  componentDidLoad(): void {
     /**
      * debounce is required as the incorrect height was retrieved instantly after
      * componentDidLoad is invoked.
      */
     setTimeout(() => {
       if (!this.linkWrapper || !this.expanded) return;
+
+      this.allGroupedNavigationItemHeights =
+        this.getGroupedNavigationItemsHeight();
 
       if (!this.isSideNavExpanded)
         this.collapsedNavItemsHeight = this.allGroupedNavigationItemHeights;
@@ -196,13 +198,16 @@ export class NavigationGroup {
       this.setGroupedLinksElementHeight(navItemsHeight);
     } else {
       setTimeout(() => {
+        const currentHeight = this.getGroupedNavigationItemsHeight();
+        this.allGroupedNavigationItemHeights = currentHeight;
+
         if (this.isSideNavExpanded) {
-          this.expandedNavItemsHeight = this.allGroupedNavigationItemHeights;
+          this.expandedNavItemsHeight = currentHeight;
         } else {
-          this.collapsedNavItemsHeight = this.allGroupedNavigationItemHeights;
+          this.collapsedNavItemsHeight = currentHeight;
         }
 
-        this.setGroupedLinksElementHeight(this.allGroupedNavigationItemHeights);
+        this.setGroupedLinksElementHeight(currentHeight);
       }, DYNAMIC_GROUPED_LINKS_HEIGHT_MS);
     }
   };

--- a/packages/web-components/src/components/ic-navigation-group/test/basic/ic-navigation-group.spec.ts
+++ b/packages/web-components/src/components/ic-navigation-group/test/basic/ic-navigation-group.spec.ts
@@ -451,4 +451,46 @@ describe("ic-navigation-group", () => {
     // test disconnected callback
     page.setContent("");
   });
+
+  it("remeasures grouped item heights when the side navigation first expands", async () => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
+    let expanded = false;
+    const page = await newSpecPage({
+      components: [NavigationGroup],
+      html: `<ic-navigation-group label="Group" expandable>
+        <ic-navigation-item>One</ic-navigation-item>
+        <ic-navigation-item>Two</ic-navigation-item>
+      </ic-navigation-group>`,
+    });
+
+    jest
+      .spyOn(page.rootInstance as any, "getGroupedNavigationItemsHeight")
+      .mockImplementation(() => (expanded ? "80px" : "160px"));
+
+    jest.advanceTimersByTime(100);
+    await page.waitForChanges();
+
+    const groupedLinks = page.root!.shadowRoot!.querySelector(
+      ".grouped-links-wrapper"
+    ) as HTMLElement;
+    expect(
+      groupedLinks.style.getPropertyValue("--navigation-child-items-height")
+    ).toBe("160px");
+
+    expanded = true;
+    (page.rootInstance as any).sideNavExpandHandler(
+      new CustomEvent("icSideNavExpanded", {
+        detail: { sideNavExpanded: true },
+      })
+    );
+
+    jest.advanceTimersByTime(100);
+    await page.waitForChanges();
+
+    expect(
+      groupedLinks.style.getPropertyValue("--navigation-child-items-height")
+    ).toBe("80px");
+
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary of the changes

Fixes grouped navigation item spacing when `collapsedIconLabels` causes taller items in a collapsed side navigation and the side navigation is then expanded.

`IcNavigationGroup` cached the sum of child item heights while collapsed. On the first transition to the expanded state, the cache-miss path waited for layout to settle but then reused the old cached total instead of measuring the now-expanded items. This left the grouped-links wrapper at the collapsed height.

This change:
- centralises the current grouped-item height measurement;
- performs the initial measurement after the existing layout debounce instead of before it;
- remeasures after the first side-navigation expansion or collapse for an uncached state;
- preserves the per-state height cache for subsequent transitions.

No public API changes.

## Related issue

Closes #3901

## Testing

- [x] Adds a unit regression with different collapsed and expanded child heights.
- [x] Verifies the grouped-links height changes from 160px collapsed to 80px expanded.
- [x] Verifies the remeasurement occurs after the existing 100ms layout debounce.
- [x] Final branch is one `web-components` commit.
- [x] Branch is based directly on `develop`.

Full upstream CI will run when the PR is opened.
