### PR TITLE
fix(web-components): #4657 show select icon when disabled

### DIFF
--- a/packages/web-components/src/components/ic-select/ic-select.css
+++ b/packages/web-components/src/components/ic-select/ic-select.css
@@ -283,6 +283,10 @@ select:not([disabled]) {
   fill: var(--ic-select-content-text);
 }
 
+:host(.ic-select-disabled) ::slotted([slot="icon"]) {
+  fill: var(--ic-atoms-input-select-content-icon-disabled);
+}
+
 .readonly ::slotted([slot="icon"]) {
   padding: 0.375rem;
   margin-bottom: 0.75rem;

--- a/packages/web-components/src/components/ic-select/ic-select.tsx
+++ b/packages/web-components/src/components/ic-select/ic-select.tsx
@@ -1122,19 +1122,17 @@ export class Select {
             readonly={readonly}
             validationStatus={validationStatus}
           >
-            {isSlotUsed(this.el, "icon") &&
-              !disabled &&
-              (!readonly || !!value) && (
-                <span
-                  slot="left-icon"
-                  class={{
-                    readonly,
-                    "has-value": !!value,
-                  }}
-                >
-                  <slot name="icon" />
-                </span>
-              )}
+            {isSlotUsed(this.el, "icon") && (!readonly || !!value) && (
+              <span
+                slot="left-icon"
+                class={{
+                  readonly,
+                  "has-value": !!value,
+                }}
+              >
+                <slot name="icon" />
+              </span>
+            )}
             {isMobileOrTablet() && this.useNativeSelectOnMobile && !multiple ? (
               <NativeSelect />
             ) : readonly ? (

--- a/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
+++ b/packages/web-components/src/components/ic-select/test/basic/ic-select.spec.tsx
@@ -2115,3 +2115,18 @@ describe("ic-select multi", () => {
     expect(button?.textContent).toContain(`${label1}, ${label2}`);
   });
 });
+
+describe("ic-select disabled icon", () => {
+  it("should render with an icon when disabled", async () => {
+    const page = await newSpecPage({
+      components: [Select, Menu, InputComponentContainer],
+      html: `<ic-select label="IC Select Test" disabled>
+        <svg slot="icon"></svg>
+      </ic-select>`,
+    });
+
+    expect(
+      page.root?.shadowRoot?.querySelector('slot[name="icon"]')
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary of the changes

Keeps the `ic-select` icon visible when the component is disabled.

The icon slot is now rendered for disabled selects and uses the existing `--ic-atoms-input-select-content-icon-disabled` token, so the icon is greyed out as expected.

No public API changes.

## Related issue

Fixes #4657

## Testing

- Added a unit regression test that verifies the icon slot is rendered when `ic-select` is disabled.
- Verified the fix in the Web Components Storybook playground with `showIcon` and `disabled` enabled.
- Jest summary: 67 test suites, 1,162 tests, and 656 snapshots passed.
- Prettier and Stylelint passed.
- ESLint completed with 0 errors (existing warnings only).

## Checklist

### General

- [x] Changes to the docs package checked; no documentation update is required.
- [x] All acceptance criteria reviewed and met.

### Testing

- [x] Relevant unit test added; no visual regression baseline was required.
- [x] Playground story checked; no story or prop changes are required.
- [x] The disabled appearance was checked against the expected behaviour in the issue.

### Accessibility and additional checks

The change restores an existing decorative icon and uses the existing disabled colour token. It does not change interaction, layout, motion, content, public API, roles, or ARIA attributes.

Manual assistive technology, zoom, high contrast, cross-browser, performance, and SSR/SSG checks were not run locally.
