### PR TITLE
fix(canary-web-components): #4487 Previous selectedRows state is maintained when the ic-data-table data prop changes

### DIFF
--- a/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/ic-data-table.tsx
@@ -1033,6 +1033,7 @@ export class DataTable {
         }
       }
       this.selectedRows = [];
+      this.selectedIcRowIds = [];
     }
 
     if (!this.initialLoad && this.previousPaginationPage !== detail.value) {
@@ -1118,6 +1119,7 @@ export class DataTable {
     this.loadingOptions = {
       ...this.loadingOptions,
     };
+
     if (this.loading) {
       !this.hasLoadedForOneSecond
         ? setTimeout(
@@ -1127,7 +1129,21 @@ export class DataTable {
           )
         : (this.loading = false);
     }
-    if (this.updating) this.updating = false;
+
+    if (this.updating) {
+      this.updating = false;
+    }
+
+    // Reset selection state
+    this.selectedRows = [];
+    this.selectedIcRowIds = [];
+
+    // Reset row IDs for the new dataset
+    this.rowIdCounter = 0;
+
+    // Reset pagination
+    this.fromRow = 0;
+    this.toRow = this.rowsPerPage;
 
     this.dataUpdated = true;
   }

--- a/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
+++ b/packages/canary-web-components/src/components/ic-data-table/test/basic/ic-data-table.spec.tsx
@@ -1352,6 +1352,61 @@ describe(icDataTable, () => {
     expect(checkbox?.getAttribute("checked")).toBe("");
   });
 
+  it("should clear selected rows when data changes", async () => {
+    const page = await newSpecPage({
+      components: [DataTable],
+      template: () => (
+        <ic-data-table
+          caption="test table"
+          columns={columns}
+          data={data}
+          row-selection={true}
+        ></ic-data-table>
+      ),
+    });
+
+    await page.rootInstance.selectAllRows();
+    await page.waitForChanges();
+
+    expect(page.rootInstance.selectedRows.length).toBeGreaterThan(0);
+
+    page.root!.data = [...longData];
+    await page.waitForChanges();
+
+    expect(page.rootInstance.selectedRows).toEqual([]);
+    expect(page.rootInstance.selectedIcRowIds).toEqual([]);
+  });
+
+  it("should clear selected rows when page changes", async () => {
+    const page = await newSpecPage({
+      components: [DataTable, PaginationBar],
+      template: () => (
+        <ic-data-table
+          caption="test table"
+          columns={columns}
+          data={longData}
+          row-selection={true}
+          show-pagination
+        ></ic-data-table>
+      ),
+    });
+
+    await page.rootInstance.selectAllRows();
+    await page.waitForChanges();
+
+    expect(page.rootInstance.selectedRows.length).toBeGreaterThan(0);
+
+    page.rootInstance.handlePageChange({
+      detail: { value: 2 },
+      target: document.createElement("div"),
+    } as any);
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.selectedRows).toEqual([]);
+    expect(page.rootInstance.selectedIcRowIds).toEqual([]);
+  });
+
   it("should apply a specified row height to all rows when globalRowHeight is set", async () => {
     const page = await newSpecPage({
       components: [DataTable],


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

When using the selectable variant of the ic data table, changing the data prop did not reset the internal selectedRows and row counter state.

Therefore, when hitting the select all checkbox & then changing the data prop (through means such as paginating) causes the previous checked items to be maintained internally and the checkbox will stay selected, with the row counter id starting from the length of the previous data.

This PR fixes this issue, resetting the internal selectedRows and row counter state when the data prop changes. 

## Related issue

#4487 

## Checklist

### General 

- [x] Changes to docs package checked and committed.
- [x] All acceptance criteria reviewed and met. 

### Testing

- [x] Relevant unit tests and visual regression tests added. 
- [x] Visual testing against Figma component specification completed. 
- [x] Playground stories in React Storybook up to date, with any prop changes and additions addressed. 
- [x] Compare performance of modified components against develop using Performance addon in React Storybook.

### Accessibility 

- [x] Accessibility Insights FastPass performed.
- [x] A11y unit test added and yields no issues.
- [x] A11y plug-in on Storybook yields no issues. 
- [x] Manual screen reader testing performed using NVDA and VoiceOver. 
- [x] Manual keyboard testing for keyboard controls and logical focus order. 
- [x] Correct roles used and ARIA attributes used correctly where required. 
- [x] Logical heading structure is maintained, and the HTML elements used for headings can be changed to fit within the wider page structure. 

### Resize/zoom behaviour 

- [x] Page can be zoomed to 400% with no loss of content. 
- [x] Screen magnifier used with no issues. 
- [x] Text resized to 200% with no loss of content.
- [x] Text spacing increased as per the [WCAG 1.4.12 success criterion](https://www.w3.org/TR/WCAG21/#text-spacing) with no loss of content.

### System modes

- [x] Browser setting 'prefers reduced motion' tested. No animations or motion visible whilst this setting is on. 
- [x] Windows High Contrast mode tested with no loss of content.
- [x] System light and dark mode tested with no loss of content.
- [x] Browser support tested (Chrome, Safari, Firefox and Edge). 

### Testing content extremes

- [x] Min/max content examples tested with no loss of content or overflow. 
- [x] All prop combinations work without issue. 
- [x] Tested for FOUC (Flash of Unstyled Content) in both SSR (Server-Side Rendering) and SSG (Static Site Generation) settings.
- [x] Controlled and uncontrolled input components tested.
- [x] Props/slots can be updated after initial render.