### PR TITLE
fix(web-components): #4653 read out radio group label when hidden

### DIFF
--- a/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
+++ b/packages/web-components/src/components/ic-radio-group/ic-radio-group.tsx
@@ -378,6 +378,7 @@ export class RadioGroup {
           role="radiogroup"
           id={this.name}
           aria-required={`${required}`}
+          aria-label={hideLabel ? label : undefined}
         >
           {!hideLabel && (
             <legend>

--- a/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
+++ b/packages/web-components/src/components/ic-radio-group/test/basic/ic-radio-group.spec.ts
@@ -525,4 +525,30 @@ describe("ic-radio-group", () => {
 
     expect((radioContainer as any).__listeners.length).toBe(0);
   });
+
+  it("should apply the label as an aria-label when hideLabel is true", async () => {
+    const page = await newSpecPage({
+      components: [RadioGroup, RadioOption],
+      html: `<ic-radio-group label="test label" name="test" hide-label>
+        <ic-radio-option value="test"></ic-radio-option>
+      </ic-radio-group>`,
+    });
+
+    const fieldset = page.root?.shadowRoot?.querySelector("fieldset");
+    expect(fieldset?.querySelector("legend")).toBeNull();
+    expect(fieldset?.getAttribute("aria-label")).toBe("test label");
+  });
+
+  it("should not set an aria-label when the label is visible", async () => {
+    const page = await newSpecPage({
+      components: [RadioGroup, RadioOption],
+      html: `<ic-radio-group label="test label" name="test">
+        <ic-radio-option value="test"></ic-radio-option>
+      </ic-radio-group>`,
+    });
+
+    const fieldset = page.root?.shadowRoot?.querySelector("fieldset");
+    expect(fieldset?.querySelector("legend")).not.toBeNull();
+    expect(fieldset?.hasAttribute("aria-label")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary of the changes

When `hideLabel` is `true`, `ic-radio-group` does not render the `<legend>`, and nothing else supplies the group's accessible name — so the `role="radiogroup"` fieldset ends up with no accessible name and screen readers announce the group without its label. The prop's own docs say the opposite:

> If `true`, the label will be hidden and the required label value will be applied as an aria-label.

This applies `label` as an `aria-label` on the fieldset when, and only when, the label is hidden:

```tsx
<fieldset
  role="radiogroup"
  id={this.name}
  aria-required={`${required}`}
  aria-label={hideLabel ? label : undefined}
>
```

The visible-label path is untouched: the `<legend>` still names the group, and no `aria-label` is added, so nothing overrides it. `ic-text-field` (`aria-label={label}` on the input) and `ic-checkbox-group` (`aria-labelledby` on a screen-reader-only span) already do the equivalent — this brings the radio group in line.

## Related issue

Fixes #4653

## Testing

Two spec tests added to `ic-radio-group.spec.ts`:

- with `hide-label`: no `<legend>` is rendered and the fieldset's `aria-label` is the label value;
- without it: the `<legend>` is rendered and the fieldset has no `aria-label` (so the legend keeps naming the group).

The first fails on `develop` and passes with the change. Existing snapshots are unaffected, since none of them set `hide-label`.

```
npx stencil test --spec       →  67 suites, 1160 tests, 656 snapshots — all passing
npx eslint src/components/ic-radio-group  →  0 errors
```

## Checklist

### General

- [x] Changes to docs package checked and committed. — no docs change needed; the prop is already documented as behaving this way.
- [x] All acceptance criteria reviewed and met.

### Testing

- [x] Relevant unit tests and visual regression tests added. — unit tests added; there is no visual change, so no VR test.
- [x] Visual testing against Figma component specification completed. — no rendered output changes.
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. — no prop changes.

### Accessibility

- [x] A11y unit test added and yields no issues.
- [x] Correct roles used and ARIA attributes used correctly where required.
- [x] Logical heading structure is maintained.

### Resize/zoom, system modes, content extremes

Not applicable — the change adds a single ARIA attribute and produces no visual or layout difference.

> Note: I do not have NVDA/VoiceOver or the Accessibility Insights FastPass available on this machine, so the manual screen reader passes on the checklist have not been performed by me. The behaviour is covered by the unit tests above and is straightforward to confirm in Storybook with `hideLabel` toggled, following the reproduction steps in the issue.
